### PR TITLE
feat(docs): add dark theme toggle and benchmark code button

### DIFF
--- a/docs/example.js
+++ b/docs/example.js
@@ -6,3 +6,98 @@ export const example = [
   "<h1>Hello {name}!</h1>",
   "",
 ].join("\n");
+
+export const benchmarkExample = `<script>
+    import { onMount } from "svelte";
+
+    let {
+        title = "Default Title",
+        count = 0,
+        items = [],
+        config = $bindable({}),
+        multiplier = 2,
+        ...rest
+    } = $props();
+
+    let state = $state("");
+    let counter = $state(0);
+
+    counter = 10;
+
+    let doubled = $derived(count * multiplier);
+
+    $effect(() => {
+        console.log("Title:", title, "Count:", count);
+    });
+
+    export const APP_VERSION = "1.0.0";
+
+    export function formatTitle(prefix) {
+        return prefix + ": " + title;
+    }
+</script>
+
+{#snippet badge(text, variant)}
+    <span class="badge" class:primary={variant === "primary"} class:secondary={variant === "secondary"}>
+        {text}
+    </span>
+{/snippet}
+
+{#snippet card(heading, body)}
+    <div class="card">
+        <h3>{heading}</h3>
+        <p>{body}</p>
+        {@render badge("new", "primary")}
+    </div>
+{/snippet}
+
+<div>
+    Chunk 0: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 0.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 0.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 0.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-0">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+
+    {@render badge("chunk-0", "secondary")}
+    {@render card(title, "Content for chunk 0")}
+</div>
+`;

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,16 @@
     </head>
     <body>
         <div class="container">
-            <h1>Rust Svelte Compiler Demo</h1>
+            <div class="toolbar">
+                <h1>Rust Svelte Compiler Demo</h1>
+                <div class="toolbar-actions">
+                    <button id="load-benchmark" class="btn" title="Load benchmark code">
+                        Load benchmark
+                    </button>
+                    <button id="theme-toggle" class="btn btn-icon" title="Toggle theme">
+                    </button>
+                </div>
+            </div>
 
             <div class="grid">
                 <div class="editor-box">
@@ -42,6 +51,24 @@
         </div>
 
         <style>
+            :root {
+                --bg: #ffffff;
+                --text: #1a1a1a;
+                --toolbar-bg: #f0f0f0;
+                --btn-bg: #e0e0e0;
+                --btn-text: #1a1a1a;
+                --btn-hover: #d0d0d0;
+            }
+
+            :root.dark {
+                --bg: #1e1e1e;
+                --text: #d4d4d4;
+                --toolbar-bg: #2d2d2d;
+                --btn-bg: #3c3c3c;
+                --btn-text: #d4d4d4;
+                --btn-hover: #505050;
+            }
+
             * {
                 margin: 0;
                 padding: 0;
@@ -51,6 +78,9 @@
                 font-family: "Space Mono", serif;
                 font-weight: 400;
                 font-style: normal;
+                background: var(--bg);
+                color: var(--text);
+                transition: background 0.2s, color 0.2s;
             }
 
             .container {
@@ -58,6 +88,41 @@
                 width: 100vw;
                 height: 80vh;
                 box-sizing: border-box;
+            }
+
+            .toolbar {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 1rem;
+            }
+
+            .toolbar-actions {
+                display: flex;
+                gap: 0.5rem;
+                align-items: center;
+            }
+
+            .btn {
+                font-family: "Space Mono", serif;
+                font-size: 14px;
+                padding: 6px 14px;
+                border: none;
+                border-radius: 6px;
+                background: var(--btn-bg);
+                color: var(--btn-text);
+                cursor: pointer;
+                transition: background 0.15s;
+            }
+
+            .btn:hover {
+                background: var(--btn-hover);
+            }
+
+            .btn-icon {
+                font-size: 18px;
+                padding: 6px 10px;
+                line-height: 1;
             }
 
             .grid {
@@ -96,6 +161,11 @@
                     font-size: 0.9rem;
                 }
 
+                .toolbar {
+                    flex-direction: column;
+                    align-items: flex-start;
+                }
+
                 .grid {
                     grid-template-columns: 1fr;
                 }
@@ -124,7 +194,7 @@
             import prettyMs from "prettyMs";
             import { compile as svelteCompiler } from "https://cdn.jsdelivr.net/npm/svelte@5.53.9/compiler/index.js/+esm";
 
-            import { example } from "./example.js";
+            import { example, benchmarkExample } from "./example.js";
 
             await init();
 
@@ -143,6 +213,35 @@
             const rustPerf = document.getElementById("rust-perf");
             const sveltePerf = document.getElementById("svelte-perf");
 
+            // --- Theme ---
+            const themeToggleBtn = document.getElementById("theme-toggle");
+            let isDark = localStorage.getItem("theme") === "dark" ||
+                (!localStorage.getItem("theme") && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+            function applyTheme() {
+                document.documentElement.classList.toggle("dark", isDark);
+                themeToggleBtn.textContent = isDark ? "\u2600\uFE0F" : "\uD83C\uDF19";
+                if (typeof monaco !== "undefined") {
+                    monaco.editor.setTheme(isDark ? "vs-dark" : "vs");
+                }
+            }
+
+            applyTheme();
+
+            themeToggleBtn.addEventListener("click", () => {
+                isDark = !isDark;
+                localStorage.setItem("theme", isDark ? "dark" : "light");
+                applyTheme();
+            });
+
+            // --- Benchmark button ---
+            document.getElementById("load-benchmark").addEventListener("click", () => {
+                if (editorInstance) {
+                    editorInstance.setValue(benchmarkExample);
+                }
+            });
+
+            // --- Monaco ---
             let scriptElement = document.createElement("script");
             scriptElement.setAttribute(
                 "src",
@@ -158,6 +257,8 @@
                 });
 
                 require(["vs/editor/editor.main"], () => {
+                    const monacoTheme = isDark ? "vs-dark" : "vs";
+
                     editorInstance = monaco.editor.create(
                         document.getElementById("editor"),
                         {
@@ -168,7 +269,7 @@
                             overviewRulerLanes: 0,
                             overviewRulerBorder: false,
                             minimap: { enabled: false },
-                            theme: "vs-dark",
+                            theme: monacoTheme,
                         },
                     );
 
@@ -185,7 +286,7 @@
                             renderSideBySide: !isNarrow,
                             minimap: { enabled: false },
                             overviewRulerLanes: 0,
-                            theme: "vs-dark",
+                            theme: monacoTheme,
                             originalEditable: false,
                         },
                     );


### PR DESCRIPTION
Add theme system with CSS custom properties and localStorage persistence.
Add toolbar with theme toggle (respects prefers-color-scheme) and
"Load benchmark" button that inserts script+snippets+chunk example code.

https://claude.ai/code/session_01EMqFWtkVZysCP9kMy8VszA