### PR TITLE
refactor: simplify codegen with NodeIndex struct, alloc_str helper, and deduplication

### DIFF
--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -52,6 +52,10 @@ impl<'a> Builder<'a> {
         self.ast.alloc(value)
     }
 
+    pub fn alloc_str(&self, s: &str) -> &'a str {
+        self.ast.allocator.alloc_str(s)
+    }
+
     // -----------------------------------------------------------------------
     // Identifiers
     // -----------------------------------------------------------------------
@@ -173,10 +177,6 @@ impl<'a> Builder<'a> {
 
     pub fn var_stmt(&self, name: &str, init: Expression<'a>) -> Statement<'a> {
         self.var_decl_stmt(name, init, VariableDeclarationKind::Var)
-    }
-
-    pub fn let_stmt_init(&self, name: &str, init: Expression<'a>) -> Statement<'a> {
-        self.var_decl_stmt(name, init, VariableDeclarationKind::Let)
     }
 
     /// `let name;` — uninitialized variable declaration.

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -7,6 +7,67 @@ use svelte_span::Span;
 
 use crate::builder::Builder;
 
+/// Pre-built index for O(1) node lookup by NodeId.
+struct NodeIndex<'a> {
+    elements: HashMap<NodeId, &'a Element>,
+    if_blocks: HashMap<NodeId, &'a IfBlock>,
+    each_blocks: HashMap<NodeId, &'a EachBlock>,
+    snippet_blocks: HashMap<NodeId, &'a SnippetBlock>,
+    render_tags: HashMap<NodeId, &'a RenderTag>,
+    expr_spans: HashMap<NodeId, Span>,
+}
+
+impl<'a> NodeIndex<'a> {
+    fn build(fragment: &'a Fragment) -> Self {
+        let mut index = Self {
+            elements: HashMap::new(),
+            if_blocks: HashMap::new(),
+            each_blocks: HashMap::new(),
+            snippet_blocks: HashMap::new(),
+            render_tags: HashMap::new(),
+            expr_spans: HashMap::new(),
+        };
+        index.walk(fragment);
+        index
+    }
+
+    fn walk(&mut self, fragment: &'a Fragment) {
+        for node in &fragment.nodes {
+            match node {
+                Node::Element(el) => {
+                    self.elements.insert(el.id, el);
+                    self.walk(&el.fragment);
+                }
+                Node::IfBlock(b) => {
+                    self.if_blocks.insert(b.id, b);
+                    self.walk(&b.consequent);
+                    if let Some(alt) = &b.alternate {
+                        self.walk(alt);
+                    }
+                }
+                Node::EachBlock(b) => {
+                    self.each_blocks.insert(b.id, b);
+                    self.walk(&b.body);
+                    if let Some(fb) = &b.fallback {
+                        self.walk(fb);
+                    }
+                }
+                Node::SnippetBlock(b) => {
+                    self.snippet_blocks.insert(b.id, b);
+                    self.walk(&b.body);
+                }
+                Node::RenderTag(t) => {
+                    self.render_tags.insert(t.id, t);
+                }
+                Node::ExpressionTag(t) => {
+                    self.expr_spans.insert(t.id, t.expression_span);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
 /// Central codegen context. Holds refs to allocator, builder, component, analysis,
 /// and mutable state (ident counter, node index).
 pub struct Ctx<'a> {
@@ -19,12 +80,7 @@ pub struct Ctx<'a> {
     pub module_hoisted: Vec<Statement<'a>>,
 
     // -- Node index (O(1) lookup by NodeId) --
-    elements: HashMap<NodeId, &'a Element>,
-    if_blocks: HashMap<NodeId, &'a IfBlock>,
-    each_blocks: HashMap<NodeId, &'a EachBlock>,
-    snippet_blocks: HashMap<NodeId, &'a SnippetBlock>,
-    render_tags: HashMap<NodeId, &'a RenderTag>,
-    expr_spans: HashMap<NodeId, Span>,
+    index: NodeIndex<'a>,
 
     // -- Bind group --
     pub needs_binding_group: bool,
@@ -44,21 +100,7 @@ impl<'a> Ctx<'a> {
         component: &'a Component,
         analysis: &'a AnalysisData,
     ) -> Self {
-        let mut elements = HashMap::new();
-        let mut if_blocks = HashMap::new();
-        let mut each_blocks = HashMap::new();
-        let mut snippet_blocks = HashMap::new();
-        let mut render_tags = HashMap::new();
-        let mut expr_spans = HashMap::new();
-        build_node_index(
-            &component.fragment,
-            &mut elements,
-            &mut if_blocks,
-            &mut each_blocks,
-            &mut snippet_blocks,
-            &mut render_tags,
-            &mut expr_spans,
-        );
+        let index = NodeIndex::build(&component.fragment);
 
         let mut prop_sources = HashSet::new();
         let mut prop_non_sources = HashMap::new();
@@ -78,12 +120,7 @@ impl<'a> Ctx<'a> {
             analysis,
             ident_counters: HashMap::new(),
             module_hoisted: Vec::new(),
-            elements,
-            if_blocks,
-            each_blocks,
-            snippet_blocks,
-            render_tags,
-            expr_spans,
+            index,
             needs_binding_group: false,
             snippet_param_names: Vec::new(),
             prop_sources,
@@ -94,27 +131,27 @@ impl<'a> Ctx<'a> {
     // -- Node lookups (O(1)) --
 
     pub fn element(&self, id: NodeId) -> &'a Element {
-        self.elements.get(&id).copied().expect("element not found")
+        self.index.elements.get(&id).copied().expect("element not found")
     }
 
     pub fn if_block(&self, id: NodeId) -> &'a IfBlock {
-        self.if_blocks.get(&id).copied().expect("if block not found")
+        self.index.if_blocks.get(&id).copied().expect("if block not found")
     }
 
     pub fn each_block(&self, id: NodeId) -> &'a EachBlock {
-        self.each_blocks.get(&id).copied().expect("each block not found")
+        self.index.each_blocks.get(&id).copied().expect("each block not found")
     }
 
     pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock {
-        self.snippet_blocks.get(&id).copied().expect("snippet block not found")
+        self.index.snippet_blocks.get(&id).copied().expect("snippet block not found")
     }
 
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
-        self.render_tags.get(&id).copied().expect("render tag not found")
+        self.index.render_tags.get(&id).copied().expect("render tag not found")
     }
 
     pub fn expr_span(&self, id: NodeId) -> Span {
-        self.expr_spans.get(&id).copied().expect("expr tag not found")
+        self.index.expr_spans.get(&id).copied().expect("expr tag not found")
     }
 
     // -- Identifiers --
@@ -131,53 +168,4 @@ impl<'a> Ctx<'a> {
         name
     }
 
-}
-
-
-// ---------------------------------------------------------------------------
-// Index builder — walks AST once, populates HashMaps
-// ---------------------------------------------------------------------------
-
-fn build_node_index<'a>(
-    fragment: &'a Fragment,
-    elements: &mut HashMap<NodeId, &'a Element>,
-    if_blocks: &mut HashMap<NodeId, &'a IfBlock>,
-    each_blocks: &mut HashMap<NodeId, &'a EachBlock>,
-    snippet_blocks: &mut HashMap<NodeId, &'a SnippetBlock>,
-    render_tags: &mut HashMap<NodeId, &'a RenderTag>,
-    expr_spans: &mut HashMap<NodeId, Span>,
-) {
-    for node in &fragment.nodes {
-        match node {
-            Node::Element(el) => {
-                elements.insert(el.id, el);
-                build_node_index(&el.fragment, elements, if_blocks, each_blocks, snippet_blocks, render_tags, expr_spans);
-            }
-            Node::IfBlock(b) => {
-                if_blocks.insert(b.id, b);
-                build_node_index(&b.consequent, elements, if_blocks, each_blocks, snippet_blocks, render_tags, expr_spans);
-                if let Some(alt) = &b.alternate {
-                    build_node_index(alt, elements, if_blocks, each_blocks, snippet_blocks, render_tags, expr_spans);
-                }
-            }
-            Node::EachBlock(b) => {
-                each_blocks.insert(b.id, b);
-                build_node_index(&b.body, elements, if_blocks, each_blocks, snippet_blocks, render_tags, expr_spans);
-                if let Some(fb) = &b.fallback {
-                    build_node_index(fb, elements, if_blocks, each_blocks, snippet_blocks, render_tags, expr_spans);
-                }
-            }
-            Node::SnippetBlock(b) => {
-                snippet_blocks.insert(b.id, b);
-                build_node_index(&b.body, elements, if_blocks, each_blocks, snippet_blocks, render_tags, expr_spans);
-            }
-            Node::RenderTag(t) => {
-                render_tags.insert(t.id, t);
-            }
-            Node::ExpressionTag(t) => {
-                expr_spans.insert(t.id, t.expression_span);
-            }
-            _ => {}
-        }
-    }
 }

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -86,9 +86,9 @@ pub fn generate(component: &Component, analysis: &AnalysisData) -> String {
     // var $$exports = { PI, greet, ... }
     if has_exports {
         let props: Vec<ObjProp<'_>> = ctx.analysis.exports.iter().map(|e| {
-            let name: &str = b.ast.allocator.alloc_str(&e.name);
+            let name: &str = b.alloc_str(&e.name);
             if let Some(alias) = &e.alias {
-                let alias: &str = b.ast.allocator.alloc_str(alias);
+                let alias: &str = b.alloc_str(alias);
                 ObjProp::KeyValue(alias, b.rid_expr(name))
             } else {
                 ObjProp::Shorthand(name)

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -20,7 +20,6 @@ use crate::context::Ctx;
 const PROPS_IS_IMMUTABLE: u32 = 1;
 const PROPS_IS_RUNES: u32 = 1 << 1;
 const PROPS_IS_UPDATED: u32 = 1 << 2;
-#[allow(dead_code)]
 const PROPS_IS_BINDABLE: u32 = 1 << 3;
 const PROPS_IS_LAZY_INITIAL: u32 = 1 << 4;
 
@@ -41,7 +40,16 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Statement<'
     let mutated_runes = &ctx.analysis.mutated_runes;
     let props = ctx.analysis.props.as_ref();
 
-    transform_script_text(allocator, script_text, is_ts, rune_names, mutated_runes, props)
+    transform_script_text(
+        allocator,
+        script_text,
+        is_ts,
+        rune_names,
+        mutated_runes,
+        props,
+        &ctx.prop_sources,
+        &ctx.prop_non_sources,
+    )
 }
 
 /// Parse the script source and apply rune transformations, returning (imports, body).
@@ -52,6 +60,8 @@ fn transform_script_text<'a>(
     rune_names: &HashSet<String>,
     mutated_runes: &HashSet<String>,
     props: Option<&PropsAnalysis>,
+    prop_sources: &HashSet<String>,
+    prop_non_sources: &HashMap<String, String>,
 ) -> (Vec<Statement<'a>>, Vec<Statement<'a>>) {
     let src_type = if is_ts {
         SourceType::default().with_typescript(true).with_module(true)
@@ -70,24 +80,11 @@ fn transform_script_text<'a>(
     let mut rune_table: HashMap<oxc_semantic::SymbolId, RuneInfo> = HashMap::new();
     let mut prop_table: HashMap<oxc_semantic::SymbolId, PropSymInfo> = HashMap::new();
 
-    let mut prop_source_names: HashSet<String> = HashSet::new();
-    let mut prop_non_source_names: HashSet<String> = HashSet::new();
-
-    if let Some(pa) = props {
-        for p in &pa.props {
-            if p.is_rest || p.is_prop_source {
-                prop_source_names.insert(p.local_name.clone());
-            } else {
-                prop_non_source_names.insert(p.local_name.clone());
-            }
-        }
-    }
-
     for sym_id in scoping.symbol_ids() {
         let name = scoping.symbol_name(sym_id);
-        if prop_source_names.contains(name) {
+        if prop_sources.contains(name) {
             prop_table.insert(sym_id, PropSymInfo { kind: PropKind::Source });
-        } else if prop_non_source_names.contains(name) {
+        } else if prop_non_sources.contains_key(name) {
             prop_table.insert(sym_id, PropSymInfo {
                 kind: PropKind::NonSource(name.to_string()),
             });
@@ -271,7 +268,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
                     Arg::Ident("$$props"),
                     Arg::Expr(arr_expr),
                 ]);
-                declarators.push((self.b.ast.allocator.alloc_str(&prop.local_name), init));
+                declarators.push((self.b.alloc_str(&prop.local_name), init));
                 continue;
             }
 
@@ -312,7 +309,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
                 }
             }
 
-            let name: &'a str = self.b.ast.allocator.alloc_str(&prop.local_name);
+            let name: &'a str = self.b.alloc_str(&prop.local_name);
             declarators.push((name, self.b.call_expr("$.prop", args)));
         }
 

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -107,7 +107,7 @@ pub(crate) fn process_class_directives<'a>(
 
         let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
 
-        let name_alloc = ctx.b.ast.allocator.alloc_str(name);
+        let name_alloc = ctx.b.alloc_str(name);
 
         if is_mutated_rune {
             let get_call = ctx.b.call_expr("$.get", [Arg::Ident(name)]);
@@ -140,15 +140,10 @@ pub(crate) fn process_class_directives<'a>(
         AssignRight::Expr(set_class_call),
     );
 
-    // () => classes = $.set_class(...)
-    let arrow = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(assign)]);
-
-    // $.template_effect(() => ...)
-    let effect_stmt = ctx.b.call_stmt("$.template_effect", [Arg::Expr(arrow)]);
-
     // let classes;
+    // $.template_effect(() => { classes = $.set_class(...) })
     init.push(ctx.b.let_stmt("classes"));
-    init.push(effect_stmt);
+    super::expression::emit_template_effect(ctx, vec![ctx.b.expr_stmt(assign)], init);
 }
 
 /// Generate a bind directive statement (getter/setter + runtime call).
@@ -238,12 +233,12 @@ pub(crate) fn process_attrs_spread<'a>(
     for attr in &el.attributes {
         match attr {
             Attribute::BooleanAttribute(a) => {
-                let name_alloc = ctx.b.ast.allocator.alloc_str(&a.name);
+                let name_alloc = ctx.b.alloc_str(&a.name);
                 props.push(ObjProp::KeyValue(name_alloc, ctx.b.bool_expr(true)));
             }
             Attribute::StringAttribute(a) => {
                 let val = ctx.component.source_text(a.value_span).to_string();
-                let name_alloc = ctx.b.ast.allocator.alloc_str(&a.name);
+                let name_alloc = ctx.b.alloc_str(&a.name);
                 props.push(ObjProp::KeyValue(name_alloc, ctx.b.str_expr(&val)));
             }
             Attribute::ExpressionAttribute(a) => {
@@ -251,16 +246,16 @@ pub(crate) fn process_attrs_spread<'a>(
                 let expr_text = ctx.component.source_text(a.expression_span).trim();
                 if a.name == expr_text {
                     // Property shorthand: name matches expression
-                    let name_alloc = ctx.b.ast.allocator.alloc_str(&a.name);
+                    let name_alloc = ctx.b.alloc_str(&a.name);
                     props.push(ObjProp::Shorthand(name_alloc));
                 } else {
-                    let name_alloc = ctx.b.ast.allocator.alloc_str(&a.name);
+                    let name_alloc = ctx.b.alloc_str(&a.name);
                     props.push(ObjProp::KeyValue(name_alloc, expr));
                 }
             }
             Attribute::ConcatenationAttribute(a) => {
                 let val = build_attr_concat(ctx, &a.parts);
-                let name_alloc = ctx.b.ast.allocator.alloc_str(&a.name);
+                let name_alloc = ctx.b.alloc_str(&a.name);
                 props.push(ObjProp::KeyValue(name_alloc, val));
             }
             Attribute::ShorthandOrSpread(a) if a.is_spread => {
@@ -274,7 +269,7 @@ pub(crate) fn process_attrs_spread<'a>(
             }
             Attribute::ShorthandOrSpread(a) => {
                 let name = ctx.component.source_text(a.expression_span).trim();
-                let name_alloc = ctx.b.ast.allocator.alloc_str(name);
+                let name_alloc = ctx.b.alloc_str(name);
                 props.push(ObjProp::Shorthand(name_alloc));
             }
             Attribute::BindDirective(bind) => {

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -274,8 +274,7 @@ pub(crate) fn emit_text_update<'a>(
 
     if is_dyn {
         let set = ctx.b.call_stmt("$.set_text", [Arg::Ident(node_name), Arg::Expr(expr)]);
-        let eff = ctx.b.arrow(ctx.b.no_params(), [set]);
-        body.push(ctx.b.call_stmt("$.template_effect", [Arg::Arrow(eff)]));
+        emit_template_effect(ctx, vec![set], body);
     } else {
         body.push(ctx.b.assign_stmt(
             AssignLeft::StaticMember(ctx.b.static_member(ctx.b.rid_expr(node_name), "nodeValue")),


### PR DESCRIPTION
- Introduce NodeIndex struct to encapsulate 6 HashMaps and recursive walker
  (replaces 7-parameter build_node_index function)
- Add Builder::alloc_str() helper to shorten ctx.b.ast.allocator.alloc_str()
  calls across 11 call sites
- Remove duplicate prop source/non-source table construction in script.rs
  (reuse pre-computed sets from Ctx)
- Unify template_effect pattern: use emit_template_effect() in
  emit_text_update and process_class_directives
- Remove stale #[allow(dead_code)] on PROPS_IS_BINDABLE (it is used)
- Remove unused let_stmt_init method from Builder

https://claude.ai/code/session_01GtjxWzZm633mQsyT6rM7JM