### PR TITLE
refactor: enforce analysis/codegen boundary and improve code quality

### DIFF
--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -61,6 +61,8 @@ pub struct AnalysisData {
     pub mutated_runes: HashSet<String>,
     /// Rune names mutated only via bind directives.
     pub bind_mutated_runes: HashSet<String>,
+    /// Elements that need a DOM variable during traversal (precomputed for codegen).
+    pub elements_needing_var: HashSet<NodeId>,
 }
 
 impl AnalysisData {
@@ -83,6 +85,7 @@ impl AnalysisData {
             rune_names: HashSet::new(),
             mutated_runes: HashSet::new(),
             bind_mutated_runes: HashSet::new(),
+            elements_needing_var: HashSet::new(),
         }
     }
 
@@ -133,6 +136,15 @@ pub enum FragmentItem {
     TextConcat { parts: Vec<ConcatPart> },
 }
 
+impl FragmentItem {
+    /// Returns `true` if this is a standalone `{expression}` with no surrounding text.
+    /// Used by codegen to pass `is_text: true` to `$.child()` / `$.sibling()`.
+    pub fn is_standalone_expr(&self) -> bool {
+        matches!(self, FragmentItem::TextConcat { parts }
+            if parts.len() == 1 && matches!(parts[0], ConcatPart::Expr(_)))
+    }
+}
+
 #[derive(Clone)]
 pub enum ConcatPart {
     /// Static text content (possibly trimmed).
@@ -159,6 +171,9 @@ pub struct PropAnalysis {
     pub is_rest: bool,
     /// Needs `$.prop()` signal wrapper (vs direct `$$props.name` access).
     pub is_prop_source: bool,
+    /// Default value requires lazy evaluation (`() => expr`).
+    /// True when `default_text` is present and is not a simple expression.
+    pub is_lazy_default: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -4,6 +4,7 @@ mod elseif;
 mod known_values;
 mod lower;
 mod mutations;
+mod needs_var;
 mod parse_js;
 mod props;
 mod reactivity;
@@ -70,6 +71,7 @@ pub fn analyze(component: &Component) -> (AnalysisData, Vec<Diagnostic>) {
     }
 
     content_types::classify_content(component, &mut data);
+    needs_var::compute_elements_needing_var(component, &mut data);
     validate::validate(component, &data, &mut diags);
 
     (data, diags)

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -1,0 +1,88 @@
+//! Compute which elements need a DOM variable during traversal.
+//!
+//! Runs after: reactivity, content_types, lower.
+
+use svelte_ast::{Attribute, Component, Element, Fragment, Node};
+
+use crate::data::{AnalysisData, ConcatPart, ContentType, FragmentItem, FragmentKey};
+
+/// Populate `data.elements_needing_var` for all elements in the component.
+pub fn compute_elements_needing_var(component: &Component, data: &mut AnalysisData) {
+    walk_fragment(&component.fragment, data);
+}
+
+fn walk_fragment(fragment: &Fragment, data: &mut AnalysisData) {
+    for node in &fragment.nodes {
+        match node {
+            Node::Element(el) => {
+                // Walk children first so nested elements are already computed
+                walk_fragment(&el.fragment, data);
+                if element_needs_var(el, data) {
+                    data.elements_needing_var.insert(el.id);
+                }
+            }
+            Node::IfBlock(b) => {
+                walk_fragment(&b.consequent, data);
+                if let Some(alt) = &b.alternate {
+                    walk_fragment(alt, data);
+                }
+            }
+            Node::EachBlock(b) => {
+                walk_fragment(&b.body, data);
+                if let Some(fb) = &b.fallback {
+                    walk_fragment(fb, data);
+                }
+            }
+            Node::SnippetBlock(b) => {
+                walk_fragment(&b.body, data);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn element_needs_var(el: &Element, data: &AnalysisData) -> bool {
+    let id = el.id;
+
+    if data.node_needs_ref.contains(&id) {
+        return true;
+    }
+
+    let has_runtime_attrs = el
+        .attributes
+        .iter()
+        .any(|a| !matches!(a, Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_)));
+    if has_runtime_attrs {
+        return true;
+    }
+
+    let key = FragmentKey::Element(id);
+    let ct = data
+        .content_types
+        .get(&key)
+        .copied()
+        .unwrap_or(ContentType::Empty);
+    match ct {
+        ContentType::Empty | ContentType::StaticText => false,
+        ContentType::DynamicText | ContentType::SingleBlock => true,
+        ContentType::SingleElement | ContentType::Mixed => {
+            let Some(lf) = data.lowered_fragments.get(&key) else {
+                return false;
+            };
+            lf.items.iter().any(|item| item_needs_var(item, data))
+        }
+    }
+}
+
+fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
+    match item {
+        FragmentItem::TextConcat { parts } => {
+            parts.iter().any(|p| matches!(p, ConcatPart::Expr(_)))
+        }
+        FragmentItem::Element(id) => {
+            // Already computed: children are walked before parents
+            data.elements_needing_var.contains(id)
+        }
+        FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) => true,
+    }
+}

--- a/crates/svelte_analyze/src/props.rs
+++ b/crates/svelte_analyze/src/props.rs
@@ -16,6 +16,9 @@ pub fn analyze_props(data: &mut AnalysisData) {
             let is_prop_source =
                 p.default_span.is_some() || is_mutated;
 
+            let is_lazy_default = p.default_text.as_ref()
+                .is_some_and(|text| !svelte_js::is_simple_expression(text));
+
             PropAnalysis {
                 local_name: p.local_name.clone(),
                 prop_name: p.prop_name.clone(),
@@ -24,6 +27,7 @@ pub fn analyze_props(data: &mut AnalysisData) {
                 is_bindable: p.is_bindable,
                 is_rest: p.is_rest,
                 is_prop_source,
+                is_lazy_default,
             }
         })
         .collect();

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::AnalysisData;
@@ -30,6 +30,12 @@ pub struct Ctx<'a> {
     pub needs_binding_group: bool,
     /// Snippet param names for the currently generating snippet body.
     pub snippet_param_names: Vec<String>,
+
+    // -- Cached prop info (computed once from analysis) --
+    /// Prop names that need `$.prop()` source wrappers (called as thunks).
+    pub prop_sources: HashSet<String>,
+    /// Non-source prop names → their original prop_name (accessed as `$$props.name`).
+    pub prop_non_sources: HashMap<String, String>,
 }
 
 impl<'a> Ctx<'a> {
@@ -54,6 +60,18 @@ impl<'a> Ctx<'a> {
             &mut expr_spans,
         );
 
+        let mut prop_sources = HashSet::new();
+        let mut prop_non_sources = HashMap::new();
+        if let Some(pa) = &analysis.props {
+            for p in &pa.props {
+                if p.is_rest || p.is_prop_source {
+                    prop_sources.insert(p.local_name.clone());
+                } else {
+                    prop_non_sources.insert(p.local_name.clone(), p.prop_name.clone());
+                }
+            }
+        }
+
         Self {
             b: Builder::new(allocator),
             component,
@@ -68,6 +86,8 @@ impl<'a> Ctx<'a> {
             expr_spans,
             needs_binding_group: false,
             snippet_param_names: Vec::new(),
+            prop_sources,
+            prop_non_sources,
         }
     }
 

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -107,6 +107,7 @@ fn transform_script_text<'a>(
                 is_rest: p.is_rest,
                 is_mutated: mutated_runes.contains(&p.local_name),
                 default_text: p.default_text.clone(),
+                is_lazy_default: p.is_lazy_default,
             }).collect(),
         }
     });
@@ -170,6 +171,7 @@ struct PropGenItem {
     is_rest: bool,
     is_mutated: bool,
     default_text: Option<String>,
+    is_lazy_default: bool,
 }
 
 struct ScriptTransformer<'b, 'a> {
@@ -291,8 +293,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
             ];
 
             if let Some(default_text) = &prop.default_text {
-                let is_simple = is_simple_expression(default_text);
-                if !is_simple {
+                if prop.is_lazy_default {
                     flags |= PROPS_IS_LAZY_INITIAL;
                 }
 
@@ -300,7 +301,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
 
                 // Parse default expression
                 let default_expr = parse_expression(self.b, default_text);
-                if is_simple {
+                if !prop.is_lazy_default {
                     args.push(Arg::Expr(default_expr));
                 } else {
                     args.push(Arg::Expr(wrap_lazy(self.b, default_expr)));
@@ -330,38 +331,6 @@ fn parse_expression<'a>(b: &Builder<'a>, text: &str) -> Expression<'a> {
     match OxcParser::new(alloc, arena_text, SourceType::default()).parse_expression() {
         Ok(expr) => expr,
         Err(_) => b.str_expr(text),
-    }
-}
-
-/// Check if an expression text represents a "simple" expression (no side effects,
-/// can be eagerly evaluated). Matches Svelte's is_simple_expression().
-fn is_simple_expression(text: &str) -> bool {
-    let alloc = Allocator::default();
-    let Ok(expr) = OxcParser::new(&alloc, text, SourceType::default()).parse_expression() else {
-        return false;
-    };
-    is_simple_expr(&expr)
-}
-
-fn is_simple_expr(expr: &Expression<'_>) -> bool {
-    match expr {
-        Expression::NumericLiteral(_)
-        | Expression::StringLiteral(_)
-        | Expression::BooleanLiteral(_)
-        | Expression::NullLiteral(_)
-        | Expression::Identifier(_)
-        | Expression::ArrowFunctionExpression(_)
-        | Expression::FunctionExpression(_) => true,
-        Expression::ConditionalExpression(c) => {
-            is_simple_expr(&c.test) && is_simple_expr(&c.consequent) && is_simple_expr(&c.alternate)
-        }
-        Expression::BinaryExpression(b) => {
-            is_simple_expr(&b.left) && is_simple_expr(&b.right)
-        }
-        Expression::LogicalExpression(l) => {
-            is_simple_expr(&l.left) && is_simple_expr(&l.right)
-        }
-        _ => false,
     }
 }
 

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -60,63 +60,9 @@ pub(crate) fn process_attr<'a>(
             ));
         }
         Attribute::BindDirective(bind) => {
-            let var_name = if bind.shorthand {
-                bind.name.clone()
-            } else if let Some(span) = bind.expression_span {
-                ctx.component.source_text(span).trim().to_string()
-            } else {
-                return;
-            };
-
-            let is_mutated_rune = ctx.analysis.is_mutable_rune(&var_name);
-
-            let getter_body = if is_mutated_rune {
-                ctx.b.call_expr("$.get", [Arg::Ident(&var_name)])
-            } else {
-                ctx.b.rid_expr(&var_name)
-            };
-            let getter = ctx
-                .b
-                .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(getter_body)]);
-
-            let setter_body = if is_mutated_rune {
-                ctx.b
-                    .call_expr("$.set", [Arg::Ident(&var_name), Arg::Ident("$$value")])
-            } else {
-                ctx.b.assign_expr(
-                    AssignLeft::Ident(var_name),
-                    AssignRight::Expr(ctx.b.rid_expr("$$value")),
-                )
-            };
-            let setter = ctx.b.arrow_expr(
-                ctx.b.params(["$$value"]),
-                [ctx.b.expr_stmt(setter_body)],
-            );
-
-            let stmt = match bind.name.as_str() {
-                "checked" => ctx.b.call_stmt(
-                    "$.bind_checked",
-                    [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
-                ),
-                "group" => {
-                    ctx.needs_binding_group = true;
-                    ctx.b.call_stmt(
-                        "$.bind_group",
-                        [
-                            Arg::Ident("binding_group"),
-                            Arg::Expr(ctx.b.empty_array_expr()),
-                            Arg::Ident(el_name),
-                            Arg::Expr(getter),
-                            Arg::Expr(setter),
-                        ],
-                    )
-                }
-                _ => ctx.b.call_stmt(
-                    "$.bind_value",
-                    [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
-                ),
-            };
-            after_update.push(stmt);
+            if let Some(stmt) = gen_bind_directive(ctx, bind, el_name) {
+                after_update.push(stmt);
+            }
         }
         Attribute::ShorthandOrSpread(_) | Attribute::ClassDirective(_) => {
             // Spread handled by process_attrs_spread; class directives by process_class_directives
@@ -205,6 +151,72 @@ pub(crate) fn process_class_directives<'a>(
     init.push(effect_stmt);
 }
 
+/// Generate a bind directive statement (getter/setter + runtime call).
+fn gen_bind_directive<'a>(
+    ctx: &mut Ctx<'a>,
+    bind: &svelte_ast::BindDirective,
+    el_name: &str,
+) -> Option<Statement<'a>> {
+    let var_name = if bind.shorthand {
+        bind.name.clone()
+    } else if let Some(span) = bind.expression_span {
+        ctx.component.source_text(span).trim().to_string()
+    } else {
+        return None;
+    };
+
+    let is_mutated_rune = ctx.analysis.is_mutable_rune(&var_name);
+
+    let getter_body = if is_mutated_rune {
+        ctx.b.call_expr("$.get", [Arg::Ident(&var_name)])
+    } else {
+        ctx.b.rid_expr(&var_name)
+    };
+    let getter = ctx
+        .b
+        .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(getter_body)]);
+
+    let setter_body = if is_mutated_rune {
+        ctx.b
+            .call_expr("$.set", [Arg::Ident(&var_name), Arg::Ident("$$value")])
+    } else {
+        ctx.b.assign_expr(
+            AssignLeft::Ident(var_name),
+            AssignRight::Expr(ctx.b.rid_expr("$$value")),
+        )
+    };
+    let setter = ctx.b.arrow_expr(
+        ctx.b.params(["$$value"]),
+        [ctx.b.expr_stmt(setter_body)],
+    );
+
+    let stmt = match bind.name.as_str() {
+        "checked" => ctx.b.call_stmt(
+            "$.bind_checked",
+            [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
+        ),
+        "group" => {
+            ctx.needs_binding_group = true;
+            ctx.b.call_stmt(
+                "$.bind_group",
+                [
+                    Arg::Ident("binding_group"),
+                    Arg::Expr(ctx.b.empty_array_expr()),
+                    Arg::Ident(el_name),
+                    Arg::Expr(getter),
+                    Arg::Expr(setter),
+                ],
+            )
+        }
+        _ => ctx.b.call_stmt(
+            "$.bind_value",
+            [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
+        ),
+    };
+
+    Some(stmt)
+}
+
 /// Check if an element has any spread attribute.
 pub(crate) fn has_spread(el: &Element) -> bool {
     el.attributes
@@ -266,64 +278,9 @@ pub(crate) fn process_attrs_spread<'a>(
                 props.push(ObjProp::Shorthand(name_alloc));
             }
             Attribute::BindDirective(bind) => {
-                // Bind directives are handled separately
-                let var_name = if bind.shorthand {
-                    bind.name.clone()
-                } else if let Some(span) = bind.expression_span {
-                    ctx.component.source_text(span).trim().to_string()
-                } else {
-                    continue;
-                };
-
-                let is_mutated_rune = ctx.analysis.is_mutable_rune(&var_name);
-
-                let getter_body = if is_mutated_rune {
-                    ctx.b.call_expr("$.get", [Arg::Ident(&var_name)])
-                } else {
-                    ctx.b.rid_expr(&var_name)
-                };
-                let getter = ctx
-                    .b
-                    .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(getter_body)]);
-
-                let setter_body = if is_mutated_rune {
-                    ctx.b
-                        .call_expr("$.set", [Arg::Ident(&var_name), Arg::Ident("$$value")])
-                } else {
-                    ctx.b.assign_expr(
-                        AssignLeft::Ident(var_name),
-                        AssignRight::Expr(ctx.b.rid_expr("$$value")),
-                    )
-                };
-                let setter = ctx.b.arrow_expr(
-                    ctx.b.params(["$$value"]),
-                    [ctx.b.expr_stmt(setter_body)],
-                );
-
-                let stmt = match bind.name.as_str() {
-                    "checked" => ctx.b.call_stmt(
-                        "$.bind_checked",
-                        [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
-                    ),
-                    "group" => {
-                        ctx.needs_binding_group = true;
-                        ctx.b.call_stmt(
-                            "$.bind_group",
-                            [
-                                Arg::Ident("binding_group"),
-                                Arg::Expr(ctx.b.empty_array_expr()),
-                                Arg::Ident(el_name),
-                                Arg::Expr(getter),
-                                Arg::Expr(setter),
-                            ],
-                        )
-                    }
-                    _ => ctx.b.call_stmt(
-                        "$.bind_value",
-                        [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
-                    ),
-                };
-                after_update.push(stmt);
+                if let Some(stmt) = gen_bind_directive(ctx, bind, el_name) {
+                    after_update.push(stmt);
+                }
                 continue;
             }
             Attribute::ClassDirective(_) => continue,

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -97,11 +97,7 @@ pub(crate) fn process_element<'a>(
                 .items
                 .clone();
             // is_text only for standalone {expression} (single Expr part, no surrounding text)
-            let is_text = matches!(
-                items.first(),
-                Some(svelte_analyze::FragmentItem::TextConcat { parts })
-                if parts.len() == 1 && matches!(parts[0], svelte_analyze::ConcatPart::Expr(_))
-            );
+            let is_text = items.first().is_some_and(|item| item.is_standalone_expr());
             let child_call = if is_text {
                 ctx.b.call_expr("$.child", [Arg::Ident(el_name), Arg::Bool(true)])
             } else {
@@ -126,9 +122,7 @@ pub(crate) fn process_element<'a>(
                 .items
                 .clone();
 
-            let first_is_text = child_items.first().is_some_and(|item| {
-                matches!(item, svelte_analyze::FragmentItem::TextConcat { parts } if parts.len() == 1)
-            });
+            let first_is_text = child_items.first().is_some_and(|item| item.is_standalone_expr());
             let first_child = if first_is_text {
                 ctx.b.call_expr("$.child", [Arg::Ident(el_name), Arg::Bool(true)])
             } else {
@@ -165,39 +159,8 @@ fn has_dynamic_children(ctx: &Ctx<'_>, el_id: NodeId) -> bool {
     lf.items.iter().any(|item| item_is_dynamic(item, ctx))
 }
 
-/// Check if an element needs a DOM variable during traversal.
-pub(crate) fn element_needs_var(ctx: &Ctx<'_>, id: NodeId) -> bool {
-    if ctx.analysis.node_needs_ref.contains(&id) {
-        return true;
-    }
-    let el = ctx.element(id);
-    let has_runtime_attrs = el
-        .attributes
-        .iter()
-        .any(|a| !matches!(a, Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_)));
-    if has_runtime_attrs {
-        return true;
-    }
-    let key = FragmentKey::Element(id);
-    let ct = ctx
-        .analysis
-        .content_types
-        .get(&key)
-        .copied()
-        .unwrap_or(ContentType::Empty);
-    match ct {
-        ContentType::Empty | ContentType::StaticText => false,
-        ContentType::DynamicText | ContentType::SingleBlock => true,
-        ContentType::SingleElement | ContentType::Mixed => {
-            let Some(lf) = ctx.analysis.lowered_fragments.get(&key) else {
-                return false;
-            };
-            lf.items.iter().any(|item| item_needs_var(item, ctx))
-        }
-    }
-}
-
 /// Check if a fragment item needs a DOM variable.
+/// Elements use precomputed `elements_needing_var` from the analysis phase.
 pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         svelte_analyze::FragmentItem::TextConcat { parts } => {
@@ -205,7 +168,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
                 .iter()
                 .any(|p| matches!(p, svelte_analyze::ConcatPart::Expr(_)))
         }
-        svelte_analyze::FragmentItem::Element(id) => element_needs_var(ctx, *id),
+        svelte_analyze::FragmentItem::Element(id) => ctx.analysis.elements_needing_var.contains(id),
         svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) => {
             true
         }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -26,28 +26,10 @@ pub(crate) fn parse_expr<'a>(ctx: &mut Ctx<'a>, span: Span) -> Expression<'a> {
     let mutated = &ctx.analysis.mutated_runes;
     let rune_names = &ctx.analysis.rune_names;
     let snippet_params = &ctx.snippet_param_names;
+    let prop_sources = &ctx.prop_sources;
+    let prop_non_sources = &ctx.prop_non_sources;
 
-    // Build prop info sets
-    let (prop_sources, prop_non_sources) = build_prop_sets(ctx);
-
-    parse_and_transform(ctx.b.ast.allocator, source, mutated, rune_names, &prop_sources, &prop_non_sources, snippet_params)
-}
-
-pub(crate) fn build_prop_sets(ctx: &Ctx<'_>) -> (HashSet<String>, HashMap<String, String>) {
-    let mut prop_sources = HashSet::new();
-    let mut prop_non_sources = HashMap::new();
-
-    if let Some(pa) = &ctx.analysis.props {
-        for p in &pa.props {
-            if p.is_rest || p.is_prop_source {
-                prop_sources.insert(p.local_name.clone());
-            } else {
-                prop_non_sources.insert(p.local_name.clone(), p.prop_name.clone());
-            }
-        }
-    }
-
-    (prop_sources, prop_non_sources)
+    parse_and_transform(ctx.b.ast.allocator, source, mutated, rune_names, prop_sources, prop_non_sources, snippet_params)
 }
 
 pub(crate) fn parse_and_transform<'a>(

--- a/crates/svelte_codegen_client/src/template/render_tag.rs
+++ b/crates/svelte_codegen_client/src/template/render_tag.rs
@@ -2,7 +2,10 @@
 
 use std::collections::{HashMap, HashSet};
 
+use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
+use oxc_parser::Parser as OxcParser;
+use oxc_span::{GetSpan as _, SourceType};
 
 use svelte_ast::NodeId;
 
@@ -19,63 +22,45 @@ pub(crate) fn gen_render_tag<'a>(
     let tag = ctx.render_tag(id);
     let source = ctx.component.source_text(tag.expression_span);
 
-    let (callee_name, arg_sources) = extract_call_parts(source);
+    let (callee_text, arg_texts) = extract_call_parts(source);
 
     let mut call_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor_expr)];
 
-    // Build prop sets once for all arguments
-    let (prop_sources, prop_non_sources) = super::expression::build_prop_sets(ctx);
+    let prop_sources = ctx.prop_sources.clone();
+    let prop_non_sources = ctx.prop_non_sources.clone();
 
-    for arg_src in &arg_sources {
+    for arg_src in &arg_texts {
         let thunk = build_thunked_arg(ctx, arg_src, &prop_sources, &prop_non_sources);
         call_args.push(Arg::Expr(thunk));
     }
 
-    stmts.push(ctx.b.call_stmt(callee_name, call_args));
+    stmts.push(ctx.b.call_stmt(callee_text, call_args));
 }
 
+/// Parse the render tag expression with OXC and extract callee name + argument source texts.
 fn extract_call_parts(source: &str) -> (&str, Vec<&str>) {
-    let paren_pos = match source.find('(') {
-        Some(pos) => pos,
-        None => return (source.trim(), vec![]),
+    let alloc = Allocator::default();
+    let Ok(expr) = OxcParser::new(&alloc, source, SourceType::default()).parse_expression() else {
+        return (source.trim(), vec![]);
     };
 
-    let callee = source[..paren_pos].trim();
-    let inner = &source[paren_pos + 1..source.len() - 1];
-    if inner.trim().is_empty() {
-        return (callee, vec![]);
-    }
+    let Expression::CallExpression(call) = &expr else {
+        return (source.trim(), vec![]);
+    };
 
-    let args = split_args(inner);
-    (callee, args)
-}
+    let callee_span = call.callee.span();
+    let callee_text = &source[callee_span.start as usize..callee_span.end as usize];
 
-fn split_args(s: &str) -> Vec<&str> {
-    let mut args = Vec::new();
-    let mut depth = 0u32;
-    let mut start = 0;
+    let arg_texts: Vec<&str> = call
+        .arguments
+        .iter()
+        .map(|arg| {
+            let sp = arg.span();
+            &source[sp.start as usize..sp.end as usize]
+        })
+        .collect();
 
-    for (i, ch) in s.char_indices() {
-        match ch {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                let arg = s[start..i].trim();
-                if !arg.is_empty() {
-                    args.push(arg);
-                }
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-
-    let last = s[start..].trim();
-    if !last.is_empty() {
-        args.push(last);
-    }
-
-    args
+    (callee_text, arg_texts)
 }
 
 /// Build `() => expr` where expr has rune transforms applied.

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -33,7 +33,7 @@ pub(crate) fn traverse_items<'a>(
         let needs_var = item_needs_var(item, ctx);
         // is_text matches Svelte's `sequence.length === 1`: a standalone {expression}
         // with no surrounding text nodes in the same sequence
-        let is_text = matches!(item, FragmentItem::TextConcat { parts } if parts.len() == 1);
+        let is_text = item.is_standalone_expr();
 
         if needs_var {
             // Build the expression to get this node's DOM reference

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -380,6 +380,41 @@ pub fn analyze_script_with_scoping(
     Ok((script_info, scoping))
 }
 
+/// Check if an expression text represents a "simple" expression that can be
+/// eagerly evaluated (no side effects). Matches Svelte's `is_simple_expression()`.
+///
+/// Simple expressions: literals, identifiers, functions, and combinations of
+/// binary/logical/conditional expressions composed of simples.
+pub fn is_simple_expression(text: &str) -> bool {
+    let alloc = Allocator::default();
+    let Ok(expr) = OxcParser::new(&alloc, text, SourceType::default()).parse_expression() else {
+        return false;
+    };
+    is_simple_expr(&expr)
+}
+
+fn is_simple_expr(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::Identifier(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_) => true,
+        Expression::ConditionalExpression(c) => {
+            is_simple_expr(&c.test) && is_simple_expr(&c.consequent) && is_simple_expr(&c.alternate)
+        }
+        Expression::BinaryExpression(b) => {
+            is_simple_expr(&b.left) && is_simple_expr(&b.right)
+        }
+        Expression::LogicalExpression(l) => {
+            is_simple_expr(&l.left) && is_simple_expr(&l.right)
+        }
+        _ => false,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Move element_needs_var computation to analysis phase (new needs_var.rs pass)
  → codegen now reads precomputed elements_needing_var HashSet
- Move is_simple_expression to svelte_js crate, add is_lazy_default to PropAnalysis
  → codegen no longer re-parses default expressions to determine laziness
- Extract duplicated bind directive logic into gen_bind_directive() helper
  → eliminates ~60 lines of copy-paste between process_attr and process_attrs_spread
- Cache prop_sources/prop_non_sources in Ctx at init time
  → avoids rebuilding HashSet/HashMap on every parse_expr() call
- Add FragmentItem::is_standalone_expr() method
  → replaces inline pattern match in element.rs and traverse.rs
- Rewrite RenderTag argument extraction using OXC CallExpression parser
  → fixes incorrect splitting of args containing strings with parens/commas

https://claude.ai/code/session_01KTq6H28JQuEEbRfqysz9HJ