### PR TITLE
feat: port {#key expr} (KeyBlock) from Svelte v5

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,7 +156,7 @@ Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/HtmlTag.js` (~60 lines)
 - **Not yet**: `is_controlled` optimization (single child → innerHTML), `is_svg`/`is_mathml` namespace flags
 
-### `{#key expr}` — Keyed re-render block
+### ~~`{#key expr}` — Keyed re-render block~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Node::KeyBlock { id, span, expression_span, fragment }`
 - **Parser**: Parse `{#key expr}...{/key}`

--- a/TODO.md
+++ b/TODO.md
@@ -4,25 +4,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 1. `{#key expr}` (KeyBlock)
+## 1. `style:prop` directive
 
-**Why first**: нужен для роутеров (ремаунт при смене route) и анимаций.
-
-**What to change**:
-- `svelte_ast/src/lib.rs`: добавить `Node::KeyBlock { expression: Span, fragment: Fragment }`
-- `svelte_parser/src/lib.rs`: парсинг `{#key expr}...{/key}`
-- `svelte_analyze/`: content_types для KeyBlock fragment
-- `svelte_codegen_client/src/template/`: `$.key(anchor, () => expr, ($$anchor) => { ... })`
-
-**Reference**: `reference/compiler/phases/3-transform/client/visitors/KeyBlock.js`
-
-**Runtime**: `$.key()`
-
----
-
-## 2. `style:prop` directive
-
-**Why second**: так же часто используется как `class:`, паттерн уже есть (ClassDirective).
+**Why first**: так же часто используется как `class:`, паттерн уже есть (ClassDirective).
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Attribute::StyleDirective { name, value, modifiers }`
@@ -35,9 +19,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 3. Event handlers (`on:event` → `onevent`)
+## 2. Event handlers (`on:event` → `onevent`)
 
-**Why third**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
+**Why second**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
 
 **What to change**:
 - `svelte_parser/src/lib.rs`: парсинг `on:click={handler}` → `Attribute::OnDirective`
@@ -48,9 +32,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 4. Void HTML elements
+## 3. Void HTML elements
 
-**Why fourth**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
+**Why third**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
 
 **What to change**:
 - Добавить `VOID_ELEMENTS` constant и `is_void(name)` helper
@@ -61,9 +45,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 5. `{@const x = expr}` (ConstTag)
+## 4. `{@const x = expr}` (ConstTag)
 
-**Why fifth**: нужен для вычислений внутри {#each} и {#if} блоков.
+**Why fourth**: нужен для вычислений внутри {#each} и {#if} блоков.
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Node::ConstTag { id, span, declaration_span }`
@@ -72,3 +56,17 @@ Next 5 features to implement, in priority order.
 - `svelte_codegen_client/src/template/`: `const x = expr` (non-reactive) or `$.derived(() => expr)` (reactive)
 
 **Reference**: `reference/compiler/phases/3-transform/client/visitors/ConstTag.js` (~134 lines)
+
+---
+
+## 5. `$state.raw(val)` rune
+
+**Why fifth**: простой рун, паттерн уже есть в script.rs.
+
+**What to change**:
+- `svelte_analyze/src/parse_js.rs`: добавить `RuneKind::StateRaw`
+- `svelte_codegen_client/src/script.rs`: `$state.raw(val)` → `$.state(val)` (без `$.proxy()`)
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/VariableDeclaration.js`
+
+**Runtime**: `$.state()`

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -35,7 +35,8 @@ fn item_is_dynamic(
         | FragmentItem::IfBlock(id)
         | FragmentItem::EachBlock(id)
         | FragmentItem::RenderTag(id)
-        | FragmentItem::HtmlTag(id) => dynamic_nodes.contains(id),
+        | FragmentItem::HtmlTag(id)
+        | FragmentItem::KeyBlock(id) => dynamic_nodes.contains(id),
     }
 }
 
@@ -51,7 +52,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentType {
             | FragmentItem::IfBlock(_)
             | FragmentItem::EachBlock(_)
             | FragmentItem::RenderTag(_)
-            | FragmentItem::HtmlTag(_) => return ContentType::SingleBlock,
+            | FragmentItem::HtmlTag(_)
+            | FragmentItem::KeyBlock(_) => return ContentType::SingleBlock,
             FragmentItem::TextConcat { .. } => {}
         }
     }
@@ -68,7 +70,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentType {
             | FragmentItem::IfBlock(_)
             | FragmentItem::EachBlock(_)
             | FragmentItem::RenderTag(_)
-            | FragmentItem::HtmlTag(_) => has_block = true,
+            | FragmentItem::HtmlTag(_)
+            | FragmentItem::KeyBlock(_) => has_block = true,
             FragmentItem::TextConcat { has_expr, .. } => {
                 if *has_expr {
                     has_dynamic_text = true;

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -49,6 +49,7 @@ pub enum FragmentKey {
     EachBody(NodeId),
     EachFallback(NodeId),
     SnippetBody(NodeId),
+    KeyBlockBody(NodeId),
 }
 
 // ---------------------------------------------------------------------------
@@ -191,6 +192,8 @@ pub enum FragmentItem {
     RenderTag(NodeId),
     /// An HtmlTag ({@html expr}).
     HtmlTag(NodeId),
+    /// A KeyBlock ({#key expr}...{/key}).
+    KeyBlock(NodeId),
     /// Adjacent text nodes and expression tags grouped together.
     TextConcat { parts: Vec<ConcatPart>, has_expr: bool },
 }

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -40,6 +40,9 @@ fn lower_fragment(
             Node::SnippetBlock(block) => {
                 lower_fragment(&block.body, FragmentKey::SnippetBody(block.id), component, data);
             }
+            Node::KeyBlock(block) => {
+                lower_fragment(&block.fragment, FragmentKey::KeyBlockBody(block.id), component, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }
@@ -138,6 +141,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
                     Node::EachBlock(block) => items.push(FragmentItem::EachBlock(block.id)),
                     Node::RenderTag(tag) => items.push(FragmentItem::RenderTag(tag.id)),
                     Node::HtmlTag(tag) => items.push(FragmentItem::HtmlTag(tag.id)),
+                    Node::KeyBlock(block) => items.push(FragmentItem::KeyBlock(block.id)),
                     _ => {}
                 }
             }

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -61,6 +61,6 @@ fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
             // Already computed: leave_element processes children before parents
             data.elements_needing_var.contains(id)
         }
-        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) => true,
+        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) => true,
     }
 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -139,6 +139,11 @@ fn walk_node<'a>(
             let source = component.source_text(tag.expression_span);
             parse_expr(alloc, source, tag.expression_span.start, tag.id, data, parsed, diags);
         }
+        Node::KeyBlock(block) => {
+            let source = component.source_text(block.expression_span);
+            parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
+            walk_fragment(alloc, &block.fragment, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
-    NodeId, RenderTag, SnippetBlock,
+    KeyBlock, NodeId, RenderTag, SnippetBlock,
 };
 use crate::data::AnalysisData;
 use crate::walker::TemplateVisitor;
@@ -86,6 +86,12 @@ impl TemplateVisitor for ReactivityVisitor {
         // body_scope is fine for the expression check — find_binding walks up parent scopes,
         // so `items` in `{#each items as item}` resolves correctly from the child scope.
         if self.expr_is_dynamic(&block.id, data, body_scope) {
+            data.dynamic_nodes.insert(block.id);
+        }
+    }
+
+    fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {
+        if self.expr_is_dynamic(&block.id, data, scope) {
             data.dynamic_nodes.insert(block.id);
         }
     }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -268,6 +268,9 @@ fn walk_template_scopes(
             Node::SnippetBlock(block) => {
                 walk_template_scopes(&block.body, component, scoping, current_scope);
             }
+            Node::KeyBlock(block) => {
+                walk_template_scopes(&block.fragment, component, scoping, current_scope);
+            }
             Node::ExpressionTag(_) | Node::Text(_) | Node::Comment(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, Fragment, HtmlTag,
-    IfBlock, Node, RenderTag, SnippetBlock,
+    IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
 };
 
 use crate::data::AnalysisData;
@@ -25,6 +25,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_each_block(&mut self, block: &EachBlock, body_scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {}
@@ -93,6 +94,10 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
             Node::HtmlTag(tag) => {
                 visitor.visit_html_tag(tag, scope, data);
             }
+            Node::KeyBlock(block) => {
+                visitor.visit_key_block(block, scope, data);
+                walk_template(&block.fragment, data, scope, visitor);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -125,6 +130,9 @@ macro_rules! impl_composite_visitor {
             }
             fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {
                 $(self.$idx.visit_snippet_block(block, scope, data);)+
+            }
+            fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {
+                $(self.$idx.visit_key_block(block, scope, data);)+
             }
             fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
                 $(self.$idx.visit_attribute(attr, idx, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -80,6 +80,7 @@ pub enum Node {
     SnippetBlock(SnippetBlock),
     RenderTag(RenderTag),
     HtmlTag(HtmlTag),
+    KeyBlock(KeyBlock),
     Error(ErrorNode),
 }
 
@@ -101,6 +102,7 @@ impl Node {
             Node::SnippetBlock(n) => n.id,
             Node::RenderTag(n) => n.id,
             Node::HtmlTag(n) => n.id,
+            Node::KeyBlock(n) => n.id,
             Node::Error(n) => n.id,
         }
     }
@@ -117,6 +119,7 @@ impl Node {
             Node::SnippetBlock(n) => n.span,
             Node::RenderTag(n) => n.span,
             Node::HtmlTag(n) => n.span,
+            Node::KeyBlock(n) => n.span,
             Node::Error(n) => n.span,
         }
     }
@@ -347,6 +350,18 @@ pub struct HtmlTag {
     pub span: Span,
     /// Span of the JS expression: "content" in `{@html content}`.
     pub expression_span: Span,
+}
+
+// ---------------------------------------------------------------------------
+// KeyBlock — {#key expr}...{/key}
+// ---------------------------------------------------------------------------
+
+pub struct KeyBlock {
+    pub id: NodeId,
+    pub span: Span,
+    /// Span of the JS expression: "count" in `{#key count}`.
+    pub expression_span: Span,
+    pub fragment: Fragment,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, FragmentKey, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
+use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeId, RenderTag, SnippetBlock};
 use svelte_span::Span;
 
 use crate::builder::Builder;
@@ -16,6 +16,7 @@ struct NodeIndex<'a> {
     snippet_blocks: FxHashMap<NodeId, &'a SnippetBlock>,
     render_tags: FxHashMap<NodeId, &'a RenderTag>,
     html_tags: FxHashMap<NodeId, &'a HtmlTag>,
+    key_blocks: FxHashMap<NodeId, &'a KeyBlock>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -29,6 +30,7 @@ impl<'a> NodeIndex<'a> {
             snippet_blocks: FxHashMap::default(),
             render_tags: FxHashMap::default(),
             html_tags: FxHashMap::default(),
+            key_blocks: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -69,6 +71,10 @@ impl<'a> NodeIndex<'a> {
                 }
                 Node::HtmlTag(t) => {
                     self.html_tags.insert(t.id, t);
+                }
+                Node::KeyBlock(b) => {
+                    self.key_blocks.insert(b.id, b);
+                    self.walk(&b.fragment);
                 }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
@@ -180,6 +186,11 @@ impl<'a> Ctx<'a> {
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
         self.index.render_tags.get(&id).copied()
             .unwrap_or_else(|| panic!("render tag {:?} not found in index", id))
+    }
+
+    pub fn key_block(&self, id: NodeId) -> &'a KeyBlock {
+        self.index.key_blocks.get(&id).copied()
+            .unwrap_or_else(|| panic!("key block {:?} not found in index", id))
     }
 
     pub fn lowered_fragment(&self, key: &FragmentKey) -> &LoweredFragment {

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, FragmentKey, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeId, RenderTag, SnippetBlock};
+use svelte_ast::{Component, ComponentNode, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
 use svelte_span::Span;
 
 use crate::builder::Builder;
@@ -16,7 +16,6 @@ struct NodeIndex<'a> {
     snippet_blocks: FxHashMap<NodeId, &'a SnippetBlock>,
     render_tags: FxHashMap<NodeId, &'a RenderTag>,
     html_tags: FxHashMap<NodeId, &'a HtmlTag>,
-    key_blocks: FxHashMap<NodeId, &'a KeyBlock>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -30,7 +29,6 @@ impl<'a> NodeIndex<'a> {
             snippet_blocks: FxHashMap::default(),
             render_tags: FxHashMap::default(),
             html_tags: FxHashMap::default(),
-            key_blocks: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -73,7 +71,6 @@ impl<'a> NodeIndex<'a> {
                     self.html_tags.insert(t.id, t);
                 }
                 Node::KeyBlock(b) => {
-                    self.key_blocks.insert(b.id, b);
                     self.walk(&b.fragment);
                 }
                 Node::ExpressionTag(t) => {
@@ -186,11 +183,6 @@ impl<'a> Ctx<'a> {
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
         self.index.render_tags.get(&id).copied()
             .unwrap_or_else(|| panic!("render tag {:?} not found in index", id))
-    }
-
-    pub fn key_block(&self, id: NodeId) -> &'a KeyBlock {
-        self.index.key_blocks.get(&id).copied()
-            .unwrap_or_else(|| panic!("key block {:?} not found in index", id))
     }
 
     pub fn lowered_fragment(&self, key: &FragmentKey) -> &LoweredFragment {

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -162,7 +162,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
         svelte_analyze::FragmentItem::Element(id) => ctx.analysis.elements_needing_var.contains(id),
-        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) => {
+        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) => {
             true
         }
     }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -233,7 +233,7 @@ pub(crate) fn emit_trailing_next<'a>(
 pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
-        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) => {
+        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) => {
             ctx.analysis.dynamic_nodes.contains(id)
         }
     }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -33,7 +33,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
                 let el = ctx.element(*id);
                 html.push_str(&element_html(ctx, el));
             }
-            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) => html.push_str("<!>"),
+            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) => html.push_str("<!>"),
         }
     }
     html

--- a/crates/svelte_codegen_client/src/template/key_block.rs
+++ b/crates/svelte_codegen_client/src/template/key_block.rs
@@ -8,32 +8,22 @@ use svelte_ast::NodeId;
 use crate::builder::Arg;
 use crate::context::Ctx;
 
-use super::expression::get_node_expr;
 use super::gen_fragment;
 
 /// Generate `$.key(anchor, () => expr, ($$anchor) => { ... })`.
 pub(crate) fn gen_key_block<'a>(
     ctx: &mut Ctx<'a>,
-    block_id: NodeId,
+    id: NodeId,
     anchor: Expression<'a>,
     stmts: &mut Vec<Statement<'a>>,
 ) {
-    let body_key = FragmentKey::KeyBlockBody(block_id);
+    let key_thunk = super::expression::build_node_thunk(ctx, id);
 
-    // Build key expression thunk: () => expr
-    let expression = get_node_expr(ctx, block_id);
-    let key_thunk = ctx.b.arrow(ctx.b.no_params(), [ctx.b.expr_stmt(expression)]);
-
-    // Build body function: ($$anchor) => { ... }
-    let body = gen_fragment(ctx, body_key);
+    let body = gen_fragment(ctx, FragmentKey::KeyBlockBody(id));
     let body_fn = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), body);
 
-    // $.key(anchor, () => expr, ($$anchor) => { ... })
-    let args: Vec<Arg<'a, '_>> = vec![
-        Arg::Expr(anchor),
-        Arg::Arrow(key_thunk),
-        Arg::Expr(body_fn),
-    ];
-
-    stmts.push(ctx.b.call_stmt("$.key", args));
+    stmts.push(ctx.b.call_stmt(
+        "$.key",
+        [Arg::Expr(anchor), Arg::Expr(key_thunk), Arg::Expr(body_fn)],
+    ));
 }

--- a/crates/svelte_codegen_client/src/template/key_block.rs
+++ b/crates/svelte_codegen_client/src/template/key_block.rs
@@ -1,0 +1,39 @@
+//! KeyBlock code generation — `{#key expr}...{/key}`.
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_analyze::FragmentKey;
+use svelte_ast::NodeId;
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::expression::get_node_expr;
+use super::gen_fragment;
+
+/// Generate `$.key(anchor, () => expr, ($$anchor) => { ... })`.
+pub(crate) fn gen_key_block<'a>(
+    ctx: &mut Ctx<'a>,
+    block_id: NodeId,
+    anchor: Expression<'a>,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let body_key = FragmentKey::KeyBlockBody(block_id);
+
+    // Build key expression thunk: () => expr
+    let expression = get_node_expr(ctx, block_id);
+    let key_thunk = ctx.b.arrow(ctx.b.no_params(), [ctx.b.expr_stmt(expression)]);
+
+    // Build body function: ($$anchor) => { ... }
+    let body = gen_fragment(ctx, body_key);
+    let body_fn = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), body);
+
+    // $.key(anchor, () => expr, ($$anchor) => { ... })
+    let args: Vec<Arg<'a, '_>> = vec![
+        Arg::Expr(anchor),
+        Arg::Arrow(key_thunk),
+        Arg::Expr(body_fn),
+    ];
+
+    stmts.push(ctx.b.call_stmt("$.key", args));
+}

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod expression;
 pub(crate) mod html;
 pub(crate) mod if_block;
 pub(crate) mod html_tag;
+pub(crate) mod key_block;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
 pub(crate) mod traverse;
@@ -25,6 +26,7 @@ enum SingleBlockKind {
     IfBlock(NodeId),
     EachBlock(NodeId),
     HtmlTag(NodeId),
+    KeyBlock(NodeId),
     RenderTag(NodeId),
     ComponentNode(NodeId),
 }
@@ -36,6 +38,7 @@ use component::gen_component;
 use if_block::gen_if_block;
 use each_block::gen_each_block;
 use html_tag::gen_html_tag;
+use key_block::gen_key_block;
 use render_tag::gen_render_tag;
 use traverse::traverse_items;
 
@@ -209,7 +212,10 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
         SingleBlockKind::HtmlTag(id) => {
             gen_html_tag(ctx, id, ctx.b.rid_expr(&node), body);
         }
-        _ => unreachable!("SingleBlock should be if/each/html at this point"),
+        SingleBlockKind::KeyBlock(id) => {
+            gen_key_block(ctx, id, ctx.b.rid_expr(&node), body);
+        }
+        _ => unreachable!("SingleBlock should be if/each/html/key at this point"),
     }
 
     body.push(ctx.b.call_stmt(
@@ -390,7 +396,10 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                         SingleBlockKind::HtmlTag(id) => {
                             gen_html_tag(ctx, id, ctx.b.rid_expr(&node), &mut body);
                         }
-                        _ => unreachable!("SingleBlock should be if/each/html at this point"),
+                        SingleBlockKind::KeyBlock(id) => {
+                            gen_key_block(ctx, id, ctx.b.rid_expr(&node), &mut body);
+                        }
+                        _ => unreachable!("SingleBlock should be if/each/html/key at this point"),
                     }
                     body.push(ctx.b.call_stmt(
                         "$.append",
@@ -457,6 +466,7 @@ fn single_block_kind(item: &FragmentItem) -> SingleBlockKind {
         FragmentItem::IfBlock(id) => SingleBlockKind::IfBlock(id),
         FragmentItem::EachBlock(id) => SingleBlockKind::EachBlock(id),
         FragmentItem::HtmlTag(id) => SingleBlockKind::HtmlTag(id),
+        FragmentItem::KeyBlock(id) => SingleBlockKind::KeyBlock(id),
         FragmentItem::RenderTag(id) => SingleBlockKind::RenderTag(id),
         FragmentItem::ComponentNode(id) => SingleBlockKind::ComponentNode(id),
         _ => unreachable!("SingleBlock should contain a block-level item"),

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -13,6 +13,7 @@ use super::element::{item_needs_var, process_element};
 use super::expression::parts_are_dynamic;
 use super::if_block::gen_if_block;
 use super::html_tag::gen_html_tag;
+use super::key_block::gen_key_block;
 use super::render_tag::gen_render_tag;
 
 /// Traverse lowered items, assign DOM variables, generate init/update statements.
@@ -125,6 +126,14 @@ pub(crate) fn traverse_items<'a>(
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
                     sibling_offset = 1;
                     gen_html_tag(ctx, *id, ctx.b.rid_expr(&node_name), init);
+                    prev_ident = Some(node_name);
+                }
+
+                FragmentItem::KeyBlock(id) => {
+                    let node_name = ctx.gen_ident("node");
+                    init.push(ctx.b.var_stmt(&node_name, node_expr));
+                    sibling_offset = 1;
+                    gen_key_block(ctx, *id, ctx.b.rid_expr(&node_name), init);
                     prev_ident = Some(node_name);
                 }
             }

--- a/crates/svelte_diagnostics/src/lib.rs
+++ b/crates/svelte_diagnostics/src/lib.rs
@@ -26,6 +26,7 @@ pub enum DiagnosticKind {
     OnlyOneTopLevelStyle,
     UnknownDirective,
     NoEachBlockToClose,
+    NoKeyBlockToClose,
     // Internal compiler errors
     InternalError(String),
 }
@@ -110,6 +111,10 @@ impl Diagnostic {
 
     pub fn no_each_block_to_close(span: Span) -> Self {
         Self::error(DiagnosticKind::NoEachBlockToClose, span)
+    }
+
+    pub fn no_key_block_to_close(span: Span) -> Self {
+        Self::error(DiagnosticKind::NoKeyBlockToClose, span)
     }
 
     pub fn internal_error(message: String) -> Self {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -7,7 +7,7 @@ use svelte_span::Span;
 use svelte_ast::{
     Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode,
     ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
-    ExpressionAttribute, Fragment, HtmlTag, IfBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
+    ExpressionAttribute, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
 };
 
@@ -24,6 +24,12 @@ enum StackEntry {
     IfBlock(IfBlockEntry),
     EachBlock(EachBlockEntry),
     SnippetBlock(SnippetBlockEntry),
+    KeyBlock(KeyBlockEntry),
+}
+
+struct KeyBlockEntry {
+    span: Span,
+    expression_span: Span,
 }
 
 struct ElementEntry {
@@ -225,6 +231,20 @@ impl<'a> Parser<'a> {
                 }
                 TokenType::EndSnippetTag => {
                     self.handle_end_snippet_tag(
+                        token.span,
+                        &mut entry_stack,
+                        &mut children_stack,
+                    );
+                }
+                TokenType::StartKeyTag(key_tag) => {
+                    entry_stack.push(StackEntry::KeyBlock(KeyBlockEntry {
+                        span: token.span,
+                        expression_span: key_tag.expression.span,
+                    }));
+                    children_stack.push(vec![]);
+                }
+                TokenType::EndKeyTag => {
+                    self.handle_end_key_tag(
                         token.span,
                         &mut entry_stack,
                         &mut children_stack,
@@ -498,6 +518,35 @@ impl<'a> Parser<'a> {
         push_child(children_stack, node);
     }
 
+    fn handle_end_key_tag(
+        &mut self,
+        span: Span,
+        entry_stack: &mut Vec<StackEntry>,
+        children_stack: &mut Vec<Vec<Node>>,
+    ) {
+        let entry = entry_stack.pop();
+
+        let Some(StackEntry::KeyBlock(kb)) = entry else {
+            self.recover(Diagnostic::no_key_block_to_close(span));
+            if let Some(entry) = entry {
+                entry_stack.push(entry);
+            }
+            return;
+        };
+
+        let body_children = pop_children(children_stack);
+        let merged_span = kb.span.merge(&span);
+
+        let node = Node::KeyBlock(KeyBlock {
+            id: self.ids.next(),
+            span: merged_span,
+            expression_span: kb.expression_span,
+            fragment: Fragment::new(body_children),
+        });
+
+        push_child(children_stack, node);
+    }
+
     /// Auto-close all remaining open entries at EOF.
     fn auto_close_entries(
         &mut self,
@@ -606,6 +655,20 @@ impl<'a> Parser<'a> {
                     name: sb.name,
                     params_span: sb.params_span,
                     body: Fragment::new(body_children),
+                });
+
+                push_child(children_stack, node);
+            }
+            StackEntry::KeyBlock(kb) => {
+                self.recover(Diagnostic::unclosed_node(kb.span));
+                let body_children = pop_children(children_stack);
+                let merged_span = kb.span.merge(&eof_span);
+
+                let node = Node::KeyBlock(KeyBlock {
+                    id: self.ids.next(),
+                    span: merged_span,
+                    expression_span: kb.expression_span,
+                    fragment: Fragment::new(body_children),
                 });
 
                 push_child(children_stack, node);
@@ -1041,6 +1104,29 @@ mod tests {
     fn html_tag_complex_expression() {
         let c = parse("{@html '<p>' + name + '</p>'}");
         assert_html_tag(&c, 0, "'<p>' + name + '</p>'");
+    }
+
+    // --- KeyBlock tests ---
+
+    fn assert_key_block(c: &Component, index: usize, expected_expr: &str) {
+        if let Node::KeyBlock(ref kb) = c.fragment.nodes[index] {
+            assert_eq!(c.source_text(kb.expression_span), expected_expr);
+        } else {
+            panic!("expected KeyBlock at index {index}");
+        }
+    }
+
+    #[test]
+    fn key_block_basic() {
+        let c = parse("{#key count}<div>{count}</div>{/key}");
+        assert_node(&c, 0, "{#key count}<div>{count}</div>{/key}");
+        assert_key_block(&c, 0, "count");
+    }
+
+    #[test]
+    fn key_block_complex_expr() {
+        let c = parse("{#key item.id}content{/key}");
+        assert_key_block(&c, 0, "item.id");
     }
 
     // --- Escape sequence tests (Bug #1) ---

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -4,7 +4,7 @@ use std::{iter::Peekable, str::Chars, vec};
 use token::{
     Attribute, AttributeIdentifierType, AttributeValue, BindDirective, ClassDirective,
     Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, JsExpression, ScriptTag,
-    StartEachTag, StartIfTag, StartTag, Token, TokenType,
+    StartEachTag, StartIfTag, StartKeyTag, StartTag, Token, TokenType,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -635,6 +635,11 @@ impl<'a> Scanner<'a> {
             }
             "each" => self.start_each_tag(),
             "snippet" => self.start_snippet_tag(),
+            "key" => {
+                let expression = self.collect_js_expression()?;
+                self.add_token(TokenType::StartKeyTag(StartKeyTag { expression }));
+                Ok(())
+            }
             _ => Err(Diagnostic::unexpected_keyword(Span::new(
                 start as u32,
                 self.current as u32,
@@ -688,6 +693,17 @@ impl<'a> Scanner<'a> {
                 }
 
                 self.add_token(TokenType::EndSnippetTag);
+
+                Ok(())
+            }
+            "key" => {
+                self.skip_whitespace();
+
+                if !self.match_char('}') {
+                    self.recover(Diagnostic::unexpected_token(Span::new(start as u32, self.current as u32)));
+                }
+
+                self.add_token(TokenType::EndKeyTag);
 
                 Ok(())
             }

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -19,6 +19,8 @@ pub enum TokenType<'a> {
     EndSnippetTag,
     RenderTag(RenderTagToken<'a>),
     HtmlTag(HtmlTagToken<'a>),
+    StartKeyTag(StartKeyTag<'a>),
+    EndKeyTag,
     StyleTag(StyleTag<'a>),
     EOF,
 }
@@ -188,6 +190,11 @@ pub struct RenderTagToken<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HtmlTagToken<'a> {
+    pub expression: JsExpression<'a>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StartKeyTag<'a> {
     pub expression: JsExpression<'a>,
 }
 

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -138,6 +138,10 @@ fn walk_node<'a>(
         Node::HtmlTag(tag) => {
             transform_node_expr(ctx, tag.id, parsed, scope, snippet_params);
         }
+        Node::KeyBlock(block) => {
+            transform_node_expr(ctx, block.id, parsed, scope, snippet_params);
+            walk_fragment(ctx, &block.fragment, component, parsed, scope, snippet_params);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/compiler_tests/cases2/key_block/case-rust.js
+++ b/tasks/compiler_tests/cases2/key_block/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let count = $.state(0);
+	$.set(count, 1);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.key(node, () => $.get(count), ($$anchor) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(count)));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/key_block/case-svelte.js
+++ b/tasks/compiler_tests/cases2/key_block/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let count = $.state(0);
+	$.set(count, 1);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.key(node, () => $.get(count), ($$anchor) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(count)));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/key_block/case.svelte
+++ b/tasks/compiler_tests/cases2/key_block/case.svelte
@@ -1,0 +1,8 @@
+<script>
+  let count = $state(0);
+  count = 1;
+</script>
+
+{#key count}
+  <div>{count}</div>
+{/key}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -275,3 +275,8 @@ fn effect_runes() {
 fn html_tag() {
     assert_compiler("html_tag");
 }
+
+#[rstest]
+fn key_block() {
+    assert_compiler("key_block");
+}


### PR DESCRIPTION
Add full support for KeyBlock across all compiler phases:
- Parser: {#key expr}...{/key} tokenization and parsing
- AST: KeyBlock struct with expression_span and fragment
- Analysis: FragmentKey::KeyBlockBody, FragmentItem::KeyBlock, reactivity detection
- Codegen: $.key(anchor, () => expr, ($$anchor) => { ... })
- Test case matching Svelte v5 reference output

https://claude.ai/code/session_01NhSJsAUvnDX6ieMLvGo8QY