### PR TITLE
Fix scanner/parser bugs: escape handling, style tags, each-block keys

### DIFF
--- a/crates/svelte_diagnostics/src/lib.rs
+++ b/crates/svelte_diagnostics/src/lib.rs
@@ -23,6 +23,7 @@ pub enum DiagnosticKind {
     NoIfBlockToClose,
     NoIfBlockForElse,
     OnlyOneTopLevelScript,
+    OnlyOneTopLevelStyle,
     UnknownDirective,
     NoEachBlockToClose,
     // Analysis errors (future)
@@ -97,6 +98,10 @@ impl Diagnostic {
 
     pub fn only_single_top_level_script(span: Span) -> Self {
         Self::error(DiagnosticKind::OnlyOneTopLevelScript, span)
+    }
+
+    pub fn only_single_top_level_style(span: Span) -> Self {
+        Self::error(DiagnosticKind::OnlyOneTopLevelStyle, span)
     }
 
     pub fn unknown_directive(span: Span) -> Self {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -7,8 +7,8 @@ use svelte_span::Span;
 use svelte_ast::{
     Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment,
     ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
-    ExpressionAttribute, Fragment, IfBlock, Node, NodeIdAllocator, RenderTag, Script, ScriptContext,
-    ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
+    ExpressionAttribute, Fragment, IfBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
+    ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -83,6 +83,7 @@ impl<'a> Parser<'a> {
         let mut children_stack: Vec<Vec<Node>> = vec![vec![]];
         let mut entry_stack: Vec<StackEntry> = vec![];
         let mut script_data: Option<ScriptData> = None;
+        let mut css_data: Option<CssData> = None;
 
         for token in tokens {
             match token.token_type {
@@ -306,6 +307,19 @@ impl<'a> Parser<'a> {
                         context,
                     });
                 }
+                TokenType::StyleTag(style_tag) => {
+                    if css_data.is_some() {
+                        return Diagnostic::only_single_top_level_style(token.span).as_err();
+                    }
+
+                    let content_start = self.offset_of(style_tag.source);
+                    let content_end = content_start + style_tag.source.len();
+
+                    css_data = Some(CssData {
+                        span: token.span,
+                        content_span: Span::new(content_start as u32, content_end as u32),
+                    });
+                }
                 TokenType::EOF => break,
             }
         }
@@ -324,11 +338,16 @@ impl<'a> Parser<'a> {
             language: sd.language,
         });
 
+        let css = css_data.map(|cd| RawBlock {
+            span: cd.span,
+            content_span: cd.content_span,
+        });
+
         let mut component = Component::new(
             self.source.to_string(),
             Fragment::new(roots),
             script,
-            None,
+            css,
         );
         component.set_next_node_id(self.ids.current());
 
@@ -526,6 +545,11 @@ struct ScriptData {
     content_span: Span,
     language: ScriptLanguage,
     context: ScriptContext,
+}
+
+struct CssData {
+    span: Span,
+    content_span: Span,
 }
 
 // ---------------------------------------------------------------------------
@@ -730,5 +754,118 @@ mod tests {
         let c = parse("{#snippet greet(name)}<p>{name}</p>{/snippet}{@render greet(x)}");
         assert_snippet_block(&c, 0, "greet", Some("name"));
         assert_render_tag(&c, 1, "greet(x)");
+    }
+
+    // --- Escape sequence tests (Bug #1) ---
+
+    #[test]
+    fn interpolation_with_escaped_quotes() {
+        let c = parse(r#"{ name.replace("\"", "'") }"#);
+        assert_node(&c, 0, r#"{ name.replace("\"", "'") }"#);
+    }
+
+    // --- Style tag tests (Bug #2) ---
+
+    fn assert_css(c: &Component, expected_content: &str) {
+        let css = c.css.as_ref().expect("expected css");
+        assert_eq!(c.source_text(css.content_span), expected_content);
+    }
+
+    #[test]
+    fn style_tag() {
+        let c = parse("<style>.foo { color: red; }</style>");
+        assert_css(&c, ".foo { color: red; }");
+    }
+
+    #[test]
+    fn style_tag_with_selectors() {
+        let c = parse("<style>a > b { color: red; }</style>");
+        assert_css(&c, "a > b { color: red; }");
+    }
+
+    #[test]
+    fn style_tag_with_script() {
+        let c = parse("<script>let x = 1;</script><style>.foo { color: red; }</style>");
+        assert_script(&c, "let x = 1;");
+        assert_css(&c, ".foo { color: red; }");
+    }
+
+    #[test]
+    fn duplicate_style_tag_returns_error() {
+        let result = Parser::new("<style>a{}</style><style>b{}</style>").parse();
+        assert!(result.is_err());
+    }
+
+    // --- Each block key tests (Bug #3) ---
+
+    fn assert_each_block(c: &Component, index: usize, expected_expr: &str, expected_key: Option<&str>) {
+        if let Node::EachBlock(ref eb) = c.fragment.nodes[index] {
+            assert_eq!(c.source_text(eb.expression_span), expected_expr);
+            let actual_key = eb.key_span.map(|s| c.source_text(s));
+            assert_eq!(actual_key, expected_key);
+        } else {
+            panic!("expected EachBlock at index {index}");
+        }
+    }
+
+    #[test]
+    fn each_block_with_key() {
+        let c = parse("{#each items as item (item.id)}content{/each}");
+        assert_each_block(&c, 0, "items", Some("item.id"));
+    }
+
+    #[test]
+    fn each_block_with_index_and_key() {
+        let c = parse("{#each items as item, i (item.id)}content{/each}");
+        assert_each_block(&c, 0, "items", Some("item.id"));
+    }
+
+    // --- Deep nesting tests ---
+
+    #[test]
+    fn deeply_nested_blocks() {
+        let c = parse("{#if a}<div>{#each items as item}{#if b}inner{/if}{/each}</div>{/if}");
+        assert_node(&c, 0, "{#if a}<div>{#each items as item}{#if b}inner{/if}{/each}</div>{/if}");
+    }
+
+    // --- Directive tests at parser level ---
+
+    #[test]
+    fn class_directive_on_element() {
+        let c = parse("<div class:active={isActive}>text</div>");
+        assert_node(&c, 0, "<div class:active={isActive}>text</div>");
+        if let Node::Element(ref el) = c.fragment.nodes[0] {
+            assert_eq!(el.attributes.len(), 1);
+            assert!(matches!(el.attributes[0], svelte_ast::Attribute::ClassDirective(_)));
+        } else {
+            panic!("expected Element");
+        }
+    }
+
+    #[test]
+    fn bind_directive_on_element() {
+        let c = parse("<input bind:value={name}/>");
+        assert_node(&c, 0, "<input bind:value={name}/>");
+        if let Node::Element(ref el) = c.fragment.nodes[0] {
+            assert_eq!(el.attributes.len(), 1);
+            assert!(matches!(el.attributes[0], svelte_ast::Attribute::BindDirective(_)));
+        } else {
+            panic!("expected Element");
+        }
+    }
+
+    #[test]
+    fn spread_attribute_on_element() {
+        let c = parse("<div {...props}>text</div>");
+        if let Node::Element(ref el) = c.fragment.nodes[0] {
+            assert_eq!(el.attributes.len(), 1);
+            if let svelte_ast::Attribute::ShorthandOrSpread(ref sos) = el.attributes[0] {
+                assert!(sos.is_spread);
+            } else {
+                panic!("expected ShorthandOrSpread");
+            }
+        } else {
+            panic!("expected Element");
+        }
     }
 }

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -233,6 +233,10 @@ impl<'a> Scanner<'a> {
             return self.script_tag(attributes);
         }
 
+        if name == "style" {
+            return self.style_tag(attributes);
+        }
+
         self.add_token(TokenType::StartTag(StartTag {
             attributes,
             name,
@@ -519,6 +523,13 @@ impl<'a> Scanner<'a> {
     fn skip_js_string(&mut self, quote: char) -> Result<(), Diagnostic> {
         let start = self.current;
         while self.peek() != Some(quote) && !self.is_at_end() {
+            if self.peek() == Some('\\') {
+                self.advance(); // skip backslash
+                if !self.is_at_end() {
+                    self.advance(); // skip escaped char
+                }
+                continue;
+            }
             self.advance();
         }
 
@@ -723,6 +734,51 @@ impl<'a> Scanner<'a> {
         Ok(())
     }
 
+    fn style_tag(&mut self, attributes: Vec<Attribute<'a>>) -> Result<(), Diagnostic> {
+        let start = self.current;
+        let mut end = start;
+
+        while !self.is_at_end() {
+            let char = self.advance();
+
+            if char != '<' {
+                continue;
+            }
+
+            end = self.prev;
+
+            if !self.match_char('/') {
+                continue;
+            }
+
+            let identifier = self.identifier();
+
+            if identifier == "style" {
+                break;
+            }
+        }
+
+        if self.is_at_end() {
+            return Err(Diagnostic::unexpected_end_of_file(Span::new(
+                start as u32,
+                self.current as u32,
+            )));
+        }
+
+        self.skip_whitespace();
+
+        if !self.match_char('>') {
+            return Err(Diagnostic::unexpected_token(Span::new(start as u32, self.current as u32)));
+        }
+
+        self.add_token(TokenType::StyleTag(token::StyleTag {
+            source: self.slice_source(start, end),
+            attributes,
+        }));
+
+        Ok(())
+    }
+
     fn comment(&mut self) -> Result<(), Diagnostic> {
         let start = self.current;
         self.advance();
@@ -904,26 +960,44 @@ impl<'a> Scanner<'a> {
             return Diagnostic::unexpected_token(Span::new(self.start as u32, self.current as u32)).as_err();
         };
 
+        let last_char = self.slice_source(self.prev, self.prev + 1);
+
         // Parse optional index: `, i`
-        let index = if self.slice_source(self.prev, self.prev + 1) == "," {
+        let mut index = None;
+        let mut key = None;
+
+        if last_char == "," {
             self.skip_whitespace();
             let idx_start = self.current;
             let idx_name = self.identifier();
             if idx_name.is_empty() {
                 return Diagnostic::unexpected_token(Span::new(self.current as u32, self.current as u32)).as_err();
             }
+            index = Some(JsExpression {
+                span: Span::new(idx_start as u32, (idx_start + idx_name.len()) as u32),
+                value: idx_name,
+            });
             self.skip_whitespace();
-            // Consume closing `}`
+
+            // After index, check for key `(expr)` or closing `}`
+            if self.peek() == Some('(') {
+                key = Some(self.collect_key_expression(false)?);
+                self.skip_whitespace();
+            }
+
             if !self.match_char('}') {
                 return Diagnostic::unexpected_token(Span::new(self.current as u32, self.current as u32)).as_err();
             }
-            Some(JsExpression {
-                span: Span::new(idx_start as u32, (idx_start + idx_name.len()) as u32),
-                value: idx_name,
-            })
-        } else {
-            None
-        };
+        } else if last_char == "(" {
+            // Key expression directly after item (no index), `(` already consumed
+            key = Some(self.collect_key_expression(true)?);
+            self.skip_whitespace();
+
+            if !self.match_char('}') {
+                return Diagnostic::unexpected_token(Span::new(self.current as u32, self.current as u32)).as_err();
+            }
+        }
+        // else: `}` — no index, no key
 
         self.add_token(TokenType::StartEachTag(StartEachTag {
             collection: JsExpression {
@@ -931,11 +1005,54 @@ impl<'a> Scanner<'a> {
                 value: collection,
             },
             item,
-            key: None,
+            key,
             index,
         }));
 
         Ok(())
+    }
+
+    /// Collect key expression in `{#each ... (key)}`.
+    /// If `open_consumed` is true, `(` was already consumed by the caller.
+    /// If false, `(` is expected at the current peek position and will be consumed.
+    fn collect_key_expression(&mut self, open_consumed: bool) -> Result<JsExpression<'a>, Diagnostic> {
+        if !open_consumed {
+            debug_assert_eq!(self.peek(), Some('('));
+            self.advance(); // consume '('
+        }
+
+        let start = self.current;
+        let mut depth: u32 = 1;
+
+        while !self.is_at_end() && depth > 0 {
+            let ch = self.advance();
+            match ch {
+                '\'' | '"' | '`' => self.skip_js_string(ch)?,
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                _ => {}
+            }
+        }
+
+        if depth != 0 {
+            return Err(Diagnostic::unexpected_end_of_file(Span::new(
+                start as u32,
+                self.current as u32,
+            )));
+        }
+
+        let end = self.prev; // position of ')'
+        let raw = self.slice_source(start, end);
+        let value = raw.trim();
+        let trim_start = raw.len() - raw.trim_start().len();
+        let trim_end = raw.len() - raw.trim_end().len();
+        let span_start = start + trim_start;
+        let span_end = end - trim_end;
+
+        Ok(JsExpression {
+            span: Span::new(span_start as u32, span_end as u32),
+            value,
+        })
     }
 
     /// Collect item expression in each-block context.
@@ -958,8 +1075,8 @@ impl<'a> Scanner<'a> {
                 '}' if curly_depth > 0 => curly_depth -= 1,
                 '[' => bracket_depth += 1,
                 ']' if bracket_depth > 0 => bracket_depth -= 1,
-                // At depth 0: `,` means index follows, `}` means end of block
-                ',' | '}' if curly_depth == 0 && bracket_depth == 0 => {
+                // At depth 0: `,` means index follows, `(` means key follows, `}` means end of block
+                ',' | '}' | '(' if curly_depth == 0 && bracket_depth == 0 => {
                     let raw = self.slice_source(start, self.prev);
                     let value = raw.trim();
                     let trim_start = raw.len() - raw.trim_start().len();
@@ -1180,5 +1297,237 @@ mod tests {
         let mut scanner = Scanner::new("<div disabled");
         let result = scanner.scan_tokens();
         assert_error_result(result, DiagnosticKind::UnterminatedStartTag);
+    }
+
+    // --- Escape sequence tests (Bug #1) ---
+
+    #[test]
+    fn interpolation_escaped_double_quote() {
+        let mut scanner = Scanner::new(r#"{ name.replace("\"", "'") }"#);
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::Interpolation(_)));
+        assert!(tokens[1].token_type == TokenType::EOF);
+    }
+
+    #[test]
+    fn interpolation_escaped_single_quote() {
+        let mut scanner = Scanner::new(r"{ 'it\'s a test' }");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::Interpolation(_)));
+        assert!(tokens[1].token_type == TokenType::EOF);
+    }
+
+    #[test]
+    fn interpolation_escaped_backtick() {
+        let mut scanner = Scanner::new(r"{ `hello \` world` }");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::Interpolation(_)));
+        assert!(tokens[1].token_type == TokenType::EOF);
+    }
+
+    #[test]
+    fn interpolation_escaped_backslash() {
+        let mut scanner = Scanner::new(r#"{ "path\\to\\file" }"#);
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::Interpolation(_)));
+        assert!(tokens[1].token_type == TokenType::EOF);
+    }
+
+    // --- Style tag tests (Bug #2) ---
+
+    #[test]
+    fn style_tag_basic() {
+        let mut scanner = Scanner::new("<style>.foo { color: red; }</style>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::StyleTag(_)));
+        if let TokenType::StyleTag(ref st) = tokens[0].token_type {
+            assert_eq!(st.source, ".foo { color: red; }");
+        }
+        assert!(tokens[1].token_type == TokenType::EOF);
+    }
+
+    #[test]
+    fn style_tag_with_angle_brackets() {
+        let mut scanner = Scanner::new("<style>a > b { color: red; }</style>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::StyleTag(_)));
+        if let TokenType::StyleTag(ref st) = tokens[0].token_type {
+            assert_eq!(st.source, "a > b { color: red; }");
+        }
+    }
+
+    // --- Each block key tests (Bug #3) ---
+
+    fn assert_start_each_tag_with_key(
+        token: &Token,
+        expected_collection: &str,
+        expected_item: &str,
+        expected_key: &str,
+    ) {
+        let tag = match &token.token_type {
+            TokenType::StartEachTag(t) => t,
+            _ => panic!("Expected token.type = StartEachTag"),
+        };
+
+        assert_eq!(tag.collection.value, expected_collection);
+        assert_eq!(tag.item.value, expected_item);
+        let key = tag.key.as_ref().expect("expected key");
+        assert_eq!(key.value, expected_key);
+    }
+
+    #[test]
+    fn each_block_with_key() {
+        let mut scanner = Scanner::new("{#each items as item (item.id)}");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert_start_each_tag_with_key(&tokens[0], "items", "item", "item.id");
+        assert!(tokens[1].token_type == TokenType::EOF);
+    }
+
+    #[test]
+    fn each_block_with_index_and_key() {
+        let mut scanner = Scanner::new("{#each items as item, i (item.id)}");
+        let tokens = scanner.scan_tokens().unwrap();
+
+        let tag = match &tokens[0].token_type {
+            TokenType::StartEachTag(t) => t,
+            _ => panic!("Expected StartEachTag"),
+        };
+        assert_eq!(tag.collection.value, "items");
+        assert_eq!(tag.item.value, "item");
+        assert_eq!(tag.index.as_ref().unwrap().value, "i");
+        assert_eq!(tag.key.as_ref().unwrap().value, "item.id");
+    }
+
+    #[test]
+    fn each_block_destructured_with_key() {
+        let mut scanner = Scanner::new("{#each items as {name} (name)}");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert_start_each_tag_with_key(&tokens[0], "items", "{name}", "name");
+    }
+
+    // --- Directive tests ---
+
+    #[test]
+    fn class_directive_with_expression() {
+        let mut scanner = Scanner::new("<div class:active={isActive}>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert_start_tag(
+            &tokens[0],
+            "div",
+            vec![("$classDirective", "isActive")],
+            false,
+        );
+    }
+
+    #[test]
+    fn class_directive_shorthand() {
+        let mut scanner = Scanner::new("<div class:active>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert_start_tag(
+            &tokens[0],
+            "div",
+            vec![("$classDirective", "active")],
+            false,
+        );
+    }
+
+    #[test]
+    fn bind_directive_with_expression() {
+        let mut scanner = Scanner::new("<input bind:value={name}>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert_start_tag(
+            &tokens[0],
+            "input",
+            vec![("$bindDirective", "name")],
+            false,
+        );
+    }
+
+    #[test]
+    fn bind_directive_shorthand() {
+        let mut scanner = Scanner::new("<input bind:value>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert_start_tag(
+            &tokens[0],
+            "input",
+            vec![("$bindDirective", "value")],
+            false,
+        );
+    }
+
+    // --- Attribute concatenation tests ---
+
+    #[test]
+    fn attribute_concatenation() {
+        let mut scanner = Scanner::new(r#"<div title="hello {name} world">"#);
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::StartTag(_)));
+        if let TokenType::StartTag(ref st) = tokens[0].token_type {
+            assert_eq!(st.name, "div");
+            assert_eq!(st.attributes.len(), 1);
+            if let Attribute::HTMLAttribute(ref attr) = st.attributes[0] {
+                assert_eq!(attr.name, "title");
+                assert!(matches!(attr.value, AttributeValue::Concatenation(_)));
+            } else {
+                panic!("Expected HTMLAttribute");
+            }
+        }
+    }
+
+    // --- Spread/shorthand attribute tests ---
+
+    #[test]
+    fn spread_attribute() {
+        let mut scanner = Scanner::new("<div {...props}>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::StartTag(_)));
+        if let TokenType::StartTag(ref st) = tokens[0].token_type {
+            assert_eq!(st.attributes.len(), 1);
+            if let Attribute::ExpressionTag(ref et) = st.attributes[0] {
+                assert_eq!(et.expression.value, "...props");
+            } else {
+                panic!("Expected ExpressionTag for spread");
+            }
+        }
+    }
+
+    #[test]
+    fn shorthand_attribute() {
+        let mut scanner = Scanner::new("<div {value}>");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::StartTag(_)));
+        if let TokenType::StartTag(ref st) = tokens[0].token_type {
+            assert_eq!(st.attributes.len(), 1);
+            if let Attribute::ExpressionTag(ref et) = st.attributes[0] {
+                assert_eq!(et.expression.value, "value");
+            } else {
+                panic!("Expected ExpressionTag for shorthand");
+            }
+        }
+    }
+
+    // --- Snippet/render token tests ---
+
+    #[test]
+    fn snippet_tag_tokens() {
+        let mut scanner = Scanner::new("{#snippet foo(a, b)}content{/snippet}");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::StartSnippetTag(_)));
+        if let TokenType::StartSnippetTag(ref st) = tokens[0].token_type {
+            assert_eq!(st.name, "foo");
+            assert_eq!(st.params.as_ref().unwrap().value, "a, b");
+        }
+        assert!(tokens[1].token_type == TokenType::Text);
+        assert!(tokens[2].token_type == TokenType::EndSnippetTag);
+    }
+
+    #[test]
+    fn render_tag_tokens() {
+        let mut scanner = Scanner::new("{@render foo(x, y)}");
+        let tokens = scanner.scan_tokens().unwrap();
+        assert!(matches!(tokens[0].token_type, TokenType::RenderTag(_)));
+        if let TokenType::RenderTag(ref rt) = tokens[0].token_type {
+            assert_eq!(rt.expression.value, "foo(x, y)");
+        }
     }
 }

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -18,6 +18,7 @@ pub enum TokenType<'a> {
     StartSnippetTag(StartSnippetTag<'a>),
     EndSnippetTag,
     RenderTag(RenderTagToken<'a>),
+    StyleTag(StyleTag<'a>),
     EOF,
 }
 
@@ -165,6 +166,12 @@ impl GetSpan for Token<'_> {
     fn span(&self) -> Span {
         self.span
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StyleTag<'a> {
+    pub source: &'a str,
+    pub attributes: Vec<Attribute<'a>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
- Fix skip_js_string() to handle backslash escape sequences (\"  \' \`)
- Add <style> tag parsing as raw content (like <script>), with StyleTag token
- Add key expression parsing for {#each items as item (key)}
- Add 29 new tests covering escapes, style, keys, directives, spread, snippets

https://claude.ai/code/session_018y3En5vCHoiiyi5SXd6JRv