### PR TITLE
perf: optimize analyze and codegen hot paths

### DIFF
--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -64,21 +64,28 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
         }
     }
 
-    // Step 2: strip leading whitespace-only Text nodes
-    while let Some(Node::Text(t)) = regular.first() {
+    // Step 2: strip leading whitespace-only Text nodes (index-based to avoid O(n) shifts)
+    let mut start = 0;
+    while let Some(Node::Text(t)) = regular.get(start) {
         if !is_ws_only(t.value(&component.source)) {
             break;
         }
-        regular.remove(0);
+        start += 1;
     }
 
     // Step 3: strip trailing whitespace-only Text nodes
-    while let Some(Node::Text(t)) = regular.last() {
-        if !is_ws_only(t.value(&component.source)) {
-            break;
+    let mut end = regular.len();
+    while end > start {
+        if let Some(Node::Text(t)) = regular.get(end - 1) {
+            if is_ws_only(t.value(&component.source)) {
+                end -= 1;
+                continue;
+            }
         }
-        regular.pop();
+        break;
     }
+
+    let regular = &regular[start..end];
 
     if regular.is_empty() {
         return vec![];

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -187,14 +187,20 @@ impl<'a> Ctx<'a> {
 
     /// Generate a unique identifier like `root`, `root_1`, `root_2`, …
     pub fn gen_ident(&mut self, prefix: &str) -> String {
-        let count = self.ident_counters.entry(prefix.to_string()).or_insert(0);
-        let name = if *count == 0 {
+        // Avoid allocating a String key on every lookup (cache hit path is allocation-free)
+        let count = if let Some(c) = self.ident_counters.get_mut(prefix) {
+            let n = *c;
+            *c += 1;
+            n
+        } else {
+            self.ident_counters.insert(prefix.to_string(), 1);
+            0
+        };
+        if count == 0 {
             prefix.to_string()
         } else {
             format!("{}_{}", prefix, count)
-        };
-        *count += 1;
-        name
+        }
     }
 
 }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -1,5 +1,7 @@
 //! HTML template string builders.
 
+use std::fmt::Write;
+
 use svelte_analyze::{ConcatPart, ContentType, FragmentItem, FragmentKey};
 use svelte_ast::{Attribute, Element};
 
@@ -42,7 +44,8 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
     let has_spread = ctx.analysis.element_has_spread.contains(&el.id);
     let has_class_directives = ctx.analysis.element_has_class_directives.contains(&el.id);
 
-    let mut html = format!("<{}", el.name);
+    let mut html = String::new();
+    write!(html, "<{}", el.name).unwrap();
 
     // When spread attrs are present, skip all attributes from HTML template
     if !has_spread {
@@ -53,14 +56,16 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
                     if a.name == "class" && has_class_directives {
                         continue;
                     }
-                    html.push_str(&format!(
+                    write!(
+                        html,
                         " {}=\"{}\"",
                         a.name,
                         ctx.component.source_text(a.value_span)
-                    ));
+                    )
+                    .unwrap();
                 }
                 Attribute::BooleanAttribute(a) => {
-                    html.push_str(&format!(" {}=\"\"", a.name));
+                    write!(html, " {}=\"\"", a.name).unwrap();
                 }
                 _ => {}
             }
@@ -75,7 +80,7 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
 
     // noscript content is stripped in the template
     if el.name == "noscript" {
-        html.push_str(&format!("</{}>", el.name));
+        write!(html, "</{}>", el.name).unwrap();
         return html;
     }
 
@@ -112,7 +117,7 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
         }
     }
 
-    html.push_str(&format!("</{}>", el.name));
+    write!(html, "</{}>", el.name).unwrap();
     html
 }
 


### PR DESCRIPTION
- lower.rs: replace O(n²) Vec::remove(0) with index-based slice trimming
- context.rs: avoid String allocation in gen_ident() on cache hit path
- html.rs: use write!() instead of format!() to eliminate intermediate String allocations

https://claude.ai/code/session_01URirriNS8WwAVZiTRk8Gin