### PR TITLE
Implement {@html expr} tag support for raw HTML insertion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,13 +147,14 @@ Theme: most commonly needed template features. Requires parser + AST + analyze +
 
 Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_client/src/template/`
 
-### `{@html expr}` — Raw HTML insertion
+### ~~`{@html expr}`~~ — Raw HTML insertion ✅
 - **Phases**: P, A, T
 - **AST**: `Node::HtmlTag { id, span, expression_span }`
 - **Parser**: Handle `{@html ...}` in tag scanner (similar to `{@render}`)
 - **Analyze**: Register expression in `parse_js`. Mark dynamic in `reactivity`. Handle in `content_types`
 - **Codegen**: `$.html(anchor, () => expr)`
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/HtmlTag.js` (~60 lines)
+- **Not yet**: `is_controlled` optimization (single child → innerHTML), `is_svg`/`is_mathml` namespace flags
 
 ### `{#key expr}` — Keyed re-render block
 - **Phases**: P, A, T

--- a/TODO.md
+++ b/TODO.md
@@ -4,25 +4,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 1. `{@html expr}` (HtmlTag)
+## 1. `{#key expr}` (KeyBlock)
 
-**Why first**: очень частая фича (markdown, CMS контент), первая фича требующая parser+AST+codegen.
-
-**What to change**:
-- `svelte_ast/src/lib.rs`: добавить `Node::HtmlTag { expression: Span }`
-- `svelte_parser/src/lib.rs`: обработка `{@html ...}` в scanner
-- `svelte_codegen_client/src/template/`: генерация `$.html(anchor, () => expr)`
-- Analyze: отметить как dynamic expression
-
-**Reference**: `reference/compiler/phases/3-transform/client/visitors/HtmlTag.js`
-
-**Runtime**: `$.html()`
-
----
-
-## 2. `{#key expr}` (KeyBlock)
-
-**Why second**: нужен для роутеров (ремаунт при смене route) и анимаций.
+**Why first**: нужен для роутеров (ремаунт при смене route) и анимаций.
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Node::KeyBlock { expression: Span, fragment: Fragment }`
@@ -36,9 +20,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 3. `style:prop` directive
+## 2. `style:prop` directive
 
-**Why third**: так же часто используется как `class:`, паттерн уже есть (ClassDirective).
+**Why second**: так же часто используется как `class:`, паттерн уже есть (ClassDirective).
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Attribute::StyleDirective { name, value, modifiers }`
@@ -51,9 +35,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 4. Event handlers (`on:event` → `onevent`)
+## 3. Event handlers (`on:event` → `onevent`)
 
-**Why fourth**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
+**Why third**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
 
 **What to change**:
 - `svelte_parser/src/lib.rs`: парсинг `on:click={handler}` → `Attribute::OnDirective`
@@ -64,9 +48,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 5. Void HTML elements
+## 4. Void HTML elements
 
-**Why fifth**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
+**Why fourth**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
 
 **What to change**:
 - Добавить `VOID_ELEMENTS` constant и `is_void(name)` helper
@@ -74,3 +58,17 @@ Next 5 features to implement, in priority order.
 - Validation: ошибка на `</input>` и child-контент внутри void elements
 
 **Reference**: `reference/compiler/phases/1-parse/state/element.js` line 371, `reference/compiler/utils.js`
+
+---
+
+## 5. `{@const x = expr}` (ConstTag)
+
+**Why fifth**: нужен для вычислений внутри {#each} и {#if} блоков.
+
+**What to change**:
+- `svelte_ast/src/lib.rs`: добавить `Node::ConstTag { id, span, declaration_span }`
+- `svelte_parser/src/lib.rs`: парсинг `{@const ...}` с извлечением variable declaration
+- `svelte_analyze/`: scope integration — const binding visible in same block
+- `svelte_codegen_client/src/template/`: `const x = expr` (non-reactive) or `$.derived(() => expr)` (reactive)
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/ConstTag.js` (~134 lines)

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -34,7 +34,8 @@ fn item_is_dynamic(
         | FragmentItem::ComponentNode(id)
         | FragmentItem::IfBlock(id)
         | FragmentItem::EachBlock(id)
-        | FragmentItem::RenderTag(id) => dynamic_nodes.contains(id),
+        | FragmentItem::RenderTag(id)
+        | FragmentItem::HtmlTag(id) => dynamic_nodes.contains(id),
     }
 }
 
@@ -49,7 +50,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentType {
             FragmentItem::ComponentNode(_)
             | FragmentItem::IfBlock(_)
             | FragmentItem::EachBlock(_)
-            | FragmentItem::RenderTag(_) => return ContentType::SingleBlock,
+            | FragmentItem::RenderTag(_)
+            | FragmentItem::HtmlTag(_) => return ContentType::SingleBlock,
             FragmentItem::TextConcat { .. } => {}
         }
     }
@@ -65,7 +67,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentType {
             FragmentItem::ComponentNode(_)
             | FragmentItem::IfBlock(_)
             | FragmentItem::EachBlock(_)
-            | FragmentItem::RenderTag(_) => has_block = true,
+            | FragmentItem::RenderTag(_)
+            | FragmentItem::HtmlTag(_) => has_block = true,
             FragmentItem::TextConcat { has_expr, .. } => {
                 if *has_expr {
                     has_dynamic_text = true;

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -160,6 +160,8 @@ pub enum FragmentItem {
     EachBlock(NodeId),
     /// A RenderTag ({@render snippet(args)}).
     RenderTag(NodeId),
+    /// An HtmlTag ({@html expr}).
+    HtmlTag(NodeId),
     /// Adjacent text nodes and expression tags grouped together.
     TextConcat { parts: Vec<ConcatPart>, has_expr: bool },
 }

--- a/crates/svelte_analyze/src/hoistable.rs
+++ b/crates/svelte_analyze/src/hoistable.rs
@@ -5,8 +5,8 @@
 use oxc_semantic::ScopeId;
 use rustc_hash::FxHashSet;
 use svelte_ast::{
-    Attribute, ComponentNode, EachBlock, Element, ExpressionTag, IfBlock, NodeId, RenderTag,
-    SnippetBlock,
+    Attribute, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock, NodeId,
+    RenderTag, SnippetBlock,
 };
 
 use crate::data::AnalysisData;
@@ -96,6 +96,10 @@ impl TemplateVisitor for HoistableSnippetsVisitor {
     }
 
     fn visit_render_tag(&mut self, tag: &RenderTag, _scope: ScopeId, data: &mut AnalysisData) {
+        self.check_expr(&tag.id, data);
+    }
+
+    fn visit_html_tag(&mut self, tag: &HtmlTag, _scope: ScopeId, data: &mut AnalysisData) {
         self.check_expr(&tag.id, data);
     }
 

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -40,7 +40,7 @@ fn lower_fragment(
             Node::SnippetBlock(block) => {
                 lower_fragment(&block.body, FragmentKey::SnippetBody(block.id), component, data);
             }
-            Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::Error(_) => {}
+            Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }
 }
@@ -130,6 +130,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
                     Node::IfBlock(block) => items.push(FragmentItem::IfBlock(block.id)),
                     Node::EachBlock(block) => items.push(FragmentItem::EachBlock(block.id)),
                     Node::RenderTag(tag) => items.push(FragmentItem::RenderTag(tag.id)),
+                    Node::HtmlTag(tag) => items.push(FragmentItem::HtmlTag(tag.id)),
                     _ => {}
                 }
             }

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -61,6 +61,6 @@ fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
             // Already computed: leave_element processes children before parents
             data.elements_needing_var.contains(id)
         }
-        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) => true,
+        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) => true,
     }
 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -101,6 +101,16 @@ fn walk_node(
                 Err(diag) => diags.push(diag),
             }
         }
+        Node::HtmlTag(tag) => {
+            let source = component.source_text(tag.expression_span);
+            let offset = tag.expression_span.start;
+            match svelte_js::analyze_expression(source, offset) {
+                Ok(info) => {
+                    data.expressions.insert(tag.id, info);
+                }
+                Err(diag) => diags.push(diag),
+            }
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, IfBlock, NodeId,
-    RenderTag, SnippetBlock,
+    Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
+    NodeId, RenderTag, SnippetBlock,
 };
 use crate::data::AnalysisData;
 use crate::walker::TemplateVisitor;
@@ -53,6 +53,12 @@ impl TemplateVisitor for ReactivityVisitor {
     }
 
     fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
+        if self.expr_is_dynamic(&tag.id, data, scope) {
+            data.dynamic_nodes.insert(tag.id);
+        }
+    }
+
+    fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {
         if self.expr_is_dynamic(&tag.id, data, scope) {
             data.dynamic_nodes.insert(tag.id);
         }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -267,7 +267,7 @@ fn walk_template_scopes(
             Node::SnippetBlock(block) => {
                 walk_template_scopes(&block.body, component, scoping, current_scope);
             }
-            Node::ExpressionTag(_) | Node::Text(_) | Node::Comment(_) | Node::RenderTag(_) | Node::Error(_) => {}
+            Node::ExpressionTag(_) | Node::Text(_) | Node::Comment(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }
 }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, Fragment, IfBlock,
-    Node, RenderTag, SnippetBlock,
+    Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, Fragment, HtmlTag,
+    IfBlock, Node, RenderTag, SnippetBlock,
 };
 
 use crate::data::AnalysisData;
@@ -20,6 +20,7 @@ use crate::data::AnalysisData;
 pub(crate) trait TemplateVisitor {
     fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_each_block(&mut self, block: &EachBlock, body_scope: ScopeId, data: &mut AnalysisData) {}
@@ -89,6 +90,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
             Node::RenderTag(tag) => {
                 visitor.visit_render_tag(tag, scope, data);
             }
+            Node::HtmlTag(tag) => {
+                visitor.visit_html_tag(tag, scope, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -106,6 +110,9 @@ macro_rules! impl_composite_visitor {
             }
             fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
                 $(self.$idx.visit_render_tag(tag, scope, data);)+
+            }
+            fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_html_tag(tag, scope, data);)+
             }
             fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
                 $(self.$idx.visit_element(el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -79,6 +79,7 @@ pub enum Node {
     EachBlock(EachBlock),
     SnippetBlock(SnippetBlock),
     RenderTag(RenderTag),
+    HtmlTag(HtmlTag),
     Error(ErrorNode),
 }
 
@@ -99,6 +100,7 @@ impl Node {
             Node::EachBlock(n) => n.id,
             Node::SnippetBlock(n) => n.id,
             Node::RenderTag(n) => n.id,
+            Node::HtmlTag(n) => n.id,
             Node::Error(n) => n.id,
         }
     }
@@ -114,6 +116,7 @@ impl Node {
             Node::EachBlock(n) => n.span,
             Node::SnippetBlock(n) => n.span,
             Node::RenderTag(n) => n.span,
+            Node::HtmlTag(n) => n.span,
             Node::Error(n) => n.span,
         }
     }
@@ -144,6 +147,10 @@ impl Node {
 
     pub fn is_render_tag(&self) -> bool {
         matches!(self, Node::RenderTag(_))
+    }
+
+    pub fn is_html_tag(&self) -> bool {
+        matches!(self, Node::HtmlTag(_))
     }
 
     pub fn is_component_node(&self) -> bool {
@@ -328,6 +335,17 @@ pub struct RenderTag {
     pub id: NodeId,
     pub span: Span,
     /// Span of the full call expression: "greeting(message)" in `{@render greeting(message)}`.
+    pub expression_span: Span,
+}
+
+// ---------------------------------------------------------------------------
+// HtmlTag — {@html expr}
+// ---------------------------------------------------------------------------
+
+pub struct HtmlTag {
+    pub id: NodeId,
+    pub span: Span,
+    /// Span of the JS expression: "content" in `{@html content}`.
     pub expression_span: Span,
 }
 

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::AnalysisData;
-use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
+use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
 use svelte_span::Span;
 
 use crate::builder::Builder;
@@ -15,6 +15,7 @@ struct NodeIndex<'a> {
     each_blocks: FxHashMap<NodeId, &'a EachBlock>,
     snippet_blocks: FxHashMap<NodeId, &'a SnippetBlock>,
     render_tags: FxHashMap<NodeId, &'a RenderTag>,
+    html_tags: FxHashMap<NodeId, &'a HtmlTag>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -27,6 +28,7 @@ impl<'a> NodeIndex<'a> {
             each_blocks: FxHashMap::default(),
             snippet_blocks: FxHashMap::default(),
             render_tags: FxHashMap::default(),
+            html_tags: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -64,6 +66,9 @@ impl<'a> NodeIndex<'a> {
                 }
                 Node::RenderTag(t) => {
                     self.render_tags.insert(t.id, t);
+                }
+                Node::HtmlTag(t) => {
+                    self.html_tags.insert(t.id, t);
                 }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
@@ -168,6 +173,10 @@ impl<'a> Ctx<'a> {
 
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
         self.index.render_tags.get(&id).copied().expect("render tag not found")
+    }
+
+    pub fn html_tag(&self, id: NodeId) -> &'a HtmlTag {
+        self.index.html_tags.get(&id).copied().expect("html tag not found")
     }
 
     pub fn expr_span(&self, id: NodeId) -> Span {

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -167,7 +167,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
         svelte_analyze::FragmentItem::Element(id) => ctx.analysis.elements_needing_var.contains(id),
-        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) => {
+        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) => {
             true
         }
     }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -167,6 +167,31 @@ impl<'a> Traverse<'a, ()> for RuneRefTransformer<'_, 'a> {
 }
 
 // ---------------------------------------------------------------------------
+// Thunk builder — `() => expr` with rune transforms
+// ---------------------------------------------------------------------------
+
+/// Build `() => expr` from raw source text, applying rune transforms.
+/// Used by HtmlTag and other nodes that need a thunked expression.
+pub(crate) fn build_expr_thunk<'a>(ctx: &mut Ctx<'a>, source: &str) -> Expression<'a> {
+    let alloc = ctx.b.ast.allocator;
+    let arena_source: &'a str = alloc.alloc_str(source);
+
+    let expr = parse_and_transform(
+        alloc,
+        arena_source,
+        &ctx.analysis.mutated_runes,
+        &ctx.analysis.rune_names,
+        &ctx.prop_sources,
+        &ctx.prop_non_sources,
+        &[],
+        &ctx.each_vars,
+    );
+
+    let params = ctx.b.no_params();
+    ctx.b.arrow_expr(params, [ctx.b.expr_stmt(expr)])
+}
+
+// ---------------------------------------------------------------------------
 // Concatenation builders
 // ---------------------------------------------------------------------------
 

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -335,7 +335,7 @@ pub(crate) fn emit_trailing_next<'a>(
 pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
-        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) => {
+        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) => {
             ctx.analysis.dynamic_nodes.contains(id)
         }
     }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -31,7 +31,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
                 let el = ctx.element(*id);
                 html.push_str(&element_html(ctx, el));
             }
-            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) => html.push_str("<!>"),
+            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) => html.push_str("<!>"),
         }
     }
     html

--- a/crates/svelte_codegen_client/src/template/html_tag.rs
+++ b/crates/svelte_codegen_client/src/template/html_tag.rs
@@ -1,0 +1,48 @@
+//! HtmlTag codegen — `{@html expr}`
+
+use oxc_ast::ast::{Expression, Statement};
+use svelte_ast::NodeId;
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+/// Generate `$.html(anchor, () => expr)`.
+pub(crate) fn gen_html_tag<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    anchor_expr: Expression<'a>,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let tag = ctx.html_tag(id);
+    let source = ctx.component.source_text(tag.expression_span);
+
+    let thunk = build_html_thunk(ctx, source);
+
+    stmts.push(ctx.b.call_stmt("$.html", [Arg::Expr(anchor_expr), Arg::Expr(thunk)]));
+}
+
+/// Build `() => expr` with rune transforms applied.
+fn build_html_thunk<'a>(ctx: &mut Ctx<'a>, source: &str) -> Expression<'a> {
+    let alloc = ctx.b.ast.allocator;
+    let arena_source: &'a str = alloc.alloc_str(source);
+
+    let mutated = &ctx.analysis.mutated_runes;
+    let rune_names = &ctx.analysis.rune_names;
+    let prop_sources = ctx.prop_sources.clone();
+    let prop_non_sources = ctx.prop_non_sources.clone();
+    let each_vars = &ctx.each_vars;
+
+    let expr = super::expression::parse_and_transform(
+        alloc,
+        arena_source,
+        mutated,
+        rune_names,
+        &prop_sources,
+        &prop_non_sources,
+        &[],
+        each_vars,
+    );
+
+    let params = ctx.b.no_params();
+    ctx.b.arrow_expr(params, [ctx.b.expr_stmt(expr)])
+}

--- a/crates/svelte_codegen_client/src/template/html_tag.rs
+++ b/crates/svelte_codegen_client/src/template/html_tag.rs
@@ -16,33 +16,7 @@ pub(crate) fn gen_html_tag<'a>(
     let tag = ctx.html_tag(id);
     let source = ctx.component.source_text(tag.expression_span);
 
-    let thunk = build_html_thunk(ctx, source);
+    let thunk = super::expression::build_expr_thunk(ctx, source);
 
     stmts.push(ctx.b.call_stmt("$.html", [Arg::Expr(anchor_expr), Arg::Expr(thunk)]));
-}
-
-/// Build `() => expr` with rune transforms applied.
-fn build_html_thunk<'a>(ctx: &mut Ctx<'a>, source: &str) -> Expression<'a> {
-    let alloc = ctx.b.ast.allocator;
-    let arena_source: &'a str = alloc.alloc_str(source);
-
-    let mutated = &ctx.analysis.mutated_runes;
-    let rune_names = &ctx.analysis.rune_names;
-    let prop_sources = ctx.prop_sources.clone();
-    let prop_non_sources = ctx.prop_non_sources.clone();
-    let each_vars = &ctx.each_vars;
-
-    let expr = super::expression::parse_and_transform(
-        alloc,
-        arena_source,
-        mutated,
-        rune_names,
-        &prop_sources,
-        &prop_non_sources,
-        &[],
-        each_vars,
-    );
-
-    let params = ctx.b.no_params();
-    ctx.b.arrow_expr(params, [ctx.b.expr_stmt(expr)])
 }

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod element;
 pub(crate) mod expression;
 pub(crate) mod html;
 pub(crate) mod if_block;
+pub(crate) mod html_tag;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
 pub(crate) mod traverse;
@@ -24,6 +25,7 @@ use html::{element_html, fragment_html};
 use component::gen_component;
 use if_block::gen_if_block;
 use each_block::gen_each_block;
+use html_tag::gen_html_tag;
 use render_tag::gen_render_tag;
 use traverse::traverse_items;
 
@@ -217,6 +219,9 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
         }
         FragmentItem::EachBlock(id) => {
             gen_each_block(ctx, id, ctx.b.rid_expr(&node), false, body);
+        }
+        FragmentItem::HtmlTag(id) => {
+            gen_html_tag(ctx, id, ctx.b.rid_expr(&node), body);
         }
         _ => unreachable!(),
     }
@@ -412,6 +417,9 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                         }
                         FragmentItem::EachBlock(id) => {
                             gen_each_block(ctx, id, ctx.b.rid_expr(&node), false, &mut body);
+                        }
+                        FragmentItem::HtmlTag(id) => {
+                            gen_html_tag(ctx, id, ctx.b.rid_expr(&node), &mut body);
                         }
                         _ => unreachable!(),
                     }

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -12,6 +12,7 @@ use super::each_block::gen_each_block;
 use super::element::{item_needs_var, process_element};
 use super::expression::parts_are_dynamic;
 use super::if_block::gen_if_block;
+use super::html_tag::gen_html_tag;
 use super::render_tag::gen_render_tag;
 
 /// Traverse lowered items, assign DOM variables, generate init/update statements.
@@ -117,6 +118,14 @@ pub(crate) fn traverse_items<'a>(
                     prev_ident = Some(node_name.clone());
                     sibling_offset = 1;
                     gen_render_tag(ctx, *id, ctx.b.rid_expr(&node_name), init);
+                }
+
+                FragmentItem::HtmlTag(id) => {
+                    let node_name = ctx.gen_ident("node");
+                    init.push(ctx.b.var_stmt(&node_name, node_expr));
+                    prev_ident = Some(node_name.clone());
+                    sibling_offset = 1;
+                    gen_html_tag(ctx, *id, ctx.b.rid_expr(&node_name), init);
                 }
             }
         } else {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -7,7 +7,7 @@ use svelte_span::Span;
 use svelte_ast::{
     Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode,
     ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
-    ExpressionAttribute, Fragment, IfBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
+    ExpressionAttribute, Fragment, HtmlTag, IfBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
 };
 
@@ -209,6 +209,14 @@ impl<'a> Parser<'a> {
                         id: self.ids.next(),
                         span: token.span,
                         expression_span: render_tag.expression.span,
+                    });
+                    children_stack.last_mut().unwrap().push(node);
+                }
+                TokenType::HtmlTag(html_tag) => {
+                    let node = Node::HtmlTag(HtmlTag {
+                        id: self.ids.next(),
+                        span: token.span,
+                        expression_span: html_tag.expression.span,
                     });
                     children_stack.last_mut().unwrap().push(node);
                 }
@@ -985,6 +993,28 @@ mod tests {
         let c = parse("{#snippet greet(name)}<p>{name}</p>{/snippet}{@render greet(x)}");
         assert_snippet_block(&c, 0, "greet", Some("name"));
         assert_render_tag(&c, 1, "greet(x)");
+    }
+
+    // --- HtmlTag tests ---
+
+    fn assert_html_tag(c: &Component, index: usize, expected_expr: &str) {
+        if let Node::HtmlTag(ref ht) = c.fragment.nodes[index] {
+            assert_eq!(c.source_text(ht.expression_span), expected_expr);
+        } else {
+            panic!("expected HtmlTag at index {index}");
+        }
+    }
+
+    #[test]
+    fn html_tag_basic() {
+        let c = parse("{@html content}");
+        assert_html_tag(&c, 0, "content");
+    }
+
+    #[test]
+    fn html_tag_complex_expression() {
+        let c = parse("{@html '<p>' + name + '</p>'}");
+        assert_html_tag(&c, 0, "'<p>' + name + '</p>'");
     }
 
     // --- Escape sequence tests (Bug #1) ---

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -921,6 +921,16 @@ impl<'a> Scanner<'a> {
 
                 Ok(())
             }
+            "html" => {
+                self.skip_whitespace();
+                let expression = self.collect_js_expression()?;
+
+                self.add_token(TokenType::HtmlTag(token::HtmlTagToken {
+                    expression,
+                }));
+
+                Ok(())
+            }
             _ => Err(Diagnostic::unexpected_keyword(Span::new(
                 start as u32,
                 self.current as u32,
@@ -1610,6 +1620,16 @@ mod tests {
         assert!(matches!(tokens[0].token_type, TokenType::RenderTag(_)));
         if let TokenType::RenderTag(ref rt) = tokens[0].token_type {
             assert_eq!(rt.expression.value, "foo(x, y)");
+        }
+    }
+
+    #[test]
+    fn html_tag_tokens() {
+        let mut scanner = Scanner::new("{@html content}");
+        let tokens = scanner.scan_tokens().0;
+        assert!(matches!(tokens[0].token_type, TokenType::HtmlTag(_)));
+        if let TokenType::HtmlTag(ref ht) = tokens[0].token_type {
+            assert_eq!(ht.expression.value, "content");
         }
     }
 

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -18,6 +18,7 @@ pub enum TokenType<'a> {
     StartSnippetTag(StartSnippetTag<'a>),
     EndSnippetTag,
     RenderTag(RenderTagToken<'a>),
+    HtmlTag(HtmlTagToken<'a>),
     StyleTag(StyleTag<'a>),
     EOF,
 }
@@ -182,6 +183,11 @@ pub struct StartSnippetTag<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct RenderTagToken<'a> {
+    pub expression: JsExpression<'a>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct HtmlTagToken<'a> {
     pub expression: JsExpression<'a>,
 }
 

--- a/tasks/compiler_tests/cases2/html_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/html_tag/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let content = "<em>hello</em>";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.html(node, () => content);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/html_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/html_tag/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let content = "<em>hello</em>";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.html(node, () => content);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/html_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/html_tag/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let content = $state("<em>hello</em>");
+</script>
+
+{@html content}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -270,3 +270,8 @@ fn unmutated_state_optimization() {
 fn effect_runes() {
     assert_compiler("effect_runes");
 }
+
+#[rstest]
+fn html_tag() {
+    assert_compiler("html_tag");
+}


### PR DESCRIPTION
## Summary
This PR implements support for the `{@html expr}` tag, which allows inserting raw HTML content into Svelte components. This is a frequently-used feature for rendering markdown, CMS content, and other dynamic HTML.

## Key Changes

### Parser & AST
- Added `HtmlTag` struct to `svelte_ast` with `id`, `span`, and `expression_span` fields
- Extended `Node` enum to include `HtmlTag` variant
- Implemented scanner support for `{@html ...}` tag parsing in `svelte_parser`
- Added parser logic to create `HtmlTag` nodes and extract expression spans

### Analysis
- Integrated `HtmlTag` into the analysis pipeline:
  - Added expression parsing in `parse_js.rs` to analyze the HTML expression
  - Marked HTML tags as dynamic nodes in `reactivity.rs`
  - Updated `walker.rs` with `visit_html_tag` visitor method
  - Integrated into content type classification and hoistable snippets analysis
- Updated `FragmentItem` enum to include `HtmlTag` variant

### Code Generation
- Created new `html_tag.rs` module in `svelte_codegen_client` to generate `$.html()` calls
- Generates `$.html(anchor, () => expr)` with proper rune transforms applied
- Integrated HTML tag generation into template traversal and fragment generation
- Added context support for HTML tag lookup

### Testing
- Added parser tests for basic and complex HTML tag expressions
- Added scanner token tests for HTML tag parsing
- Added compiler test case with expected output matching Svelte's reference implementation
- Updated TODO.md to mark `{@html expr}` as complete and reorder remaining features

## Implementation Details
- The HTML expression is wrapped in an arrow function thunk `() => expr` to defer evaluation
- Expression parsing reuses the existing `parse_and_transform` infrastructure with rune transforms
- HTML tags are treated as dynamic nodes requiring DOM variables for anchor placement
- The implementation follows the same pattern as `{@render}` tags for consistency

https://claude.ai/code/session_018hbGvxwWrxfjJtUBGkd5VV