### PR TITLE
Add single-pass composite visitor for svelte_analyze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup rust toolchain and cache
+        uses: moonrepo/setup-rust@v1
+        with:
+          channel: stable
+
+      - name: Run tests
+        run: cargo test --workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,14 @@ Reference Svelte compiler source is in `reference/compiler/`. Use it to understa
 ### Design principle
 
 Match the JS output exactly. Design the internals for Rust: direct recursion over side tables,
-no visitor/walker patterns, no mutable AST metadata. Don't replicate JS workarounds,
+no mutable AST metadata. Don't replicate JS workarounds,
 intermediate abstractions, or patterns that exist only because of zimmerframe/estree-walker.
+
+**Exception — `svelte_analyze` uses a single-pass composite visitor** (`walker.rs`).
+Each analysis pass implements `TemplateVisitor` for only the nodes it cares about.
+Independent passes are combined into a single tree traversal via tuple composite visitors
+(e.g., `(ReactivityVisitor, ElseifVisitor)` = one walk instead of two).
+Codegen (`svelte_codegen_client`) uses direct recursion — no visitor pattern there.
 
 ### Quick navigation
 

--- a/crates/svelte_analyze/src/elseif.rs
+++ b/crates/svelte_analyze/src/elseif.rs
@@ -1,40 +1,23 @@
-use svelte_ast::{Component, Fragment, Node};
+use oxc_semantic::ScopeId;
+use svelte_ast::{IfBlock, Node};
 
 use crate::data::{AnalysisData, FragmentItem, FragmentKey};
+use crate::walker::TemplateVisitor;
 
-/// Pre-compute which IfBlocks have an elseif as their alternate.
-pub fn detect_elseif(component: &Component, data: &mut AnalysisData) {
-    walk_fragment(&component.fragment, data);
-}
+pub(crate) struct ElseifVisitor;
 
-fn walk_fragment(fragment: &Fragment, data: &mut AnalysisData) {
-    for node in &fragment.nodes {
-        match node {
-            Node::Element(el) => walk_fragment(&el.fragment, data),
-            Node::IfBlock(b) => {
-                walk_fragment(&b.consequent, data);
-                if let Some(alt) = &b.alternate {
-                    walk_fragment(alt, data);
-
-                    let alt_key = FragmentKey::IfAlternate(b.id);
-                    let is_elseif = data.lowered_fragments.get(&alt_key).is_some_and(|lf| {
-                        lf.items.len() == 1
-                            && matches!(&lf.items[0], FragmentItem::IfBlock(id)
-                                if alt.nodes.iter().any(|n| matches!(n, Node::IfBlock(ib) if ib.id == *id && ib.elseif)))
-                    });
-                    if is_elseif {
-                        data.alt_is_elseif.insert(b.id);
-                    }
-                }
+impl TemplateVisitor for ElseifVisitor {
+    fn visit_if_block(&mut self, block: &IfBlock, _scope: ScopeId, data: &mut AnalysisData) {
+        if let Some(alt) = &block.alternate {
+            let alt_key = FragmentKey::IfAlternate(block.id);
+            let is_elseif = data.lowered_fragments.get(&alt_key).is_some_and(|lf| {
+                lf.items.len() == 1
+                    && matches!(&lf.items[0], FragmentItem::IfBlock(id)
+                        if alt.nodes.iter().any(|n| matches!(n, Node::IfBlock(ib) if ib.id == *id && ib.elseif)))
+            });
+            if is_elseif {
+                data.alt_is_elseif.insert(block.id);
             }
-            Node::EachBlock(b) => {
-                walk_fragment(&b.body, data);
-                if let Some(fb) = &b.fallback {
-                    walk_fragment(fb, data);
-                }
-            }
-            Node::SnippetBlock(b) => walk_fragment(&b.body, data),
-            _ => {}
         }
     }
 }

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -9,6 +9,7 @@ mod props;
 mod reactivity;
 pub(crate) mod scope;
 mod validate;
+pub(crate) mod walker;
 
 pub use data::{
     AnalysisData, ConcatPart, ContentType, FragmentItem, FragmentKey, LoweredFragment, PropAnalysis,
@@ -24,10 +25,10 @@ use svelte_diagnostics::Diagnostic;
 /// 1. parse_js      — parse JS expressions + script block
 /// 2. build_scoping — build unified scope tree (script + template)
 /// 3. known_values  — evaluate const declarations with literal initializers
-/// 4. mutations     — detect mutated runes (script assignments + bind directives)
+/// 4. mutations     — detect mutated runes (single composite walk: template + binds)
 /// 5. props         — analyze $props() destructuring
 /// 6. lower         — trim whitespace, group text+expressions
-/// 7. reactivity    — mark dynamic nodes and attributes
+/// 7. reactivity + elseif — single composite walk: mark dynamic nodes + detect elseif
 /// 8. content_types — classify fragment content
 /// 9. validate      — semantic checks
 pub fn analyze(component: &Component) -> (AnalysisData, Vec<Diagnostic>) {
@@ -57,9 +58,18 @@ pub fn analyze(component: &Component) -> (AnalysisData, Vec<Diagnostic>) {
     mutations::detect_mutations(component, &mut data);
     props::analyze_props(&mut data);
     lower::lower(component, &mut data);
-    reactivity::mark_reactivity(component, &mut data);
+
+    // Single composite walk: reactivity + elseif
+    {
+        let root = data.scoping.root_scope_id();
+        let mut visitor = (
+            reactivity::ReactivityVisitor::new(),
+            elseif::ElseifVisitor,
+        );
+        walker::walk_template(&component.fragment, &mut data, root, &mut visitor);
+    }
+
     content_types::classify_content(component, &mut data);
-    elseif::detect_elseif(component, &mut data);
     validate::validate(component, &data, &mut diags);
 
     (data, diags)

--- a/crates/svelte_analyze/src/mutations.rs
+++ b/crates/svelte_analyze/src/mutations.rs
@@ -1,7 +1,8 @@
+use svelte_ast::{Attribute, BindDirective, Component, Element, ExpressionTag};
 use oxc_semantic::ScopeId;
-use svelte_ast::{Attribute, Component, Fragment, Node};
 
 use crate::data::AnalysisData;
+use crate::walker::{self, TemplateVisitor};
 
 /// Detect which rune symbols are mutated: assigned in script (already tracked by OXC semantic),
 /// template expression assignments, or bound via bind directives.
@@ -12,114 +13,57 @@ pub fn detect_mutations(component: &Component, data: &mut AnalysisData) {
 
     let root_scope = data.scoping.root_scope_id();
 
-    // Template expression assignments (e.g. `{title = 30}`)
-    walk_template_mutations(&component.fragment, data, root_scope);
-
-    // Bind directives imply mutation
-    walk_binds(&component.fragment, component, data, root_scope);
+    // Single walk: template expression assignments + bind directive mutations
+    let mut visitor = (
+        TemplateMutationVisitor,
+        BindMutationVisitor { component },
+    );
+    walker::walk_template(&component.fragment, data, root_scope, &mut visitor);
 
     // Cache the computed rune name sets
     data.cache_rune_sets();
 }
 
-fn walk_template_mutations(
-    fragment: &Fragment,
-    data: &mut AnalysisData,
-    current_scope: ScopeId,
-) {
-    for node in &fragment.nodes {
-        match node {
-            Node::ExpressionTag(tag) => {
-                if let Some(info) = data.expressions.get(&tag.id) {
-                    for r in &info.references {
-                        if r.flags == svelte_js::ReferenceFlags::Write
-                            || r.flags == svelte_js::ReferenceFlags::ReadWrite
-                        {
-                            if let Some(sym_id) = data.scoping.find_binding(current_scope, &r.name)
-                            {
-                                if data.scoping.is_rune(sym_id) {
-                                    data.scoping.mark_template_mutated(sym_id);
-                                }
-                            }
+/// Detects write/read-write references to runes in template expressions.
+struct TemplateMutationVisitor;
+
+impl TemplateVisitor for TemplateMutationVisitor {
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {
+        if let Some(info) = data.expressions.get(&tag.id) {
+            for r in &info.references {
+                if r.flags == svelte_js::ReferenceFlags::Write
+                    || r.flags == svelte_js::ReferenceFlags::ReadWrite
+                {
+                    if let Some(sym_id) = data.scoping.find_binding(scope, &r.name) {
+                        if data.scoping.is_rune(sym_id) {
+                            data.scoping.mark_template_mutated(sym_id);
                         }
                     }
                 }
             }
-            Node::Element(el) => {
-                walk_template_mutations(&el.fragment, data, current_scope);
-            }
-            Node::IfBlock(b) => {
-                walk_template_mutations(&b.consequent, data, current_scope);
-                if let Some(alt) = &b.alternate {
-                    walk_template_mutations(alt, data, current_scope);
-                }
-            }
-            Node::EachBlock(b) => {
-                let body_scope = data
-                    .scoping
-                    .node_scope(b.id)
-                    .unwrap_or(current_scope);
-                walk_template_mutations(&b.body, data, body_scope);
-                if let Some(fb) = &b.fallback {
-                    walk_template_mutations(fb, data, current_scope);
-                }
-            }
-            Node::SnippetBlock(b) => {
-                walk_template_mutations(&b.body, data, current_scope);
-            }
-            _ => {}
         }
     }
 }
 
-fn walk_binds(
-    fragment: &Fragment,
-    component: &Component,
-    data: &mut AnalysisData,
-    current_scope: ScopeId,
-) {
-    for node in &fragment.nodes {
-        match node {
-            Node::Element(el) => {
-                for attr in &el.attributes {
-                    if let Attribute::BindDirective(bind) = attr {
-                        let name = if bind.shorthand {
-                            bind.name.clone()
-                        } else if let Some(span) = bind.expression_span {
-                            component.source_text(span).trim().to_string()
-                        } else {
-                            continue;
-                        };
-                        if let Some(sym_id) = data.scoping.find_binding(current_scope, &name) {
-                            if data.scoping.is_rune(sym_id) {
-                                data.scoping.mark_bind_mutated(sym_id);
-                                data.scoping.mark_template_mutated(sym_id);
-                            }
-                        }
-                    }
-                }
-                walk_binds(&el.fragment, component, data, current_scope);
+/// Detects rune mutations via bind directives.
+struct BindMutationVisitor<'a> {
+    component: &'a Component,
+}
+
+impl TemplateVisitor for BindMutationVisitor<'_> {
+    fn visit_bind_directive(&mut self, dir: &BindDirective, _el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+        let name = if dir.shorthand {
+            dir.name.clone()
+        } else if let Some(span) = dir.expression_span {
+            self.component.source_text(span).trim().to_string()
+        } else {
+            return;
+        };
+        if let Some(sym_id) = data.scoping.find_binding(scope, &name) {
+            if data.scoping.is_rune(sym_id) {
+                data.scoping.mark_bind_mutated(sym_id);
+                data.scoping.mark_template_mutated(sym_id);
             }
-            Node::IfBlock(b) => {
-                walk_binds(&b.consequent, component, data, current_scope);
-                if let Some(alt) = &b.alternate {
-                    walk_binds(alt, component, data, current_scope);
-                }
-            }
-            Node::EachBlock(b) => {
-                let body_scope = data
-                    .scoping
-                    .node_scope(b.id)
-                    .unwrap_or(current_scope);
-                walk_binds(&b.body, component, data, body_scope);
-                if let Some(fb) = &b.fallback {
-                    walk_binds(fb, component, data, current_scope);
-                }
-            }
-            Node::SnippetBlock(b) => {
-                walk_binds(&b.body, component, data, current_scope);
-            }
-            _ => {}
         }
     }
 }

--- a/crates/svelte_analyze/src/mutations.rs
+++ b/crates/svelte_analyze/src/mutations.rs
@@ -1,5 +1,5 @@
-use svelte_ast::{Attribute, BindDirective, Component, Element, ExpressionTag};
 use oxc_semantic::ScopeId;
+use svelte_ast::{BindDirective, Component, Element, ExpressionTag};
 
 use crate::data::AnalysisData;
 use crate::walker::{self, TemplateVisitor};
@@ -53,13 +53,13 @@ struct BindMutationVisitor<'a> {
 impl TemplateVisitor for BindMutationVisitor<'_> {
     fn visit_bind_directive(&mut self, dir: &BindDirective, _el: &Element, scope: ScopeId, data: &mut AnalysisData) {
         let name = if dir.shorthand {
-            dir.name.clone()
+            dir.name.as_str()
         } else if let Some(span) = dir.expression_span {
-            self.component.source_text(span).trim().to_string()
+            self.component.source_text(span).trim()
         } else {
             return;
         };
-        if let Some(sym_id) = data.scoping.find_binding(scope, &name) {
+        if let Some(sym_id) = data.scoping.find_binding(scope, name) {
             if data.scoping.is_rune(sym_id) {
                 data.scoping.mark_bind_mutated(sym_id);
                 data.scoping.mark_template_mutated(sym_id);

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,112 +1,102 @@
 use oxc_semantic::ScopeId;
-use svelte_ast::{Attribute, Component, Fragment, Node, NodeId};
+use svelte_ast::{
+    Attribute, EachBlock, Element, ExpressionTag, IfBlock, NodeId, RenderTag, SnippetBlock,
+};
 
 use crate::data::AnalysisData;
+use crate::walker::TemplateVisitor;
 
-pub fn mark_reactivity(component: &Component, data: &mut AnalysisData) {
-    let root = data.scoping.root_scope_id();
-    walk_fragment(&component.fragment, component, data, root, &[]);
+pub(crate) struct ReactivityVisitor {
+    /// Stack of snippet parameter names for nested snippets.
+    snippet_params_stack: Vec<Vec<String>>,
 }
 
-fn walk_fragment(
-    fragment: &Fragment,
-    component: &Component,
-    data: &mut AnalysisData,
-    current_scope: ScopeId,
-    snippet_params: &[String],
-) {
-    for node in &fragment.nodes {
-        walk_node(node, component, data, current_scope, snippet_params);
-    }
-}
-
-fn walk_node(
-    node: &Node,
-    component: &Component,
-    data: &mut AnalysisData,
-    current_scope: ScopeId,
-    snippet_params: &[String],
-) {
-    match node {
-        Node::ExpressionTag(tag) => {
-            if expr_is_dynamic(&tag.id, data, current_scope, snippet_params) {
-                data.dynamic_nodes.insert(tag.id);
-            }
+impl ReactivityVisitor {
+    pub(crate) fn new() -> Self {
+        Self {
+            snippet_params_stack: Vec::new(),
         }
-        Node::Element(el) => {
-            let mut needs_ref = false;
-            for (attr_idx, attr) in el.attributes.iter().enumerate() {
-                if attr_is_dynamic(attr, attr_idx, el.id, data, current_scope) {
-                    data.dynamic_attrs.insert((el.id, attr_idx));
-                    needs_ref = true;
+    }
+
+    fn current_snippet_params(&self) -> &[String] {
+        self.snippet_params_stack.last().map_or(&[], |v| v.as_slice())
+    }
+
+    fn expr_is_dynamic(
+        &self,
+        node_id: &NodeId,
+        data: &AnalysisData,
+        scope: ScopeId,
+    ) -> bool {
+        if let Some(info) = data.expressions.get(node_id) {
+            let params = self.current_snippet_params();
+            return info.references.iter().any(|r| {
+                // Snippet params are always dynamic (they're thunks)
+                if params.iter().any(|p| p == &r.name) {
+                    return true;
                 }
-                // Bind directives always need a DOM ref
-                if matches!(attr, Attribute::BindDirective(_)) {
-                    needs_ref = true;
-                }
-            }
-            if needs_ref {
-                data.node_needs_ref.insert(el.id);
-            }
-            walk_fragment(&el.fragment, component, data, current_scope, snippet_params);
+                data.scoping.is_dynamic_ref(scope, &r.name)
+            });
         }
-        Node::IfBlock(block) => {
-            if expr_is_dynamic(&block.id, data, current_scope, snippet_params) {
-                data.dynamic_nodes.insert(block.id);
-            }
-            walk_fragment(&block.consequent, component, data, current_scope, snippet_params);
-            if let Some(alt) = &block.alternate {
-                walk_fragment(alt, component, data, current_scope, snippet_params);
-            }
-        }
-        Node::EachBlock(block) => {
-            if expr_is_dynamic(&block.id, data, current_scope, snippet_params) {
-                data.dynamic_nodes.insert(block.id);
-            }
-            // Each block body uses the child scope (with context/index bindings)
-            let body_scope = data
-                .scoping
-                .node_scope(block.id)
-                .unwrap_or(current_scope);
-            walk_fragment(&block.body, component, data, body_scope, snippet_params);
-            // Fallback uses parent scope
-            if let Some(fb) = &block.fallback {
-                walk_fragment(fb, component, data, current_scope, snippet_params);
-            }
-        }
-        Node::SnippetBlock(block) => {
-            let params = data
-                .snippet_params
-                .get(&block.id)
-                .cloned()
-                .unwrap_or_default();
-            walk_fragment(&block.body, component, data, current_scope, &params);
-        }
-        Node::RenderTag(tag) => {
-            if expr_is_dynamic(&tag.id, data, current_scope, snippet_params) {
-                data.dynamic_nodes.insert(tag.id);
-            }
-        }
-        Node::Text(_) | Node::Comment(_) => {}
+        false
     }
 }
 
-fn expr_is_dynamic(
-    node_id: &NodeId,
-    data: &AnalysisData,
-    current_scope: ScopeId,
-    snippet_params: &[String],
-) -> bool {
-    if let Some(info) = data.expressions.get(node_id) {
-        return info.references.iter().any(|r| {
-            // Snippet params are always dynamic (they're thunks)
-            if snippet_params.iter().any(|p| p == &r.name) {
-                return true;
-            }
-            data.scoping.is_dynamic_ref(current_scope, &r.name)
-        });
+impl TemplateVisitor for ReactivityVisitor {
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {
+        if self.expr_is_dynamic(&tag.id, data, scope) {
+            data.dynamic_nodes.insert(tag.id);
+        }
     }
-    false
+
+    fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
+        if self.expr_is_dynamic(&tag.id, data, scope) {
+            data.dynamic_nodes.insert(tag.id);
+        }
+    }
+
+    fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+        let mut needs_ref = false;
+        for (attr_idx, attr) in el.attributes.iter().enumerate() {
+            if attr_is_dynamic(attr, attr_idx, el.id, data, scope) {
+                data.dynamic_attrs.insert((el.id, attr_idx));
+                needs_ref = true;
+            }
+            if matches!(attr, Attribute::BindDirective(_)) {
+                needs_ref = true;
+            }
+        }
+        if needs_ref {
+            data.node_needs_ref.insert(el.id);
+        }
+    }
+
+    fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {
+        if self.expr_is_dynamic(&block.id, data, scope) {
+            data.dynamic_nodes.insert(block.id);
+        }
+    }
+
+    fn visit_each_block(&mut self, block: &EachBlock, body_scope: ScopeId, data: &mut AnalysisData) {
+        // body_scope is fine for the expression check — find_binding walks up parent scopes,
+        // so `items` in `{#each items as item}` resolves correctly from the child scope.
+        if self.expr_is_dynamic(&block.id, data, body_scope) {
+            data.dynamic_nodes.insert(block.id);
+        }
+    }
+
+    fn visit_snippet_block(&mut self, block: &SnippetBlock, _scope: ScopeId, data: &mut AnalysisData) {
+        let params = data
+            .snippet_params
+            .get(&block.id)
+            .cloned()
+            .unwrap_or_default();
+        self.snippet_params_stack.push(params);
+    }
+
+    fn leave_snippet_block(&mut self, _block: &SnippetBlock, _scope: ScopeId, _data: &mut AnalysisData) {
+        self.snippet_params_stack.pop();
+    }
 }
 
 // Attributes are dynamic only for *mutated* runes — unlike expressions where
@@ -127,8 +117,6 @@ fn attr_is_dynamic(
     }
     if let Some(info) = data.attr_expressions.get(&(el_id, attr_idx)) {
         return info.references.iter().any(|r| {
-            // For attributes, we check if the reference is a mutated rune
-            // (same logic as before, but scope-aware)
             let root = data.scoping.root_scope_id();
             if let Some(sym_id) = data.scoping.find_binding(current_scope, &r.name) {
                 // Non-root scope binding (each-block var) is always dynamic

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,25 +1,29 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    Attribute, EachBlock, Element, ExpressionTag, IfBlock, NodeId, RenderTag, SnippetBlock,
+    Attribute, BindDirective, EachBlock, Element, ExpressionTag, IfBlock, NodeId, RenderTag,
+    SnippetBlock,
 };
 
 use crate::data::AnalysisData;
 use crate::walker::TemplateVisitor;
 
 pub(crate) struct ReactivityVisitor {
-    /// Stack of snippet parameter names for nested snippets.
-    snippet_params_stack: Vec<Vec<String>>,
+    /// Stack of snippet NodeIds for nested snippets (avoids cloning param vecs).
+    snippet_id_stack: Vec<NodeId>,
 }
 
 impl ReactivityVisitor {
     pub(crate) fn new() -> Self {
         Self {
-            snippet_params_stack: Vec::new(),
+            snippet_id_stack: Vec::new(),
         }
     }
 
-    fn current_snippet_params(&self) -> &[String] {
-        self.snippet_params_stack.last().map_or(&[], |v| v.as_slice())
+    fn current_snippet_params<'a>(&self, data: &'a AnalysisData) -> &'a [String] {
+        self.snippet_id_stack
+            .last()
+            .and_then(|id| data.snippet_params.get(id))
+            .map_or(&[], |v| v.as_slice())
     }
 
     fn expr_is_dynamic(
@@ -29,7 +33,7 @@ impl ReactivityVisitor {
         scope: ScopeId,
     ) -> bool {
         if let Some(info) = data.expressions.get(node_id) {
-            let params = self.current_snippet_params();
+            let params = self.current_snippet_params(data);
             return info.references.iter().any(|r| {
                 // Snippet params are always dynamic (they're thunks)
                 if params.iter().any(|p| p == &r.name) {
@@ -55,20 +59,16 @@ impl TemplateVisitor for ReactivityVisitor {
         }
     }
 
-    fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
-        let mut needs_ref = false;
-        for (attr_idx, attr) in el.attributes.iter().enumerate() {
-            if attr_is_dynamic(attr, attr_idx, el.id, data, scope) {
-                data.dynamic_attrs.insert((el.id, attr_idx));
-                needs_ref = true;
-            }
-            if matches!(attr, Attribute::BindDirective(_)) {
-                needs_ref = true;
-            }
-        }
-        if needs_ref {
+    fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+        if attr_is_dynamic(attr, idx, el.id, data, scope) {
+            data.dynamic_attrs.insert((el.id, idx));
             data.node_needs_ref.insert(el.id);
         }
+    }
+
+    fn visit_bind_directive(&mut self, _dir: &BindDirective, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
+        // Bind directives always need a DOM ref
+        data.node_needs_ref.insert(el.id);
     }
 
     fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {
@@ -85,17 +85,12 @@ impl TemplateVisitor for ReactivityVisitor {
         }
     }
 
-    fn visit_snippet_block(&mut self, block: &SnippetBlock, _scope: ScopeId, data: &mut AnalysisData) {
-        let params = data
-            .snippet_params
-            .get(&block.id)
-            .cloned()
-            .unwrap_or_default();
-        self.snippet_params_stack.push(params);
+    fn visit_snippet_block(&mut self, block: &SnippetBlock, _scope: ScopeId, _data: &mut AnalysisData) {
+        self.snippet_id_stack.push(block.id);
     }
 
     fn leave_snippet_block(&mut self, _block: &SnippetBlock, _scope: ScopeId, _data: &mut AnalysisData) {
-        self.snippet_params_stack.pop();
+        self.snippet_id_stack.pop();
     }
 }
 
@@ -116,8 +111,8 @@ fn attr_is_dynamic(
         return false;
     }
     if let Some(info) = data.attr_expressions.get(&(el_id, attr_idx)) {
+        let root = data.scoping.root_scope_id();
         return info.references.iter().any(|r| {
-            let root = data.scoping.root_scope_id();
             if let Some(sym_id) = data.scoping.find_binding(current_scope, &r.name) {
                 // Non-root scope binding (each-block var) is always dynamic
                 if data.scoping.symbol_scope_id(sym_id) != root {

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,0 +1,127 @@
+use oxc_semantic::ScopeId;
+use svelte_ast::{
+    Attribute, BindDirective, EachBlock, Element, ExpressionTag, Fragment, IfBlock, Node,
+    RenderTag, SnippetBlock,
+};
+
+use crate::data::AnalysisData;
+
+/// Trait for template analysis visitors.
+///
+/// Each analysis pass implements only the visit methods it cares about.
+/// All methods have default no-op implementations. The `walk_template` function
+/// handles structural recursion and scope tracking — visitors never need to
+/// recurse manually.
+///
+/// Multiple visitors can be combined into a single tree traversal using tuple
+/// composite visitors: `(VisitorA, VisitorB)` implements `TemplateVisitor` and
+/// dispatches to both visitors at each node.
+#[allow(unused_variables)]
+pub(crate) trait TemplateVisitor {
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_each_block(&mut self, block: &EachBlock, body_scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    /// Called after snippet block body has been walked. Use with `visit_snippet_block` for stack-based context.
+    fn leave_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
+}
+
+/// Walk a template fragment, dispatching to the visitor at each node.
+///
+/// Scope tracking is built-in: EachBlock bodies use their child scope,
+/// EachBlock fallbacks use the parent scope.
+pub(crate) fn walk_template<V: TemplateVisitor>(
+    fragment: &Fragment,
+    data: &mut AnalysisData,
+    scope: ScopeId,
+    visitor: &mut V,
+) {
+    for node in &fragment.nodes {
+        match node {
+            Node::ExpressionTag(tag) => {
+                visitor.visit_expression_tag(tag, scope, data);
+            }
+            Node::Element(el) => {
+                visitor.visit_element(el, scope, data);
+                for (idx, attr) in el.attributes.iter().enumerate() {
+                    visitor.visit_attribute(attr, idx, el, scope, data);
+                    if let Attribute::BindDirective(dir) = attr {
+                        visitor.visit_bind_directive(dir, el, scope, data);
+                    }
+                }
+                walk_template(&el.fragment, data, scope, visitor);
+            }
+            Node::IfBlock(block) => {
+                visitor.visit_if_block(block, scope, data);
+                walk_template(&block.consequent, data, scope, visitor);
+                if let Some(alt) = &block.alternate {
+                    walk_template(alt, data, scope, visitor);
+                }
+            }
+            Node::EachBlock(block) => {
+                let body_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
+                visitor.visit_each_block(block, body_scope, data);
+                walk_template(&block.body, data, body_scope, visitor);
+                // Fallback uses parent scope (no context/index vars)
+                if let Some(fb) = &block.fallback {
+                    walk_template(fb, data, scope, visitor);
+                }
+            }
+            Node::SnippetBlock(block) => {
+                visitor.visit_snippet_block(block, scope, data);
+                walk_template(&block.body, data, scope, visitor);
+                visitor.leave_snippet_block(block, scope, data);
+            }
+            Node::RenderTag(tag) => {
+                visitor.visit_render_tag(tag, scope, data);
+            }
+            Node::Text(_) | Node::Comment(_) => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composite visitor — tuple impls
+// ---------------------------------------------------------------------------
+
+macro_rules! impl_composite_visitor {
+    ($($T:ident : $idx:tt),+) => {
+        impl<$($T: TemplateVisitor),+> TemplateVisitor for ($($T,)+) {
+            fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_expression_tag(tag, scope, data);)+
+            }
+            fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_render_tag(tag, scope, data);)+
+            }
+            fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_element(el, scope, data);)+
+            }
+            fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_if_block(block, scope, data);)+
+            }
+            fn visit_each_block(&mut self, block: &EachBlock, body_scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_each_block(block, body_scope, data);)+
+            }
+            fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_snippet_block(block, scope, data);)+
+            }
+            fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_attribute(attr, idx, el, scope, data);)+
+            }
+            fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_bind_directive(dir, el, scope, data);)+
+            }
+            fn leave_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.leave_snippet_block(block, scope, data);)+
+            }
+        }
+    };
+}
+
+impl_composite_visitor!(A: 0, B: 1);
+impl_composite_visitor!(A: 0, B: 1, C: 2);
+impl_composite_visitor!(A: 0, B: 1, C: 2, D: 3);

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,175 @@
+# Plan: Single-Pass Composite Visitor для svelte_analyze
+
+## Проблема
+
+6 проходов по template AST с идентичным boilerplate рекурсии (~200 строк).
+Каждый pass копирует один и тот же match по Node, логику scope tracking для EachBlock,
+рекурсию в Element/IfBlock/EachBlock/SnippetBlock. Легко забыть рекурсию (баг snippet_params).
+
+## Ключевая идея: Single-Pass Composite Visitor (как в oxc)
+
+Каждый analysis pass реализует свой `TemplateVisitor` — только те visit-методы,
+которые ему интересны. Но под капотом несколько passes запускаются в **одном обходе дерева**
+через composite visitor (tuple). Один `walk_template()` вызов — все совместимые passes
+выполняются параллельно за один проход.
+
+## Дизайн
+
+### 1. Trait `TemplateVisitor`
+
+```rust
+pub(crate) trait TemplateVisitor {
+    // Leaf visitors — default no-op
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_each_block(&mut self, block: &EachBlock, body_scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+}
+```
+
+Ключевые решения:
+- `data: &mut AnalysisData` передаётся в каждый visit-метод (не хранится в visitor) — позволяет composite
+- `scope: ScopeId` передаётся walker-ом автоматически — scope tracking в одном месте
+- Все методы default no-op — каждый pass реализует только то, что ему интересно
+
+### 2. `walk_template()` — единственная функция обхода
+
+```rust
+pub(crate) fn walk_template<V: TemplateVisitor>(
+    fragment: &Fragment,
+    component: &Component,
+    data: &mut AnalysisData,
+    scope: ScopeId,
+    visitor: &mut V,
+) {
+    for node in &fragment.nodes {
+        match node {
+            Node::ExpressionTag(tag) => {
+                visitor.visit_expression_tag(tag, scope, data);
+            }
+            Node::Element(el) => {
+                visitor.visit_element(el, scope, data);
+                for (idx, attr) in el.attributes.iter().enumerate() {
+                    visitor.visit_attribute(attr, idx, el, scope, data);
+                    if let Attribute::BindDirective(dir) = attr {
+                        visitor.visit_bind_directive(dir, el, scope, data);
+                    }
+                }
+                walk_template(&el.fragment, component, data, scope, visitor);
+            }
+            Node::IfBlock(block) => {
+                visitor.visit_if_block(block, scope, data);
+                walk_template(&block.consequent, component, data, scope, visitor);
+                if let Some(alt) = &block.alternate {
+                    walk_template(alt, component, data, scope, visitor);
+                }
+            }
+            Node::EachBlock(block) => {
+                let body_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
+                visitor.visit_each_block(block, body_scope, data);
+                walk_template(&block.body, component, data, body_scope, visitor);
+                if let Some(fb) = &block.fallback {
+                    walk_template(fb, component, data, scope, visitor); // fallback = parent scope
+                }
+            }
+            Node::SnippetBlock(block) => {
+                visitor.visit_snippet_block(block, scope, data);
+                walk_template(&block.body, component, data, scope, visitor);
+            }
+            Node::RenderTag(tag) => {
+                visitor.visit_render_tag(tag, scope, data);
+            }
+            Node::Text(_) | Node::Comment(_) => {}
+        }
+    }
+}
+```
+
+Scope tracking встроен: EachBlock автоматически переключает scope, fallback остаётся на parent.
+
+### 3. Composite visitor — tuple impls
+
+```rust
+impl<A: TemplateVisitor, B: TemplateVisitor> TemplateVisitor for (A, B) {
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {
+        self.0.visit_expression_tag(tag, scope, data);
+        self.1.visit_expression_tag(tag, scope, data);
+    }
+    // ... аналогично для всех методов
+}
+```
+
+Реализовать для кортежей (A, B), (A, B, C), (A, B, C, D) — покрывает все нужды.
+Можно через macro_rules! чтобы не дублировать.
+
+### 4. Рефакторинг passes
+
+**Фаза 1 — walker utility + рефакторинг отдельных passes:**
+
+| Pass | Visitor struct | Реализует |
+|------|---------------|-----------|
+| mutations (template) | `TemplateMutationVisitor` | `visit_expression_tag` |
+| mutations (binds) | `BindMutationVisitor` | `visit_bind_directive` |
+| reactivity | `ReactivityVisitor` | `visit_expression_tag`, `visit_element`, `visit_if_block`, `visit_each_block`, `visit_render_tag` |
+| elseif | `ElseifVisitor` | `visit_if_block` |
+
+**Фаза 2 — composite merges (один обход вместо нескольких):**
+
+- `mutations`: `(TemplateMutationVisitor, BindMutationVisitor)` — один обход вместо двух
+- `post_lower`: `(ReactivityVisitor, ElseifVisitor)` — один обход вместо двух
+
+**Не трогаем:**
+- `parse_js` — особый pass, создаёт expressions и diagnostics, сложная логика парсинга. Можно перевести позже, но выигрыш минимален.
+- `build_scoping` — мутирует scoping (`add_child_scope`, `add_binding`), нужен `&mut ComponentScoping` напрямую. Можно перевести, но scope creation логика уникальна.
+- `lower` — работает с FragmentKey/LoweredFragment, другая модель обхода (не по Node, а по items).
+- `content_types` — работает с lowered fragments.
+
+### 5. snippet_params в reactivity
+
+Сейчас reactivity передаёт `snippet_params: &[String]` вручную. С walker-ом:
+- `visit_snippet_block` может push params в стек внутри `ReactivityVisitor`
+- Или walker сам трекает snippet_params (добавить в context)
+
+Предпочтительно: walker трекает snippet context автоматически, передаёт в visit-методы.
+
+## Шаги реализации
+
+1. Создать `crates/svelte_analyze/src/walker.rs` — trait + walk_template + tuple impls
+2. Рефакторинг `mutations.rs` — два visitor struct, composite, один `walk_template` вызов
+3. Рефакторинг `reactivity.rs` — visitor struct
+4. Рефакторинг `elseif.rs` — visitor struct
+5. Объединить reactivity + elseif в один обход в `lib.rs`
+6. Обновить CLAUDE.md — ослабить ограничение для analyze
+7. Прогнать тесты
+
+## Изменение CLAUDE.md
+
+Текущее ограничение (строки 38-40):
+```
+Design the internals for Rust: direct recursion over side tables,
+no visitor/walker patterns, no mutable AST metadata.
+```
+
+Заменить на:
+```
+Design the internals for Rust: direct recursion over side tables,
+no mutable AST metadata. Don't replicate JS workarounds,
+intermediate abstractions, or patterns that exist only because of zimmerframe/estree-walker.
+
+Exception: `svelte_analyze` uses a single-pass composite visitor (`walker.rs`)
+to eliminate boilerplate in template analysis passes. Each pass implements
+`TemplateVisitor` for only the nodes it cares about. Independent passes are
+combined into a single tree traversal via tuple composite visitors.
+Codegen (`svelte_codegen_client`) uses direct recursion — no visitor pattern.
+```
+
+## Что НЕ меняется
+
+- codegen — прямая рекурсия остаётся (каждая нода = уникальная генерация)
+- parse_js, build_scoping, lower, content_types — остаются как есть
+- Публичный API `analyze()` — без изменений
+- Все тесты должны проходить без изменений


### PR DESCRIPTION
Introduce TemplateVisitor trait + walk_template utility that handles
structural recursion and scope tracking in one place. Analysis passes
implement only the visit methods they need.

Independent passes are combined into single tree traversals via tuple
composite visitors:
- mutations: (TemplateMutationVisitor, BindMutationVisitor) — 1 walk instead of 2
- post-lower: (ReactivityVisitor, ElseifVisitor) — 1 walk instead of 2

This eliminates ~150 lines of duplicated tree-walking boilerplate and
makes it impossible to forget recursion for new node types.

CLAUDE.md updated to reflect the relaxed design principle for analyze.

https://claude.ai/code/session_01E93iTHXN2uBg1jrBifNZEN