### PR TITLE
Implement style:prop directive support

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -75,10 +75,12 @@ enum Attribute {
     ConcatenationAttribute(ConcatenationAttribute), // name, parts: Vec<ConcatPart>
     ShorthandOrSpread(ShorthandOrSpread),         // expression_span, is_spread
     ClassDirective(ClassDirective),               // name, expression_span?, shorthand
+    StyleDirective(StyleDirective),               // name, value: StyleDirectiveValue, important
     BindDirective(BindDirective),                 // name, expression_span?, shorthand
 }
 
 enum ConcatPart { Static(String), Dynamic(Span) }
+enum StyleDirectiveValue { Shorthand, Expression(Span), String(String), Concatenation(Vec<ConcatPart>) }
 enum ElementKind { Unknown, Input }
 enum ScriptContext { Default, Module }
 enum ScriptLanguage { JavaScript, TypeScript }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,11 +174,10 @@ Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_
 
 ### ~~`style:prop={value}` — Style directive~~ ✅
 - **Phases**: P, A, T
-- **AST**: `Attribute::StyleDirective { name, expression_span: Option<Span>, shorthand: bool, important: bool }`
-- **Parser**: Parse `style:color={expr}`, `style:color` (shorthand), `|important` modifier
-- **Codegen**: `$.set_style(el, staticStyle, prev, { directives })` — same pattern as `$.set_class()`
+- **AST**: `Attribute::StyleDirective { name, value: StyleDirectiveValue, important: bool }` with `StyleDirectiveValue` enum (Shorthand, Expression, String, Concatenation)
+- **Parser**: Parse `style:color={expr}`, `style:color` (shorthand), `style:color="red"` (string), `style:color="red-{x}"` (concat), `|important` modifier
+- **Codegen**: `$.set_style(el, staticStyle, prev, { directives })` — same pattern as `$.set_class()`. `|important` produces `[{ normal }, { important }]` array format.
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js`
-- **Not yet**: `style:color="red"` (string literal value — currently only expression and shorthand forms supported)
 
 ### `class` attribute — Object/array syntax (Svelte 5)
 - **Phases**: P, A, T

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,13 +172,13 @@ Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_
 - **Codegen**: `const x = expr` (non-reactive) or `$.derived(() => expr)` (reactive)
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/ConstTag.js` (~134 lines, destructuring support)
 
-### `style:prop={value}` — Style directive
+### ~~`style:prop={value}` — Style directive~~ ✅
 - **Phases**: P, A, T
-- **AST**: `Attribute::StyleDirective { name, value_span: Option<Span>, important: bool }`
-- **Parser**: Parse `style:color={expr}`, `style:color="red"`, `style:color` (shorthand), `|important` modifier
-- **Codegen**: `$.set_style(el, "color", value)` or `$.set_style(el, "color", value, 1)` for `|important`
-- **Pattern**: Follows exact same pattern as `ClassDirective` in parser and `process_class_directives` in codegen
+- **AST**: `Attribute::StyleDirective { name, expression_span: Option<Span>, shorthand: bool, important: bool }`
+- **Parser**: Parse `style:color={expr}`, `style:color` (shorthand), `|important` modifier
+- **Codegen**: `$.set_style(el, staticStyle, prev, { directives })` — same pattern as `$.set_class()`
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js`
+- **Not yet**: `style:color="red"` (string literal value — currently only expression and shorthand forms supported)
 
 ### `class` attribute — Object/array syntax (Svelte 5)
 - **Phases**: P, A, T

--- a/TODO.md
+++ b/TODO.md
@@ -4,24 +4,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 1. `style:prop` directive
+## 1. Event handlers (`on:event` → `onevent`)
 
-**Why first**: так же часто используется как `class:`, паттерн уже есть (ClassDirective).
-
-**What to change**:
-- `svelte_ast/src/lib.rs`: добавить `Attribute::StyleDirective { name, value, modifiers }`
-- `svelte_parser/src/lib.rs`: парсинг `style:color={value}` / `style:color="red"` / `style:color` (shorthand)
-- `svelte_codegen_client/src/template/attributes.rs`: генерация `$.set_style(element, "color", value)`
-
-**Reference**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js` (style directive section)
-
-**Runtime**: `$.set_style()`
-
----
-
-## 2. Event handlers (`on:event` → `onevent`)
-
-**Why second**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
+**Why first**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
 
 **What to change**:
 - `svelte_parser/src/lib.rs`: парсинг `on:click={handler}` → `Attribute::OnDirective`
@@ -32,9 +17,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 3. Void HTML elements
+## 2. Void HTML elements
 
-**Why third**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
+**Why second**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
 
 **What to change**:
 - Добавить `VOID_ELEMENTS` constant и `is_void(name)` helper
@@ -45,9 +30,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 4. `{@const x = expr}` (ConstTag)
+## 3. `{@const x = expr}` (ConstTag)
 
-**Why fourth**: нужен для вычислений внутри {#each} и {#if} блоков.
+**Why third**: нужен для вычислений внутри {#each} и {#if} блоков.
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Node::ConstTag { id, span, declaration_span }`
@@ -59,9 +44,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 5. `$state.raw(val)` rune
+## 4. `$state.raw(val)` rune
 
-**Why fifth**: простой рун, паттерн уже есть в script.rs.
+**Why fourth**: простой рун, паттерн уже есть в script.rs.
 
 **What to change**:
 - `svelte_analyze/src/parse_js.rs`: добавить `RuneKind::StateRaw`
@@ -70,3 +55,15 @@ Next 5 features to implement, in priority order.
 **Reference**: `reference/compiler/phases/3-transform/client/visitors/VariableDeclaration.js`
 
 **Runtime**: `$.state()`
+
+---
+
+## 5. `class` attribute — Object/array syntax (Svelte 5)
+
+**Why fifth**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
+
+**What to change**:
+- `svelte_parser/src/lib.rs`: detect object/array expression in `class` attribute value
+- `svelte_codegen_client/src/template/attributes.rs`: генерация `$.set_class(el, ...)`
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js`

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -105,6 +105,10 @@ pub struct AnalysisData {
     pub element_has_class_directives: FxHashSet<NodeId>,
     /// Static class attribute Span for elements (value_span of StringAttribute named "class").
     pub element_static_class: FxHashMap<NodeId, Span>,
+    /// Elements that have at least one style directive.
+    pub element_has_style_directives: FxHashSet<NodeId>,
+    /// Static style attribute Span for elements (value_span of StringAttribute named "style").
+    pub element_static_style: FxHashMap<NodeId, Span>,
     /// Input elements that need `$.remove_input_defaults` (have bind or value attr).
     pub needs_input_defaults: FxHashSet<NodeId>,
     /// Fragments whose items contain at least one dynamic child.
@@ -139,6 +143,8 @@ impl AnalysisData {
             element_has_spread: FxHashSet::default(),
             element_has_class_directives: FxHashSet::default(),
             element_static_class: FxHashMap::default(),
+            element_has_style_directives: FxHashSet::default(),
+            element_static_style: FxHashMap::default(),
             needs_input_defaults: FxHashSet::default(),
             fragment_has_dynamic_children: FxHashSet::default(),
             needs_context: false,

--- a/crates/svelte_analyze/src/element_flags.rs
+++ b/crates/svelte_analyze/src/element_flags.rs
@@ -24,8 +24,14 @@ impl TemplateVisitor for ElementFlagsVisitor {
             Attribute::ClassDirective(_) => {
                 data.element_has_class_directives.insert(el.id);
             }
+            Attribute::StyleDirective(_) => {
+                data.element_has_style_directives.insert(el.id);
+            }
             Attribute::StringAttribute(sa) if sa.name == "class" => {
                 data.element_static_class.insert(el.id, sa.value_span);
+            }
+            Attribute::StringAttribute(sa) if sa.name == "style" => {
+                data.element_static_style.insert(el.id, sa.value_span);
             }
             Attribute::BindDirective(_) if el.name == "input" => {
                 data.needs_input_defaults.insert(el.id);

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -196,6 +196,12 @@ fn walk_attrs<'a>(
                     parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
                 }
             }
+            Attribute::StyleDirective(a) => {
+                if let Some(span) = a.expression_span {
+                    let source = component.source_text(span);
+                    parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+                }
+            }
             Attribute::BindDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -78,6 +78,41 @@ fn parse_attr_expr<'a>(
     }
 }
 
+/// Parse concatenation parts (shared by ConcatenationAttribute and StyleDirective::Concatenation).
+fn parse_concat_parts<'a>(
+    alloc: &'a Allocator,
+    parts: &[ConcatPart],
+    owner_id: NodeId,
+    attr_idx: usize,
+    component: &Component,
+    data: &mut AnalysisData,
+    parsed: &mut ParsedExprs<'a>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let mut all_refs = Vec::new();
+    let mut dyn_idx = 0usize;
+    for part in parts {
+        if let ConcatPart::Dynamic(span) = part {
+            let source = component.source_text(*span);
+            let arena_source: &'a str = alloc.alloc_str(source);
+            match svelte_js::analyze_expression_with_alloc(alloc, arena_source, span.start) {
+                Ok((info, expr)) => {
+                    all_refs.extend(info.references);
+                    parsed.concat_part_exprs.insert((owner_id, attr_idx, dyn_idx), expr);
+                }
+                Err(diag) => diags.push(diag),
+            }
+            dyn_idx += 1;
+        }
+    }
+    let merged = ExpressionInfo {
+        kind: ExpressionKind::Other,
+        references: all_refs,
+        has_side_effects: false,
+    };
+    data.attr_expressions.insert((owner_id, attr_idx), merged);
+}
+
 fn walk_fragment<'a>(
     alloc: &'a Allocator,
     fragment: &Fragment,
@@ -166,29 +201,7 @@ fn walk_attrs<'a>(
                 parse_attr_expr(alloc, source, a.expression_span.start, key, data, parsed, diags);
             }
             Attribute::ConcatenationAttribute(a) => {
-                // Parse each dynamic part and store both metadata (merged) and individual ASTs.
-                let mut all_refs = Vec::new();
-                let mut dyn_idx = 0usize;
-                for part in &a.parts {
-                    if let ConcatPart::Dynamic(span) = part {
-                        let source = component.source_text(*span);
-                        let arena_source: &'a str = alloc.alloc_str(source);
-                        match svelte_js::analyze_expression_with_alloc(alloc, arena_source, span.start) {
-                            Ok((info, expr)) => {
-                                all_refs.extend(info.references);
-                                parsed.concat_part_exprs.insert((owner_id, attr_idx, dyn_idx), expr);
-                            }
-                            Err(diag) => diags.push(diag),
-                        }
-                        dyn_idx += 1;
-                    }
-                }
-                let merged = ExpressionInfo {
-                    kind: ExpressionKind::Other,
-                    references: all_refs,
-                    has_side_effects: false,
-                };
-                data.attr_expressions.insert(key, merged);
+                parse_concat_parts(alloc, &a.parts, owner_id, attr_idx, component, data, parsed, diags);
             }
             Attribute::ClassDirective(a) => {
                 if let Some(span) = a.expression_span {
@@ -204,28 +217,7 @@ fn walk_attrs<'a>(
                         parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
                     }
                     StyleDirectiveValue::Concatenation(parts) => {
-                        let mut all_refs = Vec::new();
-                        let mut dyn_idx = 0usize;
-                        for part in parts {
-                            if let svelte_ast::ConcatPart::Dynamic(span) = part {
-                                let source = component.source_text(*span);
-                                let arena_source: &'a str = alloc.alloc_str(source);
-                                match svelte_js::analyze_expression_with_alloc(alloc, arena_source, span.start) {
-                                    Ok((info, expr)) => {
-                                        all_refs.extend(info.references);
-                                        parsed.concat_part_exprs.insert((owner_id, attr_idx, dyn_idx), expr);
-                                    }
-                                    Err(diag) => diags.push(diag),
-                                }
-                                dyn_idx += 1;
-                            }
-                        }
-                        let merged = ExpressionInfo {
-                            kind: ExpressionKind::Other,
-                            references: all_refs,
-                            has_side_effects: false,
-                        };
-                        data.attr_expressions.insert(key, merged);
+                        parse_concat_parts(alloc, parts, owner_id, attr_idx, component, data, parsed, diags);
                     }
                     StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
                 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -197,9 +197,37 @@ fn walk_attrs<'a>(
                 }
             }
             Attribute::StyleDirective(a) => {
-                if let Some(span) = a.expression_span {
-                    let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+                use svelte_ast::StyleDirectiveValue;
+                match &a.value {
+                    StyleDirectiveValue::Expression(span) => {
+                        let source = component.source_text(*span);
+                        parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+                    }
+                    StyleDirectiveValue::Concatenation(parts) => {
+                        let mut all_refs = Vec::new();
+                        let mut dyn_idx = 0usize;
+                        for part in parts {
+                            if let svelte_ast::ConcatPart::Dynamic(span) = part {
+                                let source = component.source_text(*span);
+                                let arena_source: &'a str = alloc.alloc_str(source);
+                                match svelte_js::analyze_expression_with_alloc(alloc, arena_source, span.start) {
+                                    Ok((info, expr)) => {
+                                        all_refs.extend(info.references);
+                                        parsed.concat_part_exprs.insert((owner_id, attr_idx, dyn_idx), expr);
+                                    }
+                                    Err(diag) => diags.push(diag),
+                                }
+                                dyn_idx += 1;
+                            }
+                        }
+                        let merged = ExpressionInfo {
+                            kind: ExpressionKind::Other,
+                            references: all_refs,
+                            has_side_effects: false,
+                        };
+                        data.attr_expressions.insert(key, merged);
+                    }
+                    StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
                 }
             }
             Attribute::BindDirective(a) => {

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -225,6 +225,12 @@ impl Element {
                 expression_span: x.expression_span,
                 shorthand: x.shorthand,
             }),
+            Attribute::StyleDirective(x) => Attribute::StyleDirective(StyleDirective {
+                name: x.name.clone(),
+                expression_span: x.expression_span,
+                shorthand: x.shorthand,
+                important: x.important,
+            }),
             Attribute::BindDirective(x) => Attribute::BindDirective(BindDirective {
                 name: x.name.clone(),
                 expression_span: x.expression_span,
@@ -381,6 +387,8 @@ pub enum Attribute {
     ShorthandOrSpread(ShorthandOrSpread),
     /// class:name or class:name={expr}
     ClassDirective(ClassDirective),
+    /// style:name or style:name={expr} or style:name|important
+    StyleDirective(StyleDirective),
     /// bind:name or bind:name={expr}
     BindDirective(BindDirective),
 }
@@ -424,6 +432,14 @@ pub struct ClassDirective {
     /// Span of the JS expression. None means shorthand (class:name).
     pub expression_span: Option<Span>,
     pub shorthand: bool,
+}
+
+pub struct StyleDirective {
+    pub name: String,
+    /// Span of the JS expression. None means shorthand (style:name).
+    pub expression_span: Option<Span>,
+    pub shorthand: bool,
+    pub important: bool,
 }
 
 pub struct BindDirective {

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -227,8 +227,17 @@ impl Element {
             }),
             Attribute::StyleDirective(x) => Attribute::StyleDirective(StyleDirective {
                 name: x.name.clone(),
-                expression_span: x.expression_span,
-                shorthand: x.shorthand,
+                value: match &x.value {
+                    StyleDirectiveValue::Shorthand => StyleDirectiveValue::Shorthand,
+                    StyleDirectiveValue::Expression(span) => StyleDirectiveValue::Expression(*span),
+                    StyleDirectiveValue::String(s) => StyleDirectiveValue::String(s.clone()),
+                    StyleDirectiveValue::Concatenation(parts) => StyleDirectiveValue::Concatenation(
+                        parts.iter().map(|p| match p {
+                            ConcatPart::Static(s) => ConcatPart::Static(s.clone()),
+                            ConcatPart::Dynamic(sp) => ConcatPart::Dynamic(*sp),
+                        }).collect(),
+                    ),
+                },
                 important: x.important,
             }),
             Attribute::BindDirective(x) => Attribute::BindDirective(BindDirective {
@@ -436,10 +445,19 @@ pub struct ClassDirective {
 
 pub struct StyleDirective {
     pub name: String,
-    /// Span of the JS expression. None means shorthand (style:name).
-    pub expression_span: Option<Span>,
-    pub shorthand: bool,
+    pub value: StyleDirectiveValue,
     pub important: bool,
+}
+
+pub enum StyleDirectiveValue {
+    /// style:name — shorthand, no explicit value
+    Shorthand,
+    /// style:name={expr} — expression in braces
+    Expression(Span),
+    /// style:name="string" — static string value
+    String(String),
+    /// style:name="text{expr}text" — concatenation of static and dynamic parts
+    Concatenation(Vec<ConcatPart>),
 }
 
 pub struct BindDirective {

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -92,8 +92,8 @@ pub(crate) fn process_attr<'a>(
                 after_update.push(stmt);
             }
         }
-        Attribute::ShorthandOrSpread(_) | Attribute::ClassDirective(_) => {
-            // Spread handled by process_attrs_spread; class directives by process_class_directives
+        Attribute::ShorthandOrSpread(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => {
+            // Spread handled by process_attrs_spread; class/style directives by dedicated functions
         }
     }
 }
@@ -184,6 +184,93 @@ pub(crate) fn process_class_directives<'a>(
 
     // let classes_N;
     init.push(ctx.b.let_stmt(&classes_name));
+    // Push assignment to update vector for combined template_effect
+    update.push(ctx.b.expr_stmt(assign));
+}
+
+/// Generate `$.set_style(el, "static-style", styles_N, { ... })` for style:name directives.
+/// Pushes `let styles_N;` to `init` and the assignment to `update` for combined template_effect.
+pub(crate) fn process_style_directives<'a>(
+    ctx: &mut Ctx<'a>,
+    el: &Element,
+    el_name: &str,
+    init: &mut Vec<Statement<'a>>,
+    update: &mut Vec<Statement<'a>>,
+) {
+    if !ctx.analysis.element_has_style_directives.contains(&el.id) {
+        return;
+    }
+
+    let style_dirs: Vec<_> = el
+        .attributes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, a)| match a {
+            Attribute::StyleDirective(sd) => Some((idx, sd)),
+            _ => None,
+        })
+        .collect();
+
+    // Find static style value from precomputed span
+    let static_style = ctx
+        .analysis
+        .element_static_style
+        .get(&el.id)
+        .map(|span| ctx.component.source_text(*span).to_string())
+        .unwrap_or_default();
+
+    let mut props: Vec<ObjProp<'a>> = Vec::new();
+
+    for (attr_idx, sd) in &style_dirs {
+        let name = &sd.name;
+
+        let (expr, is_simple_ident_same_name) = if sd.expression_span.is_some() {
+            let parsed = get_attr_expr(ctx, el.id, *attr_idx);
+            let same_name = sd.expression_span
+                .map(|span| ctx.component.source_text(span).trim() == name.as_str())
+                .unwrap_or(false);
+            (parsed, same_name)
+        } else {
+            // shorthand: style:color → identifier `color`
+            (ctx.b.rid_expr(name), true)
+        };
+
+        let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
+
+        let name_alloc = ctx.b.alloc_str(name);
+
+        if is_mutated_rune {
+            let get_call = ctx.b.call_expr("$.get", [Arg::Ident(name)]);
+            props.push(ObjProp::KeyValue(name_alloc, get_call));
+        } else if is_simple_ident_same_name {
+            props.push(ObjProp::Shorthand(name_alloc));
+        } else {
+            props.push(ObjProp::KeyValue(name_alloc, expr));
+        }
+    }
+
+    let obj = ctx.b.object_expr(props);
+    let styles_name = ctx.gen_ident("styles");
+
+    // $.set_style(el, "static-style", styles_N, { ... })
+    let set_style_call = ctx.b.call_expr(
+        "$.set_style",
+        [
+            Arg::Ident(el_name),
+            Arg::Str(static_style),
+            Arg::Ident(&styles_name),
+            Arg::Expr(obj),
+        ],
+    );
+
+    // styles_N = $.set_style(...)
+    let assign = ctx.b.assign_expr(
+        AssignLeft::Ident(styles_name.clone()),
+        AssignRight::Expr(set_style_call),
+    );
+
+    // let styles_N;
+    init.push(ctx.b.let_stmt(&styles_name));
     // Push assignment to update vector for combined template_effect
     update.push(ctx.b.expr_stmt(assign));
 }
@@ -309,7 +396,7 @@ pub(crate) fn process_attrs_spread<'a>(
                 }
                 continue;
             }
-            Attribute::ClassDirective(_) => continue,
+            Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => continue,
         }
     }
 

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -1,6 +1,6 @@
 //! Attribute processing (per-attribute and spread).
 
-use oxc_ast::ast::Statement;
+use oxc_ast::ast::{Expression, Statement};
 
 use svelte_ast::{Attribute, Element, NodeId};
 
@@ -189,6 +189,7 @@ pub(crate) fn process_class_directives<'a>(
 }
 
 /// Generate `$.set_style(el, "static-style", styles_N, { ... })` for style:name directives.
+/// When `|important` is used, generates `[{ normal }, { important }]` array format.
 /// Pushes `let styles_N;` to `init` and the assignment to `update` for combined template_effect.
 pub(crate) fn process_style_directives<'a>(
     ctx: &mut Ctx<'a>,
@@ -197,6 +198,8 @@ pub(crate) fn process_style_directives<'a>(
     init: &mut Vec<Statement<'a>>,
     update: &mut Vec<Statement<'a>>,
 ) {
+    use svelte_ast::StyleDirectiveValue;
+
     if !ctx.analysis.element_has_style_directives.contains(&el.id) {
         return;
     }
@@ -219,60 +222,114 @@ pub(crate) fn process_style_directives<'a>(
         .map(|span| ctx.component.source_text(*span).to_string())
         .unwrap_or_default();
 
-    let mut props: Vec<ObjProp<'a>> = Vec::new();
+    let mut normal_props: Vec<ObjProp<'a>> = Vec::new();
+    let mut important_props: Vec<ObjProp<'a>> = Vec::new();
 
     for (attr_idx, sd) in &style_dirs {
         let name = &sd.name;
-
-        let (expr, is_simple_ident_same_name) = if sd.expression_span.is_some() {
-            let parsed = get_attr_expr(ctx, el.id, *attr_idx);
-            let same_name = sd.expression_span
-                .map(|span| ctx.component.source_text(span).trim() == name.as_str())
-                .unwrap_or(false);
-            (parsed, same_name)
-        } else {
-            // shorthand: style:color → identifier `color`
-            (ctx.b.rid_expr(name), true)
-        };
-
-        let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
-
         let name_alloc = ctx.b.alloc_str(name);
+        let target = if sd.important { &mut important_props } else { &mut normal_props };
 
-        if is_mutated_rune {
-            let get_call = ctx.b.call_expr("$.get", [Arg::Ident(name)]);
-            props.push(ObjProp::KeyValue(name_alloc, get_call));
-        } else if is_simple_ident_same_name {
-            props.push(ObjProp::Shorthand(name_alloc));
-        } else {
-            props.push(ObjProp::KeyValue(name_alloc, expr));
+        match &sd.value {
+            StyleDirectiveValue::Shorthand => {
+                let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
+                if is_mutated_rune {
+                    let get_call = ctx.b.call_expr("$.get", [Arg::Ident(name)]);
+                    target.push(ObjProp::KeyValue(name_alloc, get_call));
+                } else {
+                    target.push(ObjProp::Shorthand(name_alloc));
+                }
+            }
+            StyleDirectiveValue::Expression(span) => {
+                let parsed = get_attr_expr(ctx, el.id, *attr_idx);
+                let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
+                let expr_text = ctx.component.source_text(*span).trim();
+                let same_name = expr_text == name.as_str();
+
+                if is_mutated_rune {
+                    let get_call = ctx.b.call_expr("$.get", [Arg::Ident(name)]);
+                    target.push(ObjProp::KeyValue(name_alloc, get_call));
+                } else if same_name {
+                    target.push(ObjProp::Shorthand(name_alloc));
+                } else {
+                    target.push(ObjProp::KeyValue(name_alloc, parsed));
+                }
+            }
+            StyleDirectiveValue::String(s) => {
+                target.push(ObjProp::KeyValue(name_alloc, ctx.b.str_expr(s)));
+            }
+            StyleDirectiveValue::Concatenation(parts) => {
+                let expr = build_style_concat(ctx, el.id, *attr_idx, parts);
+                target.push(ObjProp::KeyValue(name_alloc, expr));
+            }
         }
     }
 
-    let obj = ctx.b.object_expr(props);
+    // Build the directives argument: single object or [normal, important] array
+    let directives_expr = if important_props.is_empty() {
+        ctx.b.object_expr(normal_props)
+    } else {
+        let normal_obj = ctx.b.object_expr(normal_props);
+        let important_obj = ctx.b.object_expr(important_props);
+        ctx.b.array_from_args([Arg::Expr(normal_obj), Arg::Expr(important_obj)])
+    };
+
     let styles_name = ctx.gen_ident("styles");
 
-    // $.set_style(el, "static-style", styles_N, { ... })
     let set_style_call = ctx.b.call_expr(
         "$.set_style",
         [
             Arg::Ident(el_name),
             Arg::Str(static_style),
             Arg::Ident(&styles_name),
-            Arg::Expr(obj),
+            Arg::Expr(directives_expr),
         ],
     );
 
-    // styles_N = $.set_style(...)
     let assign = ctx.b.assign_expr(
         AssignLeft::Ident(styles_name.clone()),
         AssignRight::Expr(set_style_call),
     );
 
-    // let styles_N;
     init.push(ctx.b.let_stmt(&styles_name));
-    // Push assignment to update vector for combined template_effect
     update.push(ctx.b.expr_stmt(assign));
+}
+
+/// Build a template literal for style directive concatenation values.
+/// Applies `$.get()` wrapping for mutated rune references.
+fn build_style_concat<'a>(
+    ctx: &mut Ctx<'a>,
+    owner_id: NodeId,
+    attr_idx: usize,
+    parts: &[svelte_ast::ConcatPart],
+) -> Expression<'a> {
+    use crate::builder::TemplatePart;
+    use super::expression::get_concat_part_expr;
+
+    let mut tpl_parts: Vec<TemplatePart<'a>> = Vec::new();
+    let mut dyn_idx = 0usize;
+    for part in parts {
+        match part {
+            svelte_ast::ConcatPart::Static(s) => tpl_parts.push(TemplatePart::Str(s.clone())),
+            svelte_ast::ConcatPart::Dynamic(span) => {
+                // Check if the dynamic expression is a simple mutated rune reference
+                let expr_text = ctx.component.source_text(*span).trim();
+                let is_mutated_rune = ctx.analysis.is_mutable_rune(expr_text);
+
+                if is_mutated_rune {
+                    // Replace with $.get(name) — don't consume the parsed expr
+                    let _ = get_concat_part_expr(ctx, owner_id, attr_idx, dyn_idx);
+                    let get_call = ctx.b.call_expr("$.get", [Arg::Ident(expr_text)]);
+                    tpl_parts.push(TemplatePart::Expr(get_call));
+                } else {
+                    let expr = get_concat_part_expr(ctx, owner_id, attr_idx, dyn_idx);
+                    tpl_parts.push(TemplatePart::Expr(expr));
+                }
+                dyn_idx += 1;
+            }
+        }
+    }
+    ctx.b.template_parts_expr(tpl_parts)
 }
 
 /// Generate a bind directive statement (getter/setter + runtime call).

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -317,7 +317,8 @@ fn build_style_concat<'a>(
                 let is_mutated_rune = ctx.analysis.is_mutable_rune(expr_text);
 
                 if is_mutated_rune {
-                    // Replace with $.get(name) — don't consume the parsed expr
+                    // Drain the pre-parsed expression (it's just `shade` as an identifier)
+                    // and replace with `$.get(shade)` — the rune getter call.
                     let _ = get_concat_part_expr(ctx, owner_id, attr_idx, dyn_idx);
                     let get_call = ctx.b.call_expr("$.get", [Arg::Ident(expr_text)]);
                     tpl_parts.push(TemplatePart::Expr(get_call));

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -57,7 +57,7 @@ pub(crate) fn gen_component<'a>(
             Attribute::ShorthandOrSpread(_) => AttrKind::Shorthand {
                 attr_idx: idx,
             },
-            Attribute::BindDirective(_) | Attribute::ClassDirective(_) => AttrKind::Skip,
+            Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => AttrKind::Skip,
         };
         (kind, is_dynamic)
     }).collect();

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -8,7 +8,7 @@ use svelte_ast::NodeId;
 use crate::builder::Arg;
 use crate::context::Ctx;
 
-use super::attributes::{process_attr, process_attrs_spread, process_class_directives};
+use super::attributes::{process_attr, process_attrs_spread, process_class_directives, process_style_directives};
 use super::each_block::gen_each_block;
 use super::expression::{build_concat, emit_trailing_next};
 use super::traverse::traverse_items;
@@ -60,6 +60,10 @@ pub(crate) fn process_element<'a>(
     // Class directives
     let el = ctx.element(el_id);
     process_class_directives(ctx, &el.clone_without_fragment(), el_name, init, update);
+
+    // Style directives
+    let el = ctx.element(el_id);
+    process_style_directives(ctx, &el.clone_without_fragment(), el_name, init, update);
 
     // Children
     let has_state = ctx.analysis.fragment_has_dynamic_children.contains(&child_key);

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -5,7 +5,7 @@ use scanner::{
 use svelte_span::Span;
 
 use svelte_ast::{
-    Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode,
+    Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode, StyleDirective,
     ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
     ExpressionAttribute, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
@@ -828,6 +828,19 @@ impl<'a> Parser<'a> {
                         name: cd.name.to_string(),
                         expression_span,
                         shorthand: cd.shorthand,
+                    }));
+                }
+                token::Attribute::StyleDirective(sd) => {
+                    let expression_span = if sd.shorthand {
+                        None
+                    } else {
+                        Some(sd.expression.span)
+                    };
+                    attributes.push(Attribute::StyleDirective(StyleDirective {
+                        name: sd.name.to_string(),
+                        expression_span,
+                        shorthand: sd.shorthand,
+                        important: sd.important,
                     }));
                 }
                 token::Attribute::BindDirective(bd) => {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -5,8 +5,8 @@ use scanner::{
 use svelte_span::Span;
 
 use svelte_ast::{
-    Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode, StyleDirective,
-    ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
+    Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode,
+    ConcatPart, ConcatenationAttribute, Component, EachBlock, Element, StyleDirective, StyleDirectiveValue,
     ExpressionAttribute, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
 };
@@ -831,15 +831,30 @@ impl<'a> Parser<'a> {
                     }));
                 }
                 token::Attribute::StyleDirective(sd) => {
-                    let expression_span = if sd.shorthand {
-                        None
+                    let value = if sd.shorthand {
+                        StyleDirectiveValue::Shorthand
                     } else {
-                        Some(sd.expression.span)
+                        match &sd.value {
+                            token::AttributeValue::ExpressionTag(et) => {
+                                StyleDirectiveValue::Expression(et.expression.span)
+                            }
+                            token::AttributeValue::String(s) => {
+                                StyleDirectiveValue::String(s.to_string())
+                            }
+                            token::AttributeValue::Concatenation(c) => {
+                                StyleDirectiveValue::Concatenation(
+                                    c.parts.iter().map(|p| match p {
+                                        token::ConcatenationPart::String(s) => ConcatPart::Static(s.to_string()),
+                                        token::ConcatenationPart::Expression(et) => ConcatPart::Dynamic(et.expression.span),
+                                    }).collect(),
+                                )
+                            }
+                            token::AttributeValue::Empty => StyleDirectiveValue::Shorthand,
+                        }
                     };
                     attributes.push(Attribute::StyleDirective(StyleDirective {
                         name: sd.name.to_string(),
-                        expression_span,
-                        shorthand: sd.shorthand,
+                        value,
                         important: sd.important,
                     }));
                 }

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -849,7 +849,10 @@ impl<'a> Parser<'a> {
                                     }).collect(),
                                 )
                             }
-                            token::AttributeValue::Empty => StyleDirectiveValue::Shorthand,
+                            token::AttributeValue::Empty => {
+                                debug_assert!(sd.shorthand, "Empty value on non-shorthand style directive");
+                                StyleDirectiveValue::Shorthand
+                            }
                         }
                     };
                     attributes.push(Attribute::StyleDirective(StyleDirective {

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -4,7 +4,7 @@ use std::{iter::Peekable, str::Chars, vec};
 use token::{
     Attribute, AttributeIdentifierType, AttributeValue, BindDirective, ClassDirective,
     Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, JsExpression, ScriptTag,
-    StartEachTag, StartIfTag, StartKeyTag, StartTag, Token, TokenType,
+    StartEachTag, StartIfTag, StartKeyTag, StartTag, StyleDirective, Token, TokenType,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -161,6 +161,8 @@ impl<'a> Scanner<'a> {
 
             if AttributeIdentifierType::is_class_directive(name) {
                 AttributeIdentifierType::ClassDirective(value).as_ok()
+            } else if AttributeIdentifierType::is_style_directive(name) {
+                AttributeIdentifierType::StyleDirective(value).as_ok()
             } else if AttributeIdentifierType::is_bind_directive(name) {
                 AttributeIdentifierType::BindDirective(value).as_ok()
             } else {
@@ -311,6 +313,9 @@ impl<'a> Scanner<'a> {
                     AttributeIdentifierType::ClassDirective(value) => {
                         self.class_directive(value)
                     }
+                    AttributeIdentifierType::StyleDirective(value) => {
+                        self.style_directive(value)
+                    }
                     AttributeIdentifierType::BindDirective(value) => self.bind_directive(value),
                     AttributeIdentifierType::None => break,
                 }
@@ -358,6 +363,42 @@ impl<'a> Scanner<'a> {
                 value: name,
             },
             shorthand: true,
+        }))
+    }
+
+    fn style_directive(&mut self, name: &'a str) -> Result<Attribute<'a>, Diagnostic> {
+        // Check for |important modifier
+        let important = if self.match_char('|') {
+            // Consume "important"
+            let start = self.current;
+            while self.peek().is_some_and(|c| c.is_alphabetic()) {
+                self.advance();
+            }
+            let modifier = self.slice_source(start, self.current);
+            modifier == "important"
+        } else {
+            false
+        };
+
+        if self.match_char('=') {
+            let res = self.expression_tag()?;
+
+            return Ok(Attribute::StyleDirective(StyleDirective {
+                expression: res.expression,
+                name,
+                shorthand: false,
+                important,
+            }));
+        }
+
+        Ok(Attribute::StyleDirective(StyleDirective {
+            name,
+            expression: JsExpression {
+                span: SPAN,
+                value: name,
+            },
+            shorthand: true,
+            important,
         }))
     }
 
@@ -1332,6 +1373,7 @@ mod tests {
                 Attribute::HTMLAttribute(value) => value.name,
                 Attribute::ExpressionTag(_) => "$expression",
                 Attribute::ClassDirective(_) => "$classDirective",
+                Attribute::StyleDirective(_) => "$styleDirective",
                 Attribute::BindDirective(_) => "$bindDirective",
             };
 
@@ -1339,6 +1381,7 @@ mod tests {
                 Attribute::HTMLAttribute(value) => value.value.clone(),
                 Attribute::ExpressionTag(value) => AttributeValue::String(value.expression.value),
                 Attribute::ClassDirective(cd) => AttributeValue::String(cd.expression.value),
+                Attribute::StyleDirective(sd) => AttributeValue::String(sd.expression.value),
                 Attribute::BindDirective(bd) => AttributeValue::String(bd.expression.value),
             };
 

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -374,7 +374,15 @@ impl<'a> Scanner<'a> {
                 self.advance();
             }
             let modifier = self.slice_source(start, self.current);
-            modifier == "important"
+            if modifier != "important" {
+                self.recover(Diagnostic::unknown_directive(Span::new(
+                    start as u32 - 1, // include the '|'
+                    self.current as u32,
+                )));
+                false
+            } else {
+                true
+            }
         } else {
             false
         };

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -369,7 +369,6 @@ impl<'a> Scanner<'a> {
     fn style_directive(&mut self, name: &'a str) -> Result<Attribute<'a>, Diagnostic> {
         // Check for |important modifier
         let important = if self.match_char('|') {
-            // Consume "important"
             let start = self.current;
             while self.peek().is_some_and(|c| c.is_alphabetic()) {
                 self.advance();
@@ -381,10 +380,10 @@ impl<'a> Scanner<'a> {
         };
 
         if self.match_char('=') {
-            let res = self.expression_tag()?;
+            let value = self.attribute_value()?;
 
             return Ok(Attribute::StyleDirective(StyleDirective {
-                expression: res.expression,
+                value,
                 name,
                 shorthand: false,
                 important,
@@ -393,10 +392,7 @@ impl<'a> Scanner<'a> {
 
         Ok(Attribute::StyleDirective(StyleDirective {
             name,
-            expression: JsExpression {
-                span: SPAN,
-                value: name,
-            },
+            value: AttributeValue::Empty,
             shorthand: true,
             important,
         }))
@@ -1373,7 +1369,7 @@ mod tests {
                 Attribute::HTMLAttribute(value) => value.name,
                 Attribute::ExpressionTag(_) => "$expression",
                 Attribute::ClassDirective(_) => "$classDirective",
-                Attribute::StyleDirective(_) => "$styleDirective",
+                Attribute::StyleDirective(sd) => sd.name,
                 Attribute::BindDirective(_) => "$bindDirective",
             };
 
@@ -1381,7 +1377,7 @@ mod tests {
                 Attribute::HTMLAttribute(value) => value.value.clone(),
                 Attribute::ExpressionTag(value) => AttributeValue::String(value.expression.value),
                 Attribute::ClassDirective(cd) => AttributeValue::String(cd.expression.value),
-                Attribute::StyleDirective(sd) => AttributeValue::String(sd.expression.value),
+                Attribute::StyleDirective(sd) => sd.value.clone(),
                 Attribute::BindDirective(bd) => AttributeValue::String(bd.expression.value),
             };
 

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -85,6 +85,7 @@ pub enum Attribute<'a> {
     HTMLAttribute(HTMLAttribute<'a>),
     ExpressionTag(ExpressionTag<'a>),
     ClassDirective(ClassDirective<'a>),
+    StyleDirective(StyleDirective<'a>),
     BindDirective(BindDirective<'a>),
 }
 
@@ -93,6 +94,14 @@ pub struct ClassDirective<'a> {
     pub shorthand: bool,
     pub name: &'a str,
     pub expression: JsExpression<'a>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StyleDirective<'a> {
+    pub shorthand: bool,
+    pub name: &'a str,
+    pub expression: JsExpression<'a>,
+    pub important: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -213,6 +222,7 @@ pub struct ElseTag<'a> {
 pub enum AttributeIdentifierType<'a> {
     HTMLAttribute(&'a str),
     ClassDirective(&'a str),
+    StyleDirective(&'a str),
     BindDirective(&'a str),
     None,
 }
@@ -220,6 +230,10 @@ pub enum AttributeIdentifierType<'a> {
 impl<'a> AttributeIdentifierType<'a> {
     pub fn is_class_directive(name: &str) -> bool {
         name == "class"
+    }
+
+    pub fn is_style_directive(name: &str) -> bool {
+        name == "style"
     }
 
     pub fn is_bind_directive(name: &str) -> bool {

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -100,7 +100,7 @@ pub struct ClassDirective<'a> {
 pub struct StyleDirective<'a> {
     pub shorthand: bool,
     pub name: &'a str,
-    pub expression: JsExpression<'a>,
+    pub value: AttributeValue<'a>,
     pub important: bool,
 }
 

--- a/tasks/compiler_tests/cases2/style_directive/case-rust.js
+++ b/tasks/compiler_tests/cases2/style_directive/case-rust.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>Styled</div>`);
+export default function App($$anchor) {
+	let color = "red";
+	let fontSize = "16px";
+	let bg = "blue";
+	const staticVal = "bold";
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, {
+		color,
+		"font-size": fontSize,
+		"background-color": bg,
+		"font-weight": staticVal
+	}));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/style_directive/case-svelte.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>Styled</div>`);
+export default function App($$anchor) {
+	let color = "red";
+	let fontSize = "16px";
+	let bg = "blue";
+	const staticVal = "bold";
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, {
+		color,
+		"font-size": fontSize,
+		"background-color": bg,
+		"font-weight": staticVal
+	}));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive/case.svelte
+++ b/tasks/compiler_tests/cases2/style_directive/case.svelte
@@ -1,0 +1,15 @@
+<script>
+    let color = $state('red');
+    let fontSize = $state('16px');
+    let bg = $state('blue');
+    const staticVal = 'bold';
+</script>
+
+<div
+    style:color
+    style:font-size={fontSize}
+    style:background-color={bg}
+    style:font-weight={staticVal}
+>
+    Styled
+</div>

--- a/tasks/compiler_tests/cases2/style_directive_concat/case-rust.js
+++ b/tasks/compiler_tests/cases2/style_directive_concat/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>Concat value</div>`);
+export default function App($$anchor) {
+	let shade = $.state("500");
+	$.set(shade, "600");
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, { color: `red-${$.get(shade) ?? ""}` }));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive_concat/case-svelte.js
+++ b/tasks/compiler_tests/cases2/style_directive_concat/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>Concat value</div>`);
+export default function App($$anchor) {
+	let shade = $.state("500");
+	$.set(shade, "600");
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, { color: `red-${$.get(shade) ?? ""}` }));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive_concat/case.svelte
+++ b/tasks/compiler_tests/cases2/style_directive_concat/case.svelte
@@ -1,0 +1,10 @@
+<script>
+    let shade = $state('500');
+    shade = '600';
+</script>
+
+<div
+    style:color="red-{shade}"
+>
+    Concat value
+</div>

--- a/tasks/compiler_tests/cases2/style_directive_important/case-rust.js
+++ b/tasks/compiler_tests/cases2/style_directive_important/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>Important</div>`);
+export default function App($$anchor) {
+	let color = "red";
+	let bg = "blue";
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, [{ color }, { "background-color": bg }]));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive_important/case-svelte.js
+++ b/tasks/compiler_tests/cases2/style_directive_important/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>Important</div>`);
+export default function App($$anchor) {
+	let color = "red";
+	let bg = "blue";
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, [{ color }, { "background-color": bg }]));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive_important/case.svelte
+++ b/tasks/compiler_tests/cases2/style_directive_important/case.svelte
@@ -1,0 +1,11 @@
+<script>
+    let color = $state('red');
+    let bg = $state('blue');
+</script>
+
+<div
+    style:color
+    style:background-color|important={bg}
+>
+    Important
+</div>

--- a/tasks/compiler_tests/cases2/style_directive_string/case-rust.js
+++ b/tasks/compiler_tests/cases2/style_directive_string/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>String value</div>`);
+export default function App($$anchor) {
+	let size = $.state("16px");
+	$.set(size, "20px");
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, {
+		color: "red",
+		"font-size": $.get(size)
+	}));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive_string/case-svelte.js
+++ b/tasks/compiler_tests/cases2/style_directive_string/case-svelte.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>String value</div>`);
+export default function App($$anchor) {
+	let size = $.state("16px");
+	$.set(size, "20px");
+	var div = root();
+	let styles;
+	$.template_effect(() => styles = $.set_style(div, "", styles, {
+		color: "red",
+		"font-size": $.get(size)
+	}));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/style_directive_string/case.svelte
+++ b/tasks/compiler_tests/cases2/style_directive_string/case.svelte
@@ -1,0 +1,11 @@
+<script>
+    let size = $state('16px');
+    size = '20px';
+</script>
+
+<div
+    style:color="red"
+    style:font-size={size}
+>
+    String value
+</div>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -285,3 +285,18 @@ fn key_block() {
 fn style_directive() {
     assert_compiler("style_directive");
 }
+
+#[rstest]
+fn style_directive_important() {
+    assert_compiler("style_directive_important");
+}
+
+#[rstest]
+fn style_directive_string() {
+    assert_compiler("style_directive_string");
+}
+
+#[rstest]
+fn style_directive_concat() {
+    assert_compiler("style_directive_concat");
+}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -280,3 +280,8 @@ fn html_tag() {
 fn key_block() {
     assert_compiler("key_block");
 }
+
+#[rstest]
+fn style_directive() {
+    assert_compiler("style_directive");
+}


### PR DESCRIPTION
## Summary
Adds full support for Svelte's `style:prop` directive, enabling dynamic style binding with optional `|important` modifier. This includes parsing, AST representation, analysis, and code generation.

## Key Changes

### Parser & AST
- Added `StyleDirective` token type in scanner with support for `|important` modifier parsing
- Extended `Attribute` enum with `StyleDirective` variant
- Created `StyleDirectiveValue` enum supporting four value types:
  - `Shorthand` (e.g., `style:color`)
  - `Expression` (e.g., `style:color={expr}`)
  - `String` (e.g., `style:color="red"`)
  - `Concatenation` (e.g., `style:color="red-{expr}"`)

### Analysis
- Added `element_has_style_directives` and `element_static_style` tracking in `AnalysisData`
- Extended `parse_concat_parts()` helper to handle both `ConcatenationAttribute` and `StyleDirective::Concatenation`
- Added style directive expression parsing with support for mutated rune detection

### Code Generation
- Implemented `process_style_directives()` to generate `$.set_style()` calls
- Handles `|important` modifier by generating `[{ normal }, { important }]` array format
- Supports mutated rune wrapping with `$.get()` calls
- Implemented `build_style_concat()` for template literal generation in concatenation values
- Integrated style directive processing into element code generation pipeline

### Tests
- Added four test cases covering:
  - Basic style directives with shorthand and expressions
  - `|important` modifier support
  - Static string values
  - Concatenation with dynamic expressions

## Implementation Details
- Style directives are processed similarly to class directives, using a combined `template_effect` for reactivity
- The `$.set_style()` runtime function receives: element, static style string, styles variable, and directives object/array
- Mutated runes in style values are automatically wrapped with `$.get()` for proper reactivity
- Static style attributes are extracted and passed to the runtime for optimization

https://claude.ai/code/session_01TxBJ1cCNypnUAWFiLz2fCL