### PR TITLE
feat: support void HTML elements without explicit />

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,23 +57,17 @@ Current work items: see `TODO.md`.
 
 ---
 
-## Tier 0 — Parser Fundamentals
+## Tier 0 — Parser Fundamentals ✅
 
 Theme: critical parser capabilities needed for correct HTML handling. Without these, common valid HTML fails to parse.
 
-### Void (self-closing) HTML elements
+### ~~Void (self-closing) HTML elements~~ ✅
 - **Phases**: P, V
-- **Priority**: High — `<input>`, `<br>`, `<img>` etc. without explicit `/>` currently fail to parse
-- **Problem**: Parser only recognizes explicit `/>` syntax as self-closing. `<input>` (without `/`) is treated as an opening tag expecting `</input>`, which produces a spurious error
-- **Void elements**: `area`, `base`, `br`, `col`, `command`, `embed`, `hr`, `img`, `input`, `keygen`, `link`, `meta`, `param`, `source`, `track`, `wbr`, `!doctype`
 - **Work items**:
-  1. Add `VOID_ELEMENTS` constant and `is_void(name)` helper
-  2. In scanner/parser: auto-set `self_closing: true` when tag name is void (even without `/>`)
-  3. Validation: emit error on `</input>` and similar (closing tag for void element) — `void_element_invalid_content`
-  4. Validation: emit error if void element has children
-- **Ref**: `reference/compiler/phases/1-parse/state/element.js` line 371: `const self_closing = parser.eat('/') || is_void(tag.name);`
-- **Ref**: `reference/compiler/utils.js` — `is_void()`, `VOID_ELEMENT_NAMES`
-- **Infrastructure**: `self_closing` field already exists in `Element` AST node, codegen handles it correctly
+  1. [x] Add `VOID_ELEMENTS` constant and `is_void(name)` helper
+  2. [x] In scanner/parser: auto-set `self_closing: true` when tag name is void (even without `/>`)
+  3. [x] Validation: emit error on `</input>` and similar (closing tag for void element) — `void_element_invalid_content`
+  4. [ ] Validation: emit error if void element has children (deferred — requires parser-level check for content between void open tags)
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,22 +4,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 1. Void HTML elements
+## 1. `{@const x = expr}` (ConstTag)
 
-**Why first**: `<input>`, `<br>`, `<img>` без `/>` сейчас не парсятся — критично для валидного HTML.
-
-**What to change**:
-- Добавить `VOID_ELEMENTS` constant и `is_void(name)` helper
-- В scanner/parser: auto-set `self_closing: true` для void elements
-- Validation: ошибка на `</input>` и child-контент внутри void elements
-
-**Reference**: `reference/compiler/phases/1-parse/state/element.js` line 371, `reference/compiler/utils.js`
-
----
-
-## 2. `{@const x = expr}` (ConstTag)
-
-**Why second**: нужен для вычислений внутри {#each} и {#if} блоков.
+**Why first**: нужен для вычислений внутри {#each} и {#if} блоков.
 
 **What to change**:
 - `svelte_ast/src/lib.rs`: добавить `Node::ConstTag { id, span, declaration_span }`
@@ -31,9 +18,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 3. `$state.raw(val)` rune
+## 2. `$state.raw(val)` rune
 
-**Why third**: простой рун, паттерн уже есть в script.rs.
+**Why second**: простой рун, паттерн уже есть в script.rs.
 
 **What to change**:
 - `svelte_analyze/src/parse_js.rs`: добавить `RuneKind::StateRaw`
@@ -45,9 +32,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 4. `class` attribute — Object/array syntax (Svelte 5)
+## 3. `class` attribute — Object/array syntax (Svelte 5)
 
-**Why fourth**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
+**Why third**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
 
 **What to change**:
 - `svelte_parser/src/lib.rs`: detect object/array expression in `class` attribute value
@@ -57,9 +44,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 5. `$state.snapshot(val)` rune
+## 4. `$state.snapshot(val)` rune
 
-**Why fifth**: простая перезапись вызова, паттерн уже есть в script.rs.
+**Why fourth**: простая перезапись вызова, паттерн уже есть в script.rs.
 
 **What to change**:
 - `svelte_analyze/src/parse_js.rs`: detect `$state.snapshot(val)` as inline call rewrite
@@ -68,3 +55,17 @@ Next 5 features to implement, in priority order.
 **Reference**: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`
 
 **Runtime**: `$.snapshot()`
+
+---
+
+## 5. `$effect.tracking()` rune
+
+**Why fifth**: тривиальная перезапись вызова, без аргументов.
+
+**What to change**:
+- `svelte_analyze/src/parse_js.rs`: detect `$effect.tracking()` as inline call rewrite
+- `svelte_codegen_client/src/script.rs`: `$effect.tracking()` → `$.effect_tracking()`
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`
+
+**Runtime**: `$.effect_tracking()`

--- a/crates/svelte_diagnostics/src/lib.rs
+++ b/crates/svelte_diagnostics/src/lib.rs
@@ -27,6 +27,7 @@ pub enum DiagnosticKind {
     UnknownDirective,
     NoEachBlockToClose,
     NoKeyBlockToClose,
+    VoidElementInvalidContent,
     // Internal compiler errors
     InternalError(String),
 }
@@ -115,6 +116,10 @@ impl Diagnostic {
 
     pub fn no_key_block_to_close(span: Span) -> Self {
         Self::error(DiagnosticKind::NoKeyBlockToClose, span)
+    }
+
+    pub fn void_element_invalid_content(span: Span) -> Self {
+        Self::error(DiagnosticKind::VoidElementInvalidContent, span)
     }
 
     pub fn internal_error(message: String) -> Self {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -348,6 +348,17 @@ impl<'a> Parser<'a> {
         entry_stack: &mut Vec<StackEntry>,
         children_stack: &mut Vec<Vec<Node>>,
     ) {
+        // Void elements cannot have closing tags
+        if scanner::is_void(tag.name) {
+            self.recover(Diagnostic::void_element_invalid_content(span));
+            let node = Node::Error(svelte_ast::ErrorNode {
+                id: self.ids.next(),
+                span,
+            });
+            push_child(children_stack, node);
+            return;
+        }
+
         // Try to find a matching element in the stack
         let match_idx = entry_stack.iter().rposition(|e| {
             matches!(e, StackEntry::Element(el) if el.name == tag.name)
@@ -1367,5 +1378,60 @@ mod tests {
         let (c, diags) = parse_with_diagnostics("{#each items as item}content");
         assert!(!diags.is_empty());
         assert_eq!(c.fragment.nodes.len(), 1);
+    }
+
+    fn assert_element(c: &Component, index: usize, name: &str, self_closing: bool) {
+        if let Node::Element(ref el) = c.fragment.nodes[index] {
+            assert_eq!(el.name, name, "expected element name '{name}'");
+            assert_eq!(el.self_closing, self_closing, "expected self_closing={self_closing} for <{name}>");
+        } else {
+            panic!("expected Element at index {index}");
+        }
+    }
+
+    #[test]
+    fn void_element_without_slash() {
+        let c = parse("<input>");
+        assert_element(&c, 0, "input", true);
+    }
+
+    #[test]
+    fn void_element_with_slash() {
+        let c = parse("<input />");
+        assert_element(&c, 0, "input", true);
+    }
+
+    #[test]
+    fn void_element_with_attributes() {
+        let c = parse(r#"<input type="text">"#);
+        assert_element(&c, 0, "input", true);
+    }
+
+    #[test]
+    fn void_element_br() {
+        let c = parse("<br>");
+        assert_element(&c, 0, "br", true);
+    }
+
+    #[test]
+    fn void_element_img() {
+        let c = parse(r#"<img src="x.png">"#);
+        assert_element(&c, 0, "img", true);
+    }
+
+    #[test]
+    fn void_element_closing_tag_error() {
+        let (_, diags) = parse_with_diagnostics("</input>");
+        assert!(!diags.is_empty());
+        assert!(diags.iter().any(|d| d.kind == svelte_diagnostics::DiagnosticKind::VoidElementInvalidContent));
+    }
+
+    #[test]
+    fn void_element_multiple() {
+        let c = parse("<input><br><hr>");
+        assert_eq!(c.fragment.nodes.len(), 3);
+        assert_element(&c, 0, "input", true);
+        assert_element(&c, 1, "br", true);
+        assert_element(&c, 2, "hr", true);
     }
 }

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -1,6 +1,16 @@
 pub mod token;
 
 use std::{iter::Peekable, str::Chars, vec};
+
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link",
+    "meta", "param", "source", "track", "wbr",
+];
+
+pub fn is_void(name: &str) -> bool {
+    VOID_ELEMENTS.contains(&name)
+}
+
 use token::{
     Attribute, AttributeIdentifierType, AttributeValue, BindDirective, ClassDirective,
     Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, JsExpression, OnDirectiveLegacy,
@@ -245,7 +255,7 @@ impl<'a> Scanner<'a> {
         }
 
         let attributes = self.attributes()?;
-        let self_closing = self.match_char('/');
+        let self_closing = self.match_char('/') || is_void(name);
 
         if !self.match_char('>') {
             // Emit partial StartTag with recovery — parser-level will handle auto-close
@@ -1634,7 +1644,7 @@ mod tests {
             &tokens[0],
             "input",
             vec![("$bindDirective", "name")],
-            false,
+            true,
         );
     }
 
@@ -1646,7 +1656,7 @@ mod tests {
             &tokens[0],
             "input",
             vec![("$bindDirective", "value")],
-            false,
+            true,
         );
     }
 

--- a/tasks/compiler_tests/cases2/void_elements/case-rust.js
+++ b/tasks/compiler_tests/cases2/void_elements/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="text"/> <br/> <img src="test.png"/> <hr/>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(6);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/void_elements/case-svelte.js
+++ b/tasks/compiler_tests/cases2/void_elements/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="text"/> <br/> <img src="test.png"/> <hr/>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(6);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/void_elements/case.svelte
+++ b/tasks/compiler_tests/cases2/void_elements/case.svelte
@@ -1,0 +1,4 @@
+<input type="text">
+<br>
+<img src="test.png">
+<hr>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -310,3 +310,8 @@ fn on_directive() {
 fn on_directive_modifiers() {
     assert_compiler("on_directive_modifiers");
 }
+
+#[rstest]
+fn void_elements() {
+    assert_compiler("void_elements");
+}


### PR DESCRIPTION
Add is_void() helper and VOID_ELEMENTS constant so <input>, <br>, <img>
etc. are automatically treated as self-closing without requiring />.
Emit VoidElementInvalidContent error on closing tags like </input>.

https://claude.ai/code/session_01MsrGDWjyvmbH47CHwT43AP