### PR TITLE
fix: parser robustness and codegen quality improvements

### DIFF
--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::Statement;
-use svelte_analyze::{AnalysisData, ParsedExprs};
+use svelte_analyze::{AnalysisData, FragmentKey, LoweredFragment, ParsedExprs};
 use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
 use svelte_span::Span;
 
@@ -153,27 +153,38 @@ impl<'a> Ctx<'a> {
     // -- Node lookups (O(1)) --
 
     pub fn element(&self, id: NodeId) -> &'a Element {
-        self.index.elements.get(&id).copied().expect("element not found")
+        self.index.elements.get(&id).copied()
+            .unwrap_or_else(|| panic!("element {:?} not found in index", id))
     }
 
     pub fn component_node(&self, id: NodeId) -> &'a ComponentNode {
-        self.index.component_nodes.get(&id).copied().expect("component node not found")
+        self.index.component_nodes.get(&id).copied()
+            .unwrap_or_else(|| panic!("component node {:?} not found in index", id))
     }
 
     pub fn if_block(&self, id: NodeId) -> &'a IfBlock {
-        self.index.if_blocks.get(&id).copied().expect("if block not found")
+        self.index.if_blocks.get(&id).copied()
+            .unwrap_or_else(|| panic!("if block {:?} not found in index", id))
     }
 
     pub fn each_block(&self, id: NodeId) -> &'a EachBlock {
-        self.index.each_blocks.get(&id).copied().expect("each block not found")
+        self.index.each_blocks.get(&id).copied()
+            .unwrap_or_else(|| panic!("each block {:?} not found in index", id))
     }
 
     pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock {
-        self.index.snippet_blocks.get(&id).copied().expect("snippet block not found")
+        self.index.snippet_blocks.get(&id).copied()
+            .unwrap_or_else(|| panic!("snippet block {:?} not found in index", id))
     }
 
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
-        self.index.render_tags.get(&id).copied().expect("render tag not found")
+        self.index.render_tags.get(&id).copied()
+            .unwrap_or_else(|| panic!("render tag {:?} not found in index", id))
+    }
+
+    pub fn lowered_fragment(&self, key: &FragmentKey) -> &LoweredFragment {
+        self.analysis.lowered_fragments.get(key)
+            .unwrap_or_else(|| panic!("lowered fragment {:?} not found", key))
     }
 
     // -- Identifiers --

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -111,11 +111,11 @@ pub(crate) fn process_element<'a>(
         }
 
         ContentType::SingleBlock if matches!(
-            ctx.analysis.lowered_fragments.get(&child_key).unwrap().items.first(),
+            ctx.lowered_fragment(&child_key).items.first(),
             Some(svelte_analyze::FragmentItem::EachBlock(_))
         ) => {
             // Controlled each block: element itself is the anchor, no $.child() traversal
-            let each_id = match ctx.analysis.lowered_fragments.get(&child_key).unwrap().items[0] {
+            let each_id = match ctx.lowered_fragment(&child_key).items[0] {
                 svelte_analyze::FragmentItem::EachBlock(id) => id,
                 _ => unreachable!(),
             };
@@ -124,13 +124,8 @@ pub(crate) fn process_element<'a>(
         }
 
         ContentType::SingleElement | ContentType::SingleBlock | ContentType::Mixed => {
-            let child_items: Vec<_> = ctx
-                .analysis
-                .lowered_fragments
-                .get(&child_key)
-                .unwrap()
-                .items
-                .clone();
+            // Clone needed: traverse_items borrows ctx mutably
+            let child_items: Vec<_> = ctx.lowered_fragment(&child_key).items.clone();
 
             let first_is_text = child_items.first().is_some_and(|item| item.is_standalone_expr());
             let first_child = if first_is_text {

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -96,7 +96,7 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
     match ct {
         ContentType::Empty => {}
         ContentType::StaticText => {
-            let lf = ctx.analysis.lowered_fragments.get(&child_key).unwrap();
+            let lf = ctx.lowered_fragment(&child_key);
             html.push_str(&static_text_of(&lf.items[0]));
         }
         ContentType::DynamicText if !has_state => {
@@ -107,7 +107,7 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
             html.push(' ');
         }
         ContentType::SingleBlock if matches!(
-            ctx.analysis.lowered_fragments.get(&child_key).unwrap().items.first(),
+            ctx.lowered_fragment(&child_key).items.first(),
             Some(FragmentItem::EachBlock(_))
         ) => {
             // Controlled each block: no <!> anchor in template

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -46,8 +46,7 @@ pub(crate) fn gen_if_block<'a>(
         let alt_is_elseif = ctx.analysis.alt_is_elseif.contains(&current);
 
         if alt_is_elseif {
-            let lf = ctx.analysis.lowered_fragments.get(&alternate_key).unwrap();
-            let nested_id = match &lf.items[0] {
+            let nested_id = match &ctx.lowered_fragment(&alternate_key).items[0] {
                 svelte_analyze::FragmentItem::IfBlock(id) => *id,
                 _ => unreachable!(),
             };

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -15,9 +15,19 @@ pub(crate) mod traverse;
 use oxc_ast::ast::Statement;
 
 use svelte_analyze::{ContentType, FragmentItem, FragmentKey};
+use svelte_ast::NodeId;
 
 use crate::builder::Arg;
 use crate::context::Ctx;
+
+/// Lightweight discriminant for SingleBlock items — avoids cloning full FragmentItem.
+enum SingleBlockKind {
+    IfBlock(NodeId),
+    EachBlock(NodeId),
+    HtmlTag(NodeId),
+    RenderTag(NodeId),
+    ComponentNode(NodeId),
+}
 
 use element::process_element;
 use expression::{emit_template_effect, emit_text_update, emit_trailing_next, static_text_of};
@@ -97,11 +107,7 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
 // ---------------------------------------------------------------------------
 
 fn gen_root_static_text<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
-    let lf = ctx
-        .analysis
-        .lowered_fragments
-        .get(&FragmentKey::Root)
-        .unwrap();
+    let lf = ctx.lowered_fragment(&FragmentKey::Root);
     let text = static_text_of(&lf.items[0]);
     let name = ctx.gen_ident("text");
     body.push(ctx.b.call_stmt("$.next", []));
@@ -118,14 +124,8 @@ fn gen_root_static_text<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
 }
 
 fn gen_root_dynamic_text<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
-    let item = {
-        let lf = ctx
-            .analysis
-            .lowered_fragments
-            .get(&FragmentKey::Root)
-            .unwrap();
-        lf.items[0].clone()
-    };
+    // Clone needed: emit_text_update borrows ctx mutably, so we can't hold a ref into analysis
+    let item = ctx.lowered_fragment(&FragmentKey::Root).items[0].clone();
     let name = ctx.gen_ident("text");
     body.push(ctx.b.call_stmt("$.next", []));
     body.push(ctx.b.var_stmt(&name, ctx.b.call_expr("$.text", [])));
@@ -144,16 +144,9 @@ fn gen_root_single_element<'a>(
     hoisted: &mut Vec<Statement<'a>>,
     body: &mut Vec<Statement<'a>>,
 ) {
-    let el_id = {
-        let lf = ctx
-            .analysis
-            .lowered_fragments
-            .get(&FragmentKey::Root)
-            .unwrap();
-        match lf.items[0] {
-            FragmentItem::Element(id) => id,
-            _ => unreachable!(),
-        }
+    let el_id = match ctx.lowered_fragment(&FragmentKey::Root).items[0] {
+        FragmentItem::Element(id) => id,
+        _ => unreachable!(),
     };
 
     let el = ctx.element(el_id);
@@ -182,22 +175,15 @@ fn gen_root_single_element<'a>(
 }
 
 fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
-    let item = {
-        let lf = ctx
-            .analysis
-            .lowered_fragments
-            .get(&FragmentKey::Root)
-            .unwrap();
-        lf.items[0].clone()
-    };
+    let kind = single_block_kind(&ctx.lowered_fragment(&FragmentKey::Root).items[0]);
 
     // RenderTag / ComponentNode at root: call directly with $$anchor, no wrapping
-    match item {
-        FragmentItem::RenderTag(id) => {
+    match kind {
+        SingleBlockKind::RenderTag(id) => {
             gen_render_tag(ctx, id, ctx.b.rid_expr("$$anchor"), body);
             return;
         }
-        FragmentItem::ComponentNode(id) => {
+        SingleBlockKind::ComponentNode(id) => {
             gen_component(ctx, id, ctx.b.rid_expr("$$anchor"), body);
             return;
         }
@@ -212,18 +198,18 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
         ctx.b.call_expr("$.first_child", [Arg::Ident(&frag)]),
     ));
 
-    match item {
-        FragmentItem::IfBlock(id) => {
+    match kind {
+        SingleBlockKind::IfBlock(id) => {
             let stmts = gen_if_block(ctx, id, ctx.b.rid_expr(&node));
             body.push(ctx.b.block_stmt(stmts));
         }
-        FragmentItem::EachBlock(id) => {
+        SingleBlockKind::EachBlock(id) => {
             gen_each_block(ctx, id, ctx.b.rid_expr(&node), false, body);
         }
-        FragmentItem::HtmlTag(id) => {
+        SingleBlockKind::HtmlTag(id) => {
             gen_html_tag(ctx, id, ctx.b.rid_expr(&node), body);
         }
-        _ => unreachable!(),
+        _ => unreachable!("SingleBlock should be if/each/html at this point"),
     }
 
     body.push(ctx.b.call_stmt(
@@ -238,14 +224,8 @@ fn gen_root_mixed<'a>(
     hoisted: &mut Vec<Statement<'a>>,
     body: &mut Vec<Statement<'a>>,
 ) {
-    let items: Vec<_> = {
-        let lf = ctx
-            .analysis
-            .lowered_fragments
-            .get(&FragmentKey::Root)
-            .unwrap();
-        lf.items.clone()
-    };
+    // Clone needed: traverse_items borrows ctx mutably
+    let items: Vec<_> = ctx.lowered_fragment(&FragmentKey::Root).items.clone();
 
     let starts_text = matches!(items.first(), Some(FragmentItem::TextConcat { .. }));
     if starts_text {
@@ -308,10 +288,7 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
     match ct {
         ContentType::Empty => {}
         ContentType::StaticText => {
-            let text = {
-                let lf = ctx.analysis.lowered_fragments.get(&key).unwrap();
-                static_text_of(&lf.items[0])
-            };
+            let text = static_text_of(&ctx.lowered_fragment(&key).items[0]);
             let name = ctx.gen_ident("text");
             let call = if text.is_empty() {
                 ctx.b.call_expr("$.text", [])
@@ -325,10 +302,8 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
             ));
         }
         ContentType::DynamicText => {
-            let item = {
-                let lf = ctx.analysis.lowered_fragments.get(&key).unwrap();
-                lf.items[0].clone()
-            };
+            // Clone needed: emit_text_update borrows ctx mutably
+            let item = ctx.lowered_fragment(&key).items[0].clone();
             let name = ctx.gen_ident("text");
             body.push(ctx.b.var_stmt(&name, ctx.b.call_expr("$.text", [])));
             emit_text_update(ctx, &item, &name, &mut body);
@@ -338,12 +313,9 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
             ));
         }
         ContentType::SingleElement => {
-            let el_id = {
-                let lf = ctx.analysis.lowered_fragments.get(&key).unwrap();
-                match lf.items[0] {
-                    FragmentItem::Element(id) => id,
-                    _ => unreachable!(),
-                }
+            let el_id = match ctx.lowered_fragment(&key).items[0] {
+                FragmentItem::Element(id) => id,
+                _ => unreachable!(),
             };
 
             let el = ctx.element(el_id);
@@ -386,19 +358,16 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
             return result;
         }
         ContentType::SingleBlock => {
-            let item = {
-                let lf = ctx.analysis.lowered_fragments.get(&key).unwrap();
-                lf.items[0].clone()
-            };
+            let kind = single_block_kind(&ctx.lowered_fragment(&key).items[0]);
 
             // RenderTag / ComponentNode: call directly with $$anchor
             // Still consume a "fragment" ident for consistent numbering
-            match item {
-                FragmentItem::RenderTag(id) => {
+            match kind {
+                SingleBlockKind::RenderTag(id) => {
                     ctx.gen_ident("fragment");
                     gen_render_tag(ctx, id, ctx.b.rid_expr("$$anchor"), &mut body);
                 }
-                FragmentItem::ComponentNode(id) => {
+                SingleBlockKind::ComponentNode(id) => {
                     ctx.gen_ident("fragment");
                     gen_component(ctx, id, ctx.b.rid_expr("$$anchor"), &mut body);
                 }
@@ -410,18 +379,18 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                         &node,
                         ctx.b.call_expr("$.first_child", [Arg::Ident(&frag)]),
                     ));
-                    match item {
-                        FragmentItem::IfBlock(id) => {
+                    match kind {
+                        SingleBlockKind::IfBlock(id) => {
                             let stmts = gen_if_block(ctx, id, ctx.b.rid_expr(&node));
                             body.push(ctx.b.block_stmt(stmts));
                         }
-                        FragmentItem::EachBlock(id) => {
+                        SingleBlockKind::EachBlock(id) => {
                             gen_each_block(ctx, id, ctx.b.rid_expr(&node), false, &mut body);
                         }
-                        FragmentItem::HtmlTag(id) => {
+                        SingleBlockKind::HtmlTag(id) => {
                             gen_html_tag(ctx, id, ctx.b.rid_expr(&node), &mut body);
                         }
-                        _ => unreachable!(),
+                        _ => unreachable!("SingleBlock should be if/each/html at this point"),
                     }
                     body.push(ctx.b.call_stmt(
                         "$.append",
@@ -431,10 +400,8 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
             }
         }
         ContentType::Mixed => {
-            let items: Vec<_> = {
-                let lf = ctx.analysis.lowered_fragments.get(&key).unwrap();
-                lf.items.clone()
-            };
+            // Clone needed: traverse_items borrows ctx mutably
+            let items: Vec<_> = ctx.lowered_fragment(&key).items.clone();
 
             let starts_text = matches!(items.first(), Some(FragmentItem::TextConcat { .. }));
             if starts_text {
@@ -483,4 +450,15 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
     }
 
     body
+}
+
+fn single_block_kind(item: &FragmentItem) -> SingleBlockKind {
+    match *item {
+        FragmentItem::IfBlock(id) => SingleBlockKind::IfBlock(id),
+        FragmentItem::EachBlock(id) => SingleBlockKind::EachBlock(id),
+        FragmentItem::HtmlTag(id) => SingleBlockKind::HtmlTag(id),
+        FragmentItem::RenderTag(id) => SingleBlockKind::RenderTag(id),
+        FragmentItem::ComponentNode(id) => SingleBlockKind::ComponentNode(id),
+        _ => unreachable!("SingleBlock should contain a block-level item"),
+    }
 }

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -54,7 +54,6 @@ pub(crate) fn traverse_items<'a>(
                 FragmentItem::TextConcat { parts, .. } => {
                     let name = ctx.gen_ident("text");
                     init.push(ctx.b.var_stmt(&name, node_expr));
-                    prev_ident = Some(name.clone());
                     sibling_offset = 1;
 
                     let is_dyn = parts_are_dynamic(parts, ctx);
@@ -75,57 +74,58 @@ pub(crate) fn traverse_items<'a>(
                             AssignRight::Expr(expr),
                         ));
                     }
+                    prev_ident = Some(name);
                 }
 
                 FragmentItem::Element(el_id) => {
                     let el_name_str = ctx.element(*el_id).name.clone();
                     let el_name = ctx.gen_ident(&el_name_str);
                     init.push(ctx.b.var_stmt(&el_name, node_expr));
-                    prev_ident = Some(el_name.clone());
                     sibling_offset = 1;
                     process_element(ctx, *el_id, &el_name, init, update, hoisted, after_update);
+                    prev_ident = Some(el_name);
                 }
 
                 FragmentItem::ComponentNode(id) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
-                    prev_ident = Some(node_name.clone());
                     sibling_offset = 1;
                     gen_component(ctx, *id, ctx.b.rid_expr(&node_name), init);
+                    prev_ident = Some(node_name);
                 }
 
                 FragmentItem::IfBlock(id) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
-                    prev_ident = Some(node_name.clone());
                     sibling_offset = 1;
 
                     let stmts = gen_if_block(ctx, *id, ctx.b.rid_expr(&node_name));
                     init.push(ctx.b.block_stmt(stmts));
+                    prev_ident = Some(node_name);
                 }
 
                 FragmentItem::EachBlock(id) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
-                    prev_ident = Some(node_name.clone());
                     sibling_offset = 1;
                     gen_each_block(ctx, *id, ctx.b.rid_expr(&node_name), false, init);
+                    prev_ident = Some(node_name);
                 }
 
                 FragmentItem::RenderTag(id) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
-                    prev_ident = Some(node_name.clone());
                     sibling_offset = 1;
                     gen_render_tag(ctx, *id, ctx.b.rid_expr(&node_name), init);
+                    prev_ident = Some(node_name);
                 }
 
                 FragmentItem::HtmlTag(id) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
-                    prev_ident = Some(node_name.clone());
                     sibling_offset = 1;
                     gen_html_tag(ctx, *id, ctx.b.rid_expr(&node_name), init);
+                    prev_ident = Some(node_name);
                 }
             }
         } else {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -58,6 +58,32 @@ struct SnippetBlockEntry {
 }
 
 // ---------------------------------------------------------------------------
+// Stack helpers — safe wrappers around children_stack operations
+// ---------------------------------------------------------------------------
+
+/// Push a node onto the current children list.
+/// Debug-asserts the stack is non-empty; gracefully no-ops in release.
+fn push_child(children_stack: &mut Vec<Vec<Node>>, node: Node) {
+    debug_assert!(
+        !children_stack.is_empty(),
+        "children_stack empty when pushing child"
+    );
+    if let Some(children) = children_stack.last_mut() {
+        children.push(node);
+    }
+}
+
+/// Pop the current children list.
+/// Debug-asserts the stack is non-empty; returns empty vec in release.
+fn pop_children(children_stack: &mut Vec<Vec<Node>>) -> Vec<Node> {
+    debug_assert!(
+        !children_stack.is_empty(),
+        "children_stack empty when popping"
+    );
+    children_stack.pop().unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
 // Parser
 // ---------------------------------------------------------------------------
 
@@ -96,15 +122,15 @@ impl<'a> Parser<'a> {
             match token.token_type {
                 TokenType::Text => {
                     let node = self.make_text(&token);
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(&mut children_stack, node);
                 }
                 TokenType::Comment => {
                     let node = self.make_comment(&token);
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(&mut children_stack, node);
                 }
                 TokenType::Interpolation(interpolation) => {
                     let node = self.make_expression_tag(&interpolation);
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(&mut children_stack, node);
                 }
                 TokenType::StartTag(tag) => {
                     let attrs = self.convert_attributes(&tag.attributes);
@@ -129,7 +155,7 @@ impl<'a> Parser<'a> {
                                 fragment: Fragment::empty(),
                             })
                         };
-                        children_stack.last_mut().unwrap().push(node);
+                        push_child(&mut children_stack, node);
                     } else {
                         entry_stack.push(StackEntry::Element(ElementEntry {
                             name: tag.name.to_string(),
@@ -210,7 +236,7 @@ impl<'a> Parser<'a> {
                         span: token.span,
                         expression_span: render_tag.expression.span,
                     });
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(&mut children_stack, node);
                 }
                 TokenType::HtmlTag(html_tag) => {
                     let node = Node::HtmlTag(HtmlTag {
@@ -218,7 +244,7 @@ impl<'a> Parser<'a> {
                         span: token.span,
                         expression_span: html_tag.expression.span,
                     });
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(&mut children_stack, node);
                 }
                 TokenType::ScriptTag(script_tag) => {
                     if script_data.is_some() {
@@ -269,7 +295,7 @@ impl<'a> Parser<'a> {
         // Auto-close any remaining open entries
         self.auto_close_entries(&mut entry_stack, &mut children_stack);
 
-        let roots = children_stack.pop().unwrap();
+        let roots = pop_children(&mut children_stack);
 
         let script = script_data.map(|sd| Script {
             id: self.ids.next(),
@@ -315,7 +341,7 @@ impl<'a> Parser<'a> {
                     id: self.ids.next(),
                     span,
                 });
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
             }
             Some(idx) => {
                 // Auto-close any intervening entries
@@ -331,7 +357,7 @@ impl<'a> Parser<'a> {
                     unreachable!();
                 };
 
-                let children = children_stack.pop().unwrap();
+                let children = pop_children(children_stack);
                 let merged_span = el.span_start.merge(&span);
 
                 let node = if is_component_name(&el.name) {
@@ -354,7 +380,7 @@ impl<'a> Parser<'a> {
                     })
                 };
 
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
             }
         }
     }
@@ -366,7 +392,7 @@ impl<'a> Parser<'a> {
         entry_stack: &mut Vec<StackEntry>,
         children_stack: &mut Vec<Vec<Node>>,
     ) {
-        let consequent_children = children_stack.pop().unwrap();
+        let consequent_children = pop_children(children_stack);
 
         if else_tag.elseif {
             // {:else if expr}
@@ -425,7 +451,7 @@ impl<'a> Parser<'a> {
             return;
         };
 
-        let body_children = children_stack.pop().unwrap();
+        let body_children = pop_children(children_stack);
         let merged_span = eb.span.merge(&span);
 
         let node = Node::EachBlock(EachBlock {
@@ -439,7 +465,7 @@ impl<'a> Parser<'a> {
             fallback: None,
         });
 
-        children_stack.last_mut().unwrap().push(node);
+        push_child(children_stack, node);
     }
 
     fn handle_end_snippet_tag(
@@ -458,7 +484,7 @@ impl<'a> Parser<'a> {
             return;
         };
 
-        let body_children = children_stack.pop().unwrap();
+        let body_children = pop_children(children_stack);
         let merged_span = sb.span_start.merge(&span);
 
         let node = Node::SnippetBlock(SnippetBlock {
@@ -469,7 +495,7 @@ impl<'a> Parser<'a> {
             body: Fragment::new(body_children),
         });
 
-        children_stack.last_mut().unwrap().push(node);
+        push_child(children_stack, node);
     }
 
     /// Auto-close all remaining open entries at EOF.
@@ -495,7 +521,7 @@ impl<'a> Parser<'a> {
         match entry {
             StackEntry::Element(el) => {
                 self.recover(Diagnostic::unclosed_node(el.span_start));
-                let children = children_stack.pop().unwrap();
+                let children = pop_children(children_stack);
                 let merged_span = el.span_start.merge(&eof_span);
 
                 let node = if is_component_name(&el.name) {
@@ -518,11 +544,11 @@ impl<'a> Parser<'a> {
                     })
                 };
 
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
             }
             StackEntry::IfBlock(ib) => {
                 self.recover(Diagnostic::unclosed_node(ib.span));
-                let last_children = children_stack.pop().unwrap();
+                let last_children = pop_children(children_stack);
 
                 let (consequent, alternate) = if let Some(cons) = ib.consequent {
                     (cons, Some(Fragment::new(last_children)))
@@ -542,18 +568,18 @@ impl<'a> Parser<'a> {
                 });
 
                 if ib.elseif {
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(children_stack, node);
                     // Continue unwinding parent if-blocks
                     if children_stack.len() > 1 {
                         // Parent if-block will be auto-closed in the next iteration
                     }
                 } else {
-                    children_stack.last_mut().unwrap().push(node);
+                    push_child(children_stack, node);
                 }
             }
             StackEntry::EachBlock(eb) => {
                 self.recover(Diagnostic::unclosed_node(eb.span));
-                let body_children = children_stack.pop().unwrap();
+                let body_children = pop_children(children_stack);
                 let merged_span = eb.span.merge(&eof_span);
 
                 let node = Node::EachBlock(EachBlock {
@@ -567,11 +593,11 @@ impl<'a> Parser<'a> {
                     fallback: None,
                 });
 
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
             }
             StackEntry::SnippetBlock(sb) => {
                 self.recover(Diagnostic::unclosed_node(sb.span_start));
-                let body_children = children_stack.pop().unwrap();
+                let body_children = pop_children(children_stack);
                 let merged_span = sb.span_start.merge(&eof_span);
 
                 let node = Node::SnippetBlock(SnippetBlock {
@@ -582,7 +608,7 @@ impl<'a> Parser<'a> {
                     body: Fragment::new(body_children),
                 });
 
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
             }
         }
     }
@@ -607,7 +633,7 @@ impl<'a> Parser<'a> {
                 return;
             };
 
-            let last_children = children_stack.pop().unwrap();
+            let last_children = pop_children(children_stack);
 
             let (consequent, alternate) = if let Some(cons) = ib.consequent {
                 // We had {:else} or {:else if}, so cons = consequent, last_children = alternate
@@ -630,7 +656,7 @@ impl<'a> Parser<'a> {
 
             if ib.elseif {
                 // This is an else-if: it becomes the alternate of the parent if-block.
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
 
                 // Check if parent entry is also an IfBlock — if so, continue the loop.
                 if entry_stack
@@ -643,7 +669,7 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 // This is the outermost {#if}
-                children_stack.last_mut().unwrap().push(node);
+                push_child(children_stack, node);
                 break;
             }
         }


### PR DESCRIPTION
- Parser: replace 25+ children_stack unwrap() calls with safe
  push_child/pop_children helpers (debug_assert + graceful fallback)
- Codegen: eliminate unnecessary FragmentItem clones in SingleBlock
  paths by extracting NodeId via lightweight SingleBlockKind enum
- Codegen: remove 7 String::clone() calls in traverse_items by
  moving ownership into prev_ident after last borrow
- Codegen: add lowered_fragment() helper to Ctx, centralizing
  10 scattered HashMap lookups with descriptive panic messages
- Codegen: improve expect() messages in node lookup methods to
  include NodeId for easier debugging

https://claude.ai/code/session_01S19zrAeqA4KvaMiw7T4hU3