### PR TITLE
Implement legacy on:directive event handler syntax

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -454,7 +454,7 @@ Theme: deprecated syntax superseded by Svelte 5 features. Only needed for migrat
 
 | Feature | Svelte 5 replacement | Transform | Phases |
 |---------|----------------------|-----------|--------|
-| `on:event={handler}` + modifiers | `onclick={handler}` (already works) | `$.event(el, "click", handler, modifiers)` | P, A, T |
+| ~~`on:event={handler}` + modifiers~~ | ~~`onclick={handler}` (already works)~~ | ~~`$.event(el, "click", handler, modifiers)`~~ | ~~P, A, T~~ | ✅ Done |
 | `<slot>` + `let:` | `{#snippet}` + `{@render}` | `$.slot(...)` | P, A, T |
 | `<svelte:component this={X}>` | `<X />` with capitalized variable | `$.component(...)` | P, A, T |
 | `<svelte:self>` | Import component directly | Recursive ref | P, T |
@@ -497,3 +497,14 @@ These are imported from `svelte` and used as regular function calls. The compile
 - **Codegen**: direct recursion, no visitor pattern
 - **Scope system NOT needed** for Tiers 1-5 (runes mode). Current approach (OXC + side tables) is sufficient
 - Each feature: test case → expected output via reference compiler → `cargo test`
+
+---
+
+## Edge Cases / Tech Debt
+
+Deferred items from completed features. Each links back to the originating tier.
+
+### on:directive (Tier 8)
+- [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis. Rare in Svelte 4 code.
+- [ ] SvelteDocument/SvelteWindow/SvelteBody routing: events on these special elements should go to `init` not `after_update`. Blocked on Tier 5 (special elements).
+- [ ] Dev-mode `$.apply()` wrapping for imported identifier handlers. Blocked on `dev` compiler option.

--- a/TODO.md
+++ b/TODO.md
@@ -4,22 +4,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 1. Event handlers (`on:event` → `onevent`)
+## 1. Void HTML elements
 
-**Why first**: базовая интерактивность уже работает через `onclick={handler}`, но `on:event` синтаксис Svelte 4 ещё не поддержан.
-
-**What to change**:
-- `svelte_parser/src/lib.rs`: парсинг `on:click={handler}` → `Attribute::OnDirective`
-- `svelte_ast/src/lib.rs`: добавить `Attribute::OnDirective { name, expression, modifiers }`
-- `svelte_codegen_client/src/template/attributes.rs`: генерация event listener
-
-**Reference**: `reference/compiler/phases/3-transform/client/visitors/shared/events.js`
-
----
-
-## 2. Void HTML elements
-
-**Why second**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
+**Why first**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
 
 **What to change**:
 - Добавить `VOID_ELEMENTS` constant и `is_void(name)` helper
@@ -30,9 +17,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 3. `{@const x = expr}` (ConstTag)
+## 2. `{@const x = expr}` (ConstTag)
 
-**Why third**: нужен для вычислений внутри {#each} и {#if} блоков.
+**Why second**: нужен для вычислений внутри {#each} и {#if} блоков.
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Node::ConstTag { id, span, declaration_span }`
@@ -44,9 +31,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 4. `$state.raw(val)` rune
+## 3. `$state.raw(val)` rune
 
-**Why fourth**: простой рун, паттерн уже есть в script.rs.
+**Why third**: простой рун, паттерн уже есть в script.rs.
 
 **What to change**:
 - `svelte_analyze/src/parse_js.rs`: добавить `RuneKind::StateRaw`
@@ -58,12 +45,26 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 5. `class` attribute — Object/array syntax (Svelte 5)
+## 4. `class` attribute — Object/array syntax (Svelte 5)
 
-**Why fifth**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
+**Why fourth**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
 
 **What to change**:
 - `svelte_parser/src/lib.rs`: detect object/array expression in `class` attribute value
 - `svelte_codegen_client/src/template/attributes.rs`: генерация `$.set_class(el, ...)`
 
 **Reference**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js`
+
+---
+
+## 5. `$state.snapshot(val)` rune
+
+**Why fifth**: простая перезапись вызова, паттерн уже есть в script.rs.
+
+**What to change**:
+- `svelte_analyze/src/parse_js.rs`: detect `$state.snapshot(val)` as inline call rewrite
+- `svelte_codegen_client/src/script.rs`: `$state.snapshot(val)` → `$.snapshot(val)`
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`
+
+**Runtime**: `$.snapshot()`

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -243,6 +243,13 @@ fn walk_attrs<'a>(
                 parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
             }
             Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_) => {}
+            // LEGACY(svelte4): on:directive — parse expression if present
+            Attribute::OnDirectiveLegacy(a) => {
+                if let Some(span) = a.expression_span {
+                    let source = component.source_text(span);
+                    parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+                }
+            }
         }
     }
 }

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -245,6 +245,12 @@ impl Element {
                 expression_span: x.expression_span,
                 shorthand: x.shorthand,
             }),
+            // LEGACY(svelte4): on:directive
+            Attribute::OnDirectiveLegacy(x) => Attribute::OnDirectiveLegacy(OnDirectiveLegacy {
+                name: x.name.clone(),
+                expression_span: x.expression_span,
+                modifiers: x.modifiers.clone(),
+            }),
         }).collect();
 
         Element {
@@ -400,6 +406,9 @@ pub enum Attribute {
     StyleDirective(StyleDirective),
     /// bind:name or bind:name={expr}
     BindDirective(BindDirective),
+    /// LEGACY(svelte4): on:event or on:event={handler} or on:event|modifier={handler}
+    /// Deprecated in Svelte 5, remove in Svelte 6.
+    OnDirectiveLegacy(OnDirectiveLegacy),
 }
 
 pub struct StringAttribute {
@@ -465,6 +474,16 @@ pub struct BindDirective {
     /// Span of the JS expression. None means shorthand (bind:name).
     pub expression_span: Option<Span>,
     pub shorthand: bool,
+}
+
+/// LEGACY(svelte4): on:directive syntax. Deprecated in Svelte 5, remove in Svelte 6.
+pub struct OnDirectiveLegacy {
+    /// Event name (e.g., "click" in `on:click`).
+    pub name: String,
+    /// Span of the JS expression. None if no expression (bubble event).
+    pub expression_span: Option<Span>,
+    /// Modifiers like "preventDefault", "stopPropagation", "capture", etc.
+    pub modifiers: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -376,6 +376,63 @@ impl<'a> Builder<'a> {
         )
     }
 
+    /// Create a function expression: `function(params) { body }`
+    pub fn function_expr(
+        &self,
+        params: FormalParameters<'a>,
+        body: Vec<Statement<'a>>,
+    ) -> Expression<'a> {
+        let body = self.ast.alloc_function_body(
+            SPAN,
+            self.ast.vec(),
+            self.ast.vec_from_iter(body),
+        );
+        Expression::FunctionExpression(self.alloc(self.ast.function(
+            SPAN,
+            FunctionType::FunctionExpression,
+            None,
+            false,
+            false,
+            false,
+            NONE,
+            NONE,
+            params,
+            NONE,
+            Some(body),
+        )))
+    }
+
+    /// Create params with a rest element: `...name`
+    pub fn rest_params(&self, name: &str) -> FormalParameters<'a> {
+        let atom = self.ast.atom(name);
+        let pattern = self.ast.binding_pattern_binding_identifier(SPAN, atom);
+        let rest_element = self.ast.binding_rest_element(SPAN, pattern);
+        let rest = self.ast.formal_parameter_rest(SPAN, self.ast.vec(), rest_element, NONE);
+        self.ast.formal_parameters(
+            SPAN,
+            ast::FormalParameterKind::FormalParameter,
+            self.ast.vec(),
+            Some(rest),
+        )
+    }
+
+    /// `this` expression
+    pub fn this_expr(&self) -> Expression<'a> {
+        self.ast.expression_this(SPAN)
+    }
+
+    /// Call expression with an arbitrary `Expression` as callee (not just a string identifier).
+    pub fn call_expr_callee<'short>(
+        &self,
+        callee: Expression<'a>,
+        args: impl IntoIterator<Item = Arg<'a, 'short>>,
+    ) -> Expression<'a> {
+        let args = args.into_iter().map(|a| self.arg_to_argument(a));
+        Expression::CallExpression(self.alloc(
+            self.ast.call_expression(SPAN, callee, NONE, self.ast.vec_from_iter(args), false),
+        ))
+    }
+
     // -----------------------------------------------------------------------
     // Member expressions
     // -----------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -95,6 +95,10 @@ pub(crate) fn process_attr<'a>(
         Attribute::ShorthandOrSpread(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => {
             // Spread handled by process_attrs_spread; class/style directives by dedicated functions
         }
+        // LEGACY(svelte4): on:directive
+        Attribute::OnDirectiveLegacy(od) => {
+            gen_on_directive_legacy(ctx, od, owner_id, attr_idx, el_name, after_update);
+        }
     }
 }
 
@@ -455,6 +459,8 @@ pub(crate) fn process_attrs_spread<'a>(
                 continue;
             }
             Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => continue,
+            // LEGACY(svelte4): on:directive handled separately
+            Attribute::OnDirectiveLegacy(_) => continue,
         }
     }
 
@@ -462,4 +468,97 @@ pub(crate) fn process_attrs_spread<'a>(
     let obj = ctx.b.object_expr(props);
     let arrow = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(obj)]);
     init.push(ctx.b.call_stmt("$.attribute_effect", [Arg::Ident(el_name), Arg::Expr(arrow)]));
+}
+
+// ---------------------------------------------------------------------------
+// LEGACY(svelte4): on:directive codegen
+// ---------------------------------------------------------------------------
+
+/// Generate `$.event()` calls for legacy `on:directive` syntax.
+/// Reference: `OnDirective.js` + `shared/events.js` (`build_event`, `build_event_handler`).
+fn gen_on_directive_legacy<'a>(
+    ctx: &mut Ctx<'a>,
+    od: &svelte_ast::OnDirectiveLegacy,
+    owner_id: NodeId,
+    attr_idx: usize,
+    el_name: &str,
+    after_update: &mut Vec<Statement<'a>>,
+) {
+    // --- Build event handler ---
+    let handler = if od.expression_span.is_none() {
+        // Bubble event: function($$arg) { $.bubble_event.call(this, $$props, $$arg) }
+        let bubble_call = ctx.b.static_member_expr(
+            ctx.b.rid_expr("$.bubble_event"),
+            "call",
+        );
+        let call = ctx.b.call_expr_callee(bubble_call, [
+            Arg::Expr(ctx.b.this_expr()),
+            Arg::Ident("$$props"),
+            Arg::Ident("$$arg"),
+        ]);
+        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
+    } else {
+        let expr = get_attr_expr(ctx, owner_id, attr_idx);
+        build_legacy_event_handler(ctx, expr)
+    };
+
+    // --- Apply modifier wrappers (order matches Svelte reference) ---
+    let mut wrapped = handler;
+    for modifier in &[
+        "stopPropagation",
+        "stopImmediatePropagation",
+        "preventDefault",
+        "self",
+        "trusted",
+        "once",
+    ] {
+        if od.modifiers.iter().any(|m| m == modifier) {
+            let fn_name = format!("$.{}", modifier);
+            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
+        }
+    }
+
+    // --- Build $.event() call ---
+    let capture = od.modifiers.iter().any(|m| m == "capture");
+    let passive = if od.modifiers.iter().any(|m| m == "passive") {
+        Some(true)
+    } else if od.modifiers.iter().any(|m| m == "nonpassive") {
+        Some(false)
+    } else {
+        None
+    };
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Str(od.name.clone()),
+        Arg::Ident(el_name),
+        Arg::Expr(wrapped),
+    ];
+    if capture || passive.is_some() {
+        args.push(Arg::Bool(capture));
+    }
+    if let Some(p) = passive {
+        args.push(Arg::Bool(p));
+    }
+
+    after_update.push(ctx.b.call_stmt("$.event", args));
+}
+
+/// Build event handler for legacy on:directive (non-dev mode).
+/// Reference: `events.js` `build_event_handler()`.
+fn build_legacy_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
+    match &handler {
+        // Inline arrow/function — pass through
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
+        // Identifier — pass through in non-dev mode
+        Expression::Identifier(_) => handler,
+        // Other expressions (member, conditional, etc.) — wrap in function(...$$args) { handler.apply(this, $$args) }
+        _ => {
+            let apply = ctx.b.static_member_expr(handler, "apply");
+            let call = ctx.b.call_expr_callee(apply, [
+                Arg::Expr(ctx.b.this_expr()),
+                Arg::Ident("$$args"),
+            ]);
+            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
+        }
+    }
 }

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -57,7 +57,8 @@ pub(crate) fn gen_component<'a>(
             Attribute::ShorthandOrSpread(_) => AttrKind::Shorthand {
                 attr_idx: idx,
             },
-            Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => AttrKind::Skip,
+            Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_)
+            | Attribute::OnDirectiveLegacy(_) => AttrKind::Skip,
         };
         (kind, is_dynamic)
     }).collect();

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -6,7 +6,7 @@ use svelte_span::Span;
 
 use svelte_ast::{
     Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode,
-    ConcatPart, ConcatenationAttribute, Component, EachBlock, Element, StyleDirective, StyleDirectiveValue,
+    ConcatPart, ConcatenationAttribute, Component, EachBlock, Element, OnDirectiveLegacy, StyleDirective, StyleDirectiveValue,
     ExpressionAttribute, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
 };
@@ -871,6 +871,19 @@ impl<'a> Parser<'a> {
                         name: bd.name.to_string(),
                         expression_span,
                         shorthand: bd.shorthand,
+                    }));
+                }
+                // LEGACY(svelte4): on:directive
+                token::Attribute::OnDirectiveLegacy(od) => {
+                    let expression_span = if od.has_expression {
+                        Some(od.expression.span)
+                    } else {
+                        None
+                    };
+                    attributes.push(Attribute::OnDirectiveLegacy(OnDirectiveLegacy {
+                        name: od.name.to_string(),
+                        expression_span,
+                        modifiers: od.modifiers.iter().map(|m| m.to_string()).collect(),
                     }));
                 }
             }

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -3,8 +3,8 @@ pub mod token;
 use std::{iter::Peekable, str::Chars, vec};
 use token::{
     Attribute, AttributeIdentifierType, AttributeValue, BindDirective, ClassDirective,
-    Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, JsExpression, ScriptTag,
-    StartEachTag, StartIfTag, StartKeyTag, StartTag, StyleDirective, Token, TokenType,
+    Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, JsExpression, OnDirectiveLegacy,
+    ScriptTag, StartEachTag, StartIfTag, StartKeyTag, StartTag, StyleDirective, Token, TokenType,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -165,6 +165,9 @@ impl<'a> Scanner<'a> {
                 AttributeIdentifierType::StyleDirective(value).as_ok()
             } else if AttributeIdentifierType::is_bind_directive(name) {
                 AttributeIdentifierType::BindDirective(value).as_ok()
+            // LEGACY(svelte4): on:directive
+            } else if AttributeIdentifierType::is_on_directive(name) {
+                AttributeIdentifierType::OnDirectiveLegacy(value).as_ok()
             } else {
                 Diagnostic::unknown_directive(Span::new(colon_pos as u32, self.current as u32)).as_err()
             }
@@ -317,6 +320,8 @@ impl<'a> Scanner<'a> {
                         self.style_directive(value)
                     }
                     AttributeIdentifierType::BindDirective(value) => self.bind_directive(value),
+                    // LEGACY(svelte4): on:directive
+                    AttributeIdentifierType::OnDirectiveLegacy(value) => self.on_directive_legacy(value),
                     AttributeIdentifierType::None => break,
                 }
             };
@@ -424,6 +429,39 @@ impl<'a> Scanner<'a> {
                 value: name,
             },
             shorthand: true,
+        }))
+    }
+
+    /// LEGACY(svelte4): Parse `on:event|modifier1|modifier2={handler}` or `on:event` (bubble).
+    fn on_directive_legacy(&mut self, name: &'a str) -> Result<Attribute<'a>, Diagnostic> {
+        let mut modifiers = Vec::new();
+        while self.match_char('|') {
+            let start = self.current;
+            while self.peek().is_some_and(|c| c.is_alphabetic() || c == '_') {
+                self.advance();
+            }
+            modifiers.push(self.slice_source(start, self.current));
+        }
+
+        if self.match_char('=') {
+            let res = self.expression_tag()?;
+            return Ok(Attribute::OnDirectiveLegacy(OnDirectiveLegacy {
+                name,
+                expression: res.expression,
+                modifiers,
+                has_expression: true,
+            }));
+        }
+
+        // No expression — bubble event
+        Ok(Attribute::OnDirectiveLegacy(OnDirectiveLegacy {
+            name,
+            expression: JsExpression {
+                span: SPAN,
+                value: "",
+            },
+            modifiers,
+            has_expression: false,
         }))
     }
 
@@ -1379,6 +1417,7 @@ mod tests {
                 Attribute::ClassDirective(_) => "$classDirective",
                 Attribute::StyleDirective(sd) => sd.name,
                 Attribute::BindDirective(_) => "$bindDirective",
+                Attribute::OnDirectiveLegacy(od) => od.name,
             };
 
             let value: AttributeValue = match attribute {
@@ -1387,6 +1426,7 @@ mod tests {
                 Attribute::ClassDirective(cd) => AttributeValue::String(cd.expression.value),
                 Attribute::StyleDirective(sd) => sd.value.clone(),
                 Attribute::BindDirective(bd) => AttributeValue::String(bd.expression.value),
+                Attribute::OnDirectiveLegacy(od) => AttributeValue::String(od.expression.value),
             };
 
             assert_eq!(name, *expected_name);

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -87,6 +87,8 @@ pub enum Attribute<'a> {
     ClassDirective(ClassDirective<'a>),
     StyleDirective(StyleDirective<'a>),
     BindDirective(BindDirective<'a>),
+    /// LEGACY(svelte4): on:directive syntax. Deprecated in Svelte 5, remove in Svelte 6.
+    OnDirectiveLegacy(OnDirectiveLegacy<'a>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -109,6 +111,19 @@ pub struct BindDirective<'a> {
     pub shorthand: bool,
     pub name: &'a str,
     pub expression: JsExpression<'a>,
+}
+
+/// LEGACY(svelte4): on:directive syntax. Deprecated in Svelte 5, remove in Svelte 6.
+#[derive(Debug, PartialEq, Eq)]
+pub struct OnDirectiveLegacy<'a> {
+    /// Event name after "on:" (e.g., "click" in `on:click`).
+    pub name: &'a str,
+    /// Handler expression. Empty if bubble event (no `={...}`).
+    pub expression: JsExpression<'a>,
+    /// Modifiers from pipe-separated list (e.g., ["preventDefault", "once"]).
+    pub modifiers: Vec<&'a str>,
+    /// Whether an expression was provided (`on:click={handler}` vs `on:click`).
+    pub has_expression: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -224,6 +239,8 @@ pub enum AttributeIdentifierType<'a> {
     ClassDirective(&'a str),
     StyleDirective(&'a str),
     BindDirective(&'a str),
+    /// LEGACY(svelte4): on:directive
+    OnDirectiveLegacy(&'a str),
     None,
 }
 
@@ -238,6 +255,11 @@ impl<'a> AttributeIdentifierType<'a> {
 
     pub fn is_bind_directive(name: &str) -> bool {
         name == "bind"
+    }
+
+    /// LEGACY(svelte4): on:directive
+    pub fn is_on_directive(name: &str) -> bool {
+        name == "on"
     }
 
     pub fn is_empty(&self) -> bool {

--- a/tasks/compiler_tests/cases2/on_directive/case-rust.js
+++ b/tasks/compiler_tests/cases2/on_directive/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>Click me</button>`);
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	var button = root();
+	$.event("click", button, handleClick);
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/on_directive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/on_directive/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>Click me</button>`);
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	var button = root();
+	$.event("click", button, handleClick);
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/on_directive/case.svelte
+++ b/tasks/compiler_tests/cases2/on_directive/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleClick() {
+		console.log('clicked');
+	}
+</script>
+
+<button on:click={handleClick}>Click me</button>

--- a/tasks/compiler_tests/cases2/on_directive_modifiers/case-rust.js
+++ b/tasks/compiler_tests/cases2/on_directive_modifiers/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>Click me</button>`);
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	var button = root();
+	$.event("click", button, $.preventDefault(handleClick));
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/on_directive_modifiers/case-svelte.js
+++ b/tasks/compiler_tests/cases2/on_directive_modifiers/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>Click me</button>`);
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	var button = root();
+	$.event("click", button, $.preventDefault(handleClick));
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/on_directive_modifiers/case.svelte
+++ b/tasks/compiler_tests/cases2/on_directive_modifiers/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleClick() {
+		console.log('clicked');
+	}
+</script>
+
+<button on:click|preventDefault={handleClick}>Click me</button>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -300,3 +300,13 @@ fn style_directive_string() {
 fn style_directive_concat() {
     assert_compiler("style_directive_concat");
 }
+
+#[rstest]
+fn on_directive() {
+    assert_compiler("on_directive");
+}
+
+#[rstest]
+fn on_directive_modifiers() {
+    assert_compiler("on_directive_modifiers");
+}

--- a/tasks/generate_test_cases/generate.mjs
+++ b/tasks/generate_test_cases/generate.mjs
@@ -1,7 +1,9 @@
 import { compile } from "svelte/compiler";
 import { readFileSync } from "node:fs";
 
-const files = JSON.parse(readFileSync("/dev/stdin", "utf8"));
+// Read from temp file written by the Rust caller, or fall back to /dev/stdin
+const inputPath = process.env.INPUT_FILE || "/dev/stdin";
+const files = JSON.parse(readFileSync(inputPath, "utf8"));
 const results = {};
 for (const file of files) {
   const text = readFileSync(file, "utf8");

--- a/tasks/generate_test_cases/src/main.rs
+++ b/tasks/generate_test_cases/src/main.rs
@@ -15,18 +15,21 @@ fn main() {
 
     let input_json = serde_json::to_string(&files).unwrap();
 
+    // Write input to temp file since /dev/stdin may not be available
+    let tmp_input = std::env::temp_dir().join("svelte_gen_input.json");
+    std::fs::write(&tmp_input, &input_json).expect("Failed to write temp input file");
+
     let output = Command::new("node")
         .arg("./tasks/generate_test_cases/generate.mjs")
-        .stdin(std::process::Stdio::piped())
+        .env("INPUT_FILE", &tmp_input)
+        .env("NODE_PATH", "./tasks/generate_test_cases/node_modules")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .and_then(|mut child| {
-            use std::io::Write as _;
-            child.stdin.take().unwrap().write_all(input_json.as_bytes())?;
-            child.wait_with_output()
-        })
+        .and_then(|child| child.wait_with_output())
         .expect("Failed to run node generate.mjs");
+
+    let _ = std::fs::remove_file(&tmp_input);
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Summary
Add support for Svelte 4's `on:event` directive syntax with modifiers, generating `$.event()` calls at runtime. This is marked as legacy (deprecated in Svelte 5) but needed for migration support.

## Key Changes

**Parser & AST**
- Added `OnDirectiveLegacy` token type in `svelte_parser` to parse `on:event|modifier={handler}` syntax
- Added `OnDirectiveLegacy` AST node in `svelte_ast` with fields for event name, expression span, and modifiers
- Parser converts token to AST, preserving expression span for analysis

**Codegen**
- Implemented `gen_on_directive_legacy()` in `svelte_codegen_client` to generate `$.event()` calls
- Supports bubble events (no handler expression) via `$.bubble_event.call()`
- Applies modifier wrappers in correct order: `stopPropagation`, `stopImmediatePropagation`, `preventDefault`, `self`, `trusted`, `once`
- Handles `capture` and `passive`/`nonpassive` modifiers as boolean flags to `$.event()`
- Implemented `build_legacy_event_handler()` to wrap non-function expressions with `.apply()`

**Builder Utilities**
- Added `function_expr()` to create function expressions with parameters and body
- Added `rest_params()` to create rest parameter syntax (`...name`)
- Added `this_expr()` for `this` keyword
- Added `call_expr_callee()` to support arbitrary expressions as call targets

**Analysis**
- Updated `svelte_analyze` to parse expressions in `on:directive` attributes

**Tests**
- Added test cases for basic `on:click={handler}` and `on:click|preventDefault={handler}`
- Fixed `generate_test_cases` to use temp file instead of `/dev/stdin` for better portability

**Documentation**
- Updated TODO.md and ROADMAP.md to mark `on:directive` as completed
- Added edge cases section for future optimizations (call memoization, special element routing)

## Implementation Details
- Event handlers are placed in `after_update` phase (matching Svelte reference)
- Bubble events (no `={...}`) generate `function($$arg) { $.bubble_event.call(this, $$props, $$arg) }`
- Non-function expressions wrapped with `.apply()` to preserve `this` context
- Modifiers applied as nested function calls before passing to `$.event()`

https://claude.ai/code/session_01QQtYm26TpXYMGdUryyEpEQ