### PR TITLE
Export analysis and codegen for `export const/function/class` and `ex…

### DIFF
--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -48,6 +48,8 @@ pub struct AnalysisData {
     pub alt_is_elseif: HashSet<NodeId>,
     /// Props analysis (from $props() destructuring).
     pub props: Option<PropsAnalysis>,
+    /// Exported names from `export const/function/class` or `export { ... }`.
+    pub exports: Vec<svelte_js::ExportInfo>,
 
     // -- Cached sets for codegen (populated after mutations pass) --
     /// All rune symbol names (precomputed).
@@ -73,6 +75,7 @@ impl AnalysisData {
             known_values: HashMap::new(),
             alt_is_elseif: HashSet::new(),
             props: None,
+            exports: Vec::new(),
             rune_names: HashSet::new(),
             mutated_runes: HashSet::new(),
             bind_mutated_runes: HashSet::new(),

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -11,8 +11,8 @@ pub(crate) mod scope;
 mod validate;
 
 pub use data::{
-    AnalysisData, ConcatPart, ContentType, FragmentItem, FragmentKey, LoweredFragment,
-    PropAnalysis, PropsAnalysis,
+    AnalysisData, ConcatPart, ContentType, FragmentItem, FragmentKey, LoweredFragment, PropAnalysis,
+    PropsAnalysis,
 };
 
 use svelte_ast::Component;

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -12,6 +12,7 @@ pub fn parse_js(component: &Component, data: &mut AnalysisData, diags: &mut Vec<
         match svelte_js::analyze_script_with_scoping(source, script.content_span.start, typescript)
         {
             Ok((info, scoping)) => {
+                data.exports = info.exports.clone();
                 data.script = Some(info);
                 data.scoping = ComponentScoping::from_scoping(scoping);
             }

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -235,6 +235,10 @@ impl<'a> Builder<'a> {
         Statement::VariableDeclaration(self.alloc(declaration))
     }
 
+    pub fn return_stmt(&self, expr: Expression<'a>) -> Statement<'a> {
+        Statement::ReturnStatement(self.alloc(self.ast.return_statement(SPAN, Some(expr))))
+    }
+
     pub fn block_stmt(&self, body: Vec<Statement<'a>>) -> Statement<'a> {
         let block = self.ast.block_statement(SPAN, self.ast.vec_from_iter(body));
         Statement::BlockStatement(self.alloc(block))

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -11,7 +11,7 @@ use oxc_codegen::Codegen;
 use svelte_analyze::AnalysisData;
 use svelte_ast::Component;
 
-use builder::Arg;
+use builder::{Arg, ObjProp};
 use context::Ctx;
 
 /// Generate JavaScript client-side code for a compiled Svelte component.
@@ -48,27 +48,50 @@ pub fn generate(component: &Component, analysis: &AnalysisData) -> String {
     // (already in `hoisted`)
 
     // export default function App($$anchor, $$props?) { ... }
-    let fn_params = if ctx.analysis.props.is_some() {
+    let has_exports = !ctx.analysis.exports.is_empty();
+    let has_bindable = ctx.analysis.props.as_ref().is_some_and(|p| p.has_bindable);
+    let needs_push = has_bindable || has_exports;
+
+    let fn_params = if ctx.analysis.props.is_some() || needs_push {
         b.params(["$$anchor", "$$props"])
     } else {
         b.params(["$$anchor"])
     };
-    let has_bindable = ctx.analysis.props.as_ref().is_some_and(|p| p.has_bindable);
 
     let mut fn_body: Vec<Statement<'_>> = Vec::new();
     if ctx.needs_binding_group {
         fn_body.push(b.const_stmt("binding_group", b.empty_array_expr()));
     }
-    if has_bindable {
+    if needs_push {
         fn_body.push(b.expr_stmt(b.call_expr("$.push", [
             Arg::Ident("$$props"),
             Arg::Expr(b.bool_expr(true)),
         ])));
     }
     fn_body.extend(script_body);
+
+    // var $$exports = { PI, greet, ... }
+    if has_exports {
+        let props: Vec<ObjProp<'_>> = ctx.analysis.exports.iter().map(|e| {
+            let name: &str = b.ast.allocator.alloc_str(&e.name);
+            if let Some(alias) = &e.alias {
+                let alias: &str = b.ast.allocator.alloc_str(alias);
+                ObjProp::KeyValue(alias, b.rid_expr(name))
+            } else {
+                ObjProp::Shorthand(name)
+            }
+        }).collect();
+        fn_body.push(b.var_stmt("$$exports", b.object_expr(props)));
+    }
+
     fn_body.extend(template_body);
-    if has_bindable {
-        fn_body.push(b.expr_stmt(b.call_expr("$.pop", std::iter::empty::<Arg<'_, '_>>())));
+
+    if needs_push {
+        if has_exports {
+            fn_body.push(b.return_stmt(b.call_expr("$.pop", [Arg::Ident("$$exports")])));
+        } else {
+            fn_body.push(b.expr_stmt(b.call_expr("$.pop", std::iter::empty::<Arg<'_, '_>>())));
+        }
     }
 
     let fn_decl = b.function_decl(b.bid("App"), fn_body, fn_params);

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -385,26 +385,44 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
+        // Strip `export` keyword: ExportNamedDeclaration → inner declaration
+        let mut i = 0;
+        while i < stmts.len() {
+            if let Statement::ExportNamedDeclaration(_) = &stmts[i] {
+                let stmt = stmts.remove(i);
+                if let Statement::ExportNamedDeclaration(export) = stmt {
+                    if let Some(decl) = export.unbox().declaration {
+                        stmts.insert(i, Statement::from(decl));
+                        i += 1;
+                    }
+                    // else: `export { x }` form — just remove
+                }
+            } else {
+                i += 1;
+            }
+        }
+
+        // Replace $props() destructuring
         if self.props_gen.is_none() {
             return;
         }
 
         let mut idx = None;
-        for (i, stmt) in stmts.iter().enumerate() {
+        for (j, stmt) in stmts.iter().enumerate() {
             if let Statement::VariableDeclaration(decl) = stmt {
                 if Self::is_props_declaration(decl) {
-                    idx = Some(i);
+                    idx = Some(j);
                     break;
                 }
             }
         }
 
-        let Some(i) = idx else { return };
+        let Some(j) = idx else { return };
 
         let replacement = self.gen_props_statements();
-        stmts.remove(i);
-        for (j, stmt) in replacement.into_iter().enumerate() {
-            stmts.insert(i + j, stmt);
+        stmts.remove(j);
+        for (k, stmt) in replacement.into_iter().enumerate() {
+            stmts.insert(j + k, stmt);
         }
     }
 

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -64,9 +64,16 @@ pub struct PropsDeclaration {
 }
 
 #[derive(Debug, Clone)]
+pub struct ExportInfo {
+    pub name: String,
+    pub alias: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct ScriptInfo {
     pub declarations: Vec<DeclarationInfo>,
     pub props_declaration: Option<PropsDeclaration>,
+    pub exports: Vec<ExportInfo>,
 }
 
 #[derive(Debug, Clone)]
@@ -123,139 +130,213 @@ pub fn analyze_expression(source: &str, offset: u32) -> Result<ExpressionInfo, D
 fn extract_script_info(program: &oxc_ast::ast::Program<'_>, offset: u32, source: &str) -> ScriptInfo {
     let mut declarations = Vec::new();
     let mut props_declaration = None;
+    let mut exports = Vec::new();
 
     for stmt in &program.body {
         use oxc_ast::ast::Statement;
 
         match stmt {
-            Statement::VariableDeclaration(decl) => {
-                let kind = match decl.kind {
-                    oxc_ast::ast::VariableDeclarationKind::Let => DeclarationKind::Let,
-                    oxc_ast::ast::VariableDeclarationKind::Const => DeclarationKind::Const,
-                    oxc_ast::ast::VariableDeclarationKind::Var => DeclarationKind::Var,
-                    _ => DeclarationKind::Var,
-                };
-
-                for declarator in &decl.declarations {
-                    match &declarator.id {
-                        oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => {
-                            let name = ident.name.to_string();
-                            let decl_span = Span::new(
-                                ident.span.start + offset,
-                                ident.span.end + offset,
-                            );
-
-                            let (init_span, is_rune) = if let Some(init) = &declarator.init {
-                                let init_sp = Span::new(
-                                    init.span().start + offset,
-                                    init.span().end + offset,
-                                );
-                                let rune = detect_rune(init);
-                                (Some(init_sp), rune)
-                            } else {
-                                (None, None)
-                            };
-
-                            declarations.push(DeclarationInfo {
-                                name,
-                                span: decl_span,
-                                kind,
-                                init_span,
-                                is_rune,
-                            });
-                        }
-                        oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
-                            let is_props = declarator.init.as_ref()
-                                .and_then(|init| detect_rune(init))
-                                .map(|r| r == RuneKind::Props)
-                                .unwrap_or(false);
-
-                            if is_props {
-                                let mut props = Vec::new();
-
-                                for prop in &obj_pat.properties {
-                                    let key_name = extract_property_key_name(&prop.key);
-                                    let Some(key_name) = key_name else { continue };
-
-                                    let local_name = extract_binding_name(&prop.value);
-                                    let local_name = local_name.unwrap_or_else(|| key_name.clone());
-
-                                    let (default_span, default_text, is_bindable) = extract_prop_default(&prop.value, offset, source);
-
-                                    let decl_span = Span::new(
-                                        prop.span.start + offset,
-                                        prop.span.end + offset,
-                                    );
-
-                                    declarations.push(DeclarationInfo {
-                                        name: local_name.clone(),
-                                        span: decl_span,
-                                        kind,
-                                        init_span: None,
-                                        is_rune: Some(RuneKind::Props),
-                                    });
-
-                                    props.push(PropInfo {
-                                        local_name,
-                                        prop_name: key_name,
-                                        default_span,
-                                        default_text,
-                                        is_bindable,
-                                        is_rest: false,
-                                    });
-                                }
-
-                                if let Some(rest) = &obj_pat.rest {
-                                    if let oxc_ast::ast::BindingPattern::BindingIdentifier(ident) = &rest.argument {
-                                        let rest_name = ident.name.to_string();
-                                        let decl_span = Span::new(
-                                            ident.span.start + offset,
-                                            ident.span.end + offset,
-                                        );
-                                        declarations.push(DeclarationInfo {
-                                            name: rest_name.clone(),
-                                            span: decl_span,
-                                            kind,
-                                            init_span: None,
-                                            is_rune: Some(RuneKind::Props),
-                                        });
-                                        props.push(PropInfo {
-                                            local_name: rest_name.clone(),
-                                            prop_name: rest_name,
-                                            default_span: None,
-                                            default_text: None,
-                                            is_bindable: false,
-                                            is_rest: true,
-                                        });
-                                    }
-                                }
-
-                                props_declaration = Some(PropsDeclaration { props });
-                            }
-                        }
-                        _ => {}
-                    }
+            Statement::ExportNamedDeclaration(export) => {
+                // `export { x, y as z }` form
+                for spec in &export.specifiers {
+                    let local = spec.local.name().to_string();
+                    let exported = spec.exported.name().to_string();
+                    let alias = if local != exported { Some(exported) } else { None };
+                    exports.push(ExportInfo { name: local, alias });
+                }
+                // `export const/function/class ...` form
+                if let Some(decl) = &export.declaration {
+                    collect_export_names_from_declaration(decl, &mut exports);
+                    collect_declarations_from_declaration(decl, offset, source, &mut declarations, &mut props_declaration);
                 }
             }
+            Statement::VariableDeclaration(decl) => {
+                collect_var_declarations(decl, offset, source, &mut declarations, &mut props_declaration);
+            }
             Statement::FunctionDeclaration(func) => {
-                if let Some(ident) = &func.id {
-                    declarations.push(DeclarationInfo {
-                        name: ident.name.to_string(),
-                        span: Span::new(
-                            ident.span.start + offset,
-                            ident.span.end + offset,
-                        ),
-                        kind: DeclarationKind::Function,
-                        init_span: None,
-                        is_rune: None,
-                    });
-                }
+                collect_func_declaration(func, offset, &mut declarations);
             }
             _ => {}
         }
     }
 
-    ScriptInfo { declarations, props_declaration }
+    ScriptInfo { declarations, props_declaration, exports }
+}
+
+fn collect_export_names_from_declaration(
+    decl: &oxc_ast::ast::Declaration<'_>,
+    exports: &mut Vec<ExportInfo>,
+) {
+    match decl {
+        oxc_ast::ast::Declaration::VariableDeclaration(var_decl) => {
+            for declarator in &var_decl.declarations {
+                if let oxc_ast::ast::BindingPattern::BindingIdentifier(ident) = &declarator.id {
+                    exports.push(ExportInfo { name: ident.name.to_string(), alias: None });
+                }
+            }
+        }
+        oxc_ast::ast::Declaration::FunctionDeclaration(func) => {
+            if let Some(ident) = &func.id {
+                exports.push(ExportInfo { name: ident.name.to_string(), alias: None });
+            }
+        }
+        oxc_ast::ast::Declaration::ClassDeclaration(cls) => {
+            if let Some(ident) = &cls.id {
+                exports.push(ExportInfo { name: ident.name.to_string(), alias: None });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_declarations_from_declaration(
+    decl: &oxc_ast::ast::Declaration<'_>,
+    offset: u32,
+    source: &str,
+    declarations: &mut Vec<DeclarationInfo>,
+    props_declaration: &mut Option<PropsDeclaration>,
+) {
+    match decl {
+        oxc_ast::ast::Declaration::VariableDeclaration(var_decl) => {
+            collect_var_declarations(var_decl, offset, source, declarations, props_declaration);
+        }
+        oxc_ast::ast::Declaration::FunctionDeclaration(func) => {
+            collect_func_declaration(func, offset, declarations);
+        }
+        _ => {}
+    }
+}
+
+fn collect_func_declaration(
+    func: &oxc_ast::ast::Function<'_>,
+    offset: u32,
+    declarations: &mut Vec<DeclarationInfo>,
+) {
+    if let Some(ident) = &func.id {
+        declarations.push(DeclarationInfo {
+            name: ident.name.to_string(),
+            span: Span::new(ident.span.start + offset, ident.span.end + offset),
+            kind: DeclarationKind::Function,
+            init_span: None,
+            is_rune: None,
+        });
+    }
+}
+
+fn collect_var_declarations(
+    decl: &oxc_ast::ast::VariableDeclaration<'_>,
+    offset: u32,
+    source: &str,
+    declarations: &mut Vec<DeclarationInfo>,
+    props_declaration: &mut Option<PropsDeclaration>,
+) {
+    let kind = match decl.kind {
+        oxc_ast::ast::VariableDeclarationKind::Let => DeclarationKind::Let,
+        oxc_ast::ast::VariableDeclarationKind::Const => DeclarationKind::Const,
+        oxc_ast::ast::VariableDeclarationKind::Var => DeclarationKind::Var,
+        _ => DeclarationKind::Var,
+    };
+
+    for declarator in &decl.declarations {
+        match &declarator.id {
+            oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => {
+                let name = ident.name.to_string();
+                let decl_span = Span::new(
+                    ident.span.start + offset,
+                    ident.span.end + offset,
+                );
+
+                let (init_span, is_rune) = if let Some(init) = &declarator.init {
+                    let init_sp = Span::new(
+                        init.span().start + offset,
+                        init.span().end + offset,
+                    );
+                    let rune = detect_rune(init);
+                    (Some(init_sp), rune)
+                } else {
+                    (None, None)
+                };
+
+                declarations.push(DeclarationInfo {
+                    name,
+                    span: decl_span,
+                    kind,
+                    init_span,
+                    is_rune,
+                });
+            }
+            oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
+                let is_props = declarator.init.as_ref()
+                    .and_then(|init| detect_rune(init))
+                    .map(|r| r == RuneKind::Props)
+                    .unwrap_or(false);
+
+                if is_props {
+                    let mut props = Vec::new();
+
+                    for prop in &obj_pat.properties {
+                        let key_name = extract_property_key_name(&prop.key);
+                        let Some(key_name) = key_name else { continue };
+
+                        let local_name = extract_binding_name(&prop.value);
+                        let local_name = local_name.unwrap_or_else(|| key_name.clone());
+
+                        let (default_span, default_text, is_bindable) = extract_prop_default(&prop.value, offset, source);
+
+                        let decl_span = Span::new(
+                            prop.span.start + offset,
+                            prop.span.end + offset,
+                        );
+
+                        declarations.push(DeclarationInfo {
+                            name: local_name.clone(),
+                            span: decl_span,
+                            kind,
+                            init_span: None,
+                            is_rune: Some(RuneKind::Props),
+                        });
+
+                        props.push(PropInfo {
+                            local_name,
+                            prop_name: key_name,
+                            default_span,
+                            default_text,
+                            is_bindable,
+                            is_rest: false,
+                        });
+                    }
+
+                    if let Some(rest) = &obj_pat.rest {
+                        if let oxc_ast::ast::BindingPattern::BindingIdentifier(ident) = &rest.argument {
+                            let rest_name = ident.name.to_string();
+                            let decl_span = Span::new(
+                                ident.span.start + offset,
+                                ident.span.end + offset,
+                            );
+                            declarations.push(DeclarationInfo {
+                                name: rest_name.clone(),
+                                span: decl_span,
+                                kind,
+                                init_span: None,
+                                is_rune: Some(RuneKind::Props),
+                            });
+                            props.push(PropInfo {
+                                local_name: rest_name.clone(),
+                                prop_name: rest_name,
+                                default_span: None,
+                                default_text: None,
+                                is_bindable: false,
+                                is_rest: true,
+                            });
+                        }
+                    }
+
+                    *props_declaration = Some(PropsDeclaration { props });
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Parse a `<script>` block once and return both owned analysis info and OXC Scoping.
@@ -566,5 +647,19 @@ mod tests {
         let info = analyze_expression("x", 100).unwrap();
         assert_eq!(info.references[0].span.start, 100);
         assert_eq!(info.references[0].span.end, 101);
+    }
+
+    #[test]
+    fn analyze_script_exports() {
+        let (info, _) = analyze_script_with_scoping(
+            "export const PI = 3.14; export function greet(name) { return name; }",
+            0, false
+        ).unwrap();
+        assert_eq!(info.exports.len(), 2);
+        assert_eq!(info.exports[0].name, "PI");
+        assert_eq!(info.exports[1].name, "greet");
+        // Declarations are also extracted from exported statements
+        assert!(info.declarations.iter().any(|d| d.name == "PI"));
+        assert!(info.declarations.iter().any(|d| d.name == "greet"));
     }
 }

--- a/tasks/compiler_tests/cases2/exports/case-rust.js
+++ b/tasks/compiler_tests/cases2/exports/case-rust.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const PI = 3.14;
+	function greet(name) {
+		return "Hello " + name;
+	}
+	var $$exports = {
+		PI,
+		greet
+	};
+	var p = root();
+	p.textContent = "PI is 3.14";
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/exports/case-svelte.js
+++ b/tasks/compiler_tests/cases2/exports/case-svelte.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const PI = 3.14;
+	function greet(name) {
+		return "Hello " + name;
+	}
+	var $$exports = {
+		PI,
+		greet
+	};
+	var p = root();
+	p.textContent = "PI is 3.14";
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/exports/case.svelte
+++ b/tasks/compiler_tests/cases2/exports/case.svelte
@@ -1,0 +1,6 @@
+<script>
+  export const PI = 3.14;
+  export function greet(name) { return 'Hello ' + name; }
+</script>
+
+<p>PI is {PI}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -187,3 +187,8 @@ fn props_mutated() {
 fn props_mixed() {
     assert_compiler("props_mixed");
 }
+
+#[rstest]
+fn exports() {
+    assert_compiler("exports");
+}


### PR DESCRIPTION
…port { ... }`

Adds export tracking through all phases: svelte_js extracts ExportInfo, svelte_analyze stores it on AnalysisData, codegen strips export keywords, builds $$exports object, and returns it via $.pop(). Uses svelte_js::ExportInfo directly instead of a duplicate struct in analyze.