### PR TITLE
Add diagnostic error codes, messages, and code frames

### DIFF
--- a/crates/svelte_diagnostics/src/lib.rs
+++ b/crates/svelte_diagnostics/src/lib.rs
@@ -32,6 +32,99 @@ pub enum DiagnosticKind {
     InternalError(String),
 }
 
+impl DiagnosticKind {
+    /// Returns the snake_case error code for this diagnostic.
+    /// Matches official Svelte error codes where applicable.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnexpectedEndOfFile => "unexpected_eof",
+            Self::InvalidTagName => "tag_invalid_name",
+            Self::UnterminatedStartTag => "unterminated_start_tag",
+            Self::InvalidAttributeName => "attribute_invalid_name",
+            Self::UnexpectedToken => "unexpected_token",
+            Self::UnexpectedKeyword => "unexpected_reserved_word",
+            Self::NoElementToClose => "element_invalid_closing_tag",
+            Self::UnclosedNode => "element_unclosed",
+            Self::InvalidExpression => "invalid_expression",
+            Self::NoIfBlockToClose => "block_unexpected_close",
+            Self::NoIfBlockForElse => "block_unexpected_close",
+            Self::OnlyOneTopLevelScript => "script_duplicate",
+            Self::OnlyOneTopLevelStyle => "style_duplicate",
+            Self::UnknownDirective => "unknown_directive",
+            Self::NoEachBlockToClose => "block_unexpected_close",
+            Self::NoKeyBlockToClose => "block_unexpected_close",
+            Self::VoidElementInvalidContent => "void_element_invalid_content",
+            Self::InternalError(_) => "internal_error",
+        }
+    }
+
+    /// Returns a human-readable error message.
+    pub fn message(&self) -> String {
+        match self {
+            Self::UnexpectedEndOfFile => "Unexpected end of input".into(),
+            Self::InvalidTagName => {
+                "Expected a valid element or component name".into()
+            }
+            Self::UnterminatedStartTag => "Start tag is not terminated".into(),
+            Self::InvalidAttributeName => "Invalid attribute name".into(),
+            Self::UnexpectedToken => "Unexpected token".into(),
+            Self::UnexpectedKeyword => "Unexpected reserved word".into(),
+            Self::NoElementToClose => {
+                "Attempted to close an element that was not open".into()
+            }
+            Self::UnclosedNode => "Element was left open".into(),
+            Self::InvalidExpression => "Invalid expression".into(),
+            Self::NoIfBlockToClose => {
+                "Unexpected {/if} \u{2014} there is no matching {#if}".into()
+            }
+            Self::NoIfBlockForElse => {
+                "Unexpected {:else} \u{2014} there is no matching {#if}".into()
+            }
+            Self::OnlyOneTopLevelScript => {
+                "A component can have a single top-level <script> element".into()
+            }
+            Self::OnlyOneTopLevelStyle => {
+                "A component can have a single top-level <style> element".into()
+            }
+            Self::UnknownDirective => "Unknown directive".into(),
+            Self::NoEachBlockToClose => {
+                "Unexpected {/each} \u{2014} there is no matching {#each}".into()
+            }
+            Self::NoKeyBlockToClose => {
+                "Unexpected {/key} \u{2014} there is no matching {#key}".into()
+            }
+            Self::VoidElementInvalidContent => {
+                "Void elements cannot have children or closing tags".into()
+            }
+            Self::InternalError(msg) => format!("Internal compiler error: {msg}"),
+        }
+    }
+
+    /// Returns a link to the Svelte documentation for this error, if one exists.
+    pub fn svelte_doc_url(&self) -> Option<String> {
+        let code = self.code();
+        match self {
+            // These codes have matching pages on svelte.dev
+            Self::UnexpectedEndOfFile
+            | Self::InvalidTagName
+            | Self::InvalidAttributeName
+            | Self::UnexpectedKeyword
+            | Self::NoElementToClose
+            | Self::UnclosedNode
+            | Self::NoIfBlockToClose
+            | Self::NoIfBlockForElse
+            | Self::OnlyOneTopLevelScript
+            | Self::OnlyOneTopLevelStyle
+            | Self::NoEachBlockToClose
+            | Self::NoKeyBlockToClose
+            | Self::VoidElementInvalidContent => {
+                Some(format!("https://svelte.dev/e/{code}"))
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, serde::Serialize)]
 pub struct Diagnostic {
     pub kind: DiagnosticKind,
@@ -41,7 +134,11 @@ pub struct Diagnostic {
 
 impl fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.kind)
+        write!(f, "{}", self.kind.message())?;
+        if let Some(url) = self.kind.svelte_doc_url() {
+            write!(f, "\n{url}")?;
+        }
+        Ok(())
     }
 }
 
@@ -160,5 +257,192 @@ impl LineIndex {
             .saturating_sub(1);
         let col = offset - self.line_starts[line];
         (line, col)
+    }
+
+    /// Renders a code frame showing ±2 lines of context around the error.
+    /// Returns `None` if the span is out of bounds.
+    pub fn code_frame(&self, source: &str, span: Span) -> Option<String> {
+        let total_lines = self.line_starts.len();
+        if total_lines == 0 {
+            return None;
+        }
+
+        let (error_line, error_col) = self.line_col(span.start as usize);
+
+        let frame_start = error_line.saturating_sub(2);
+        let frame_end = (error_line + 3).min(total_lines);
+
+        let lines: Vec<&str> = source.split('\n').collect();
+        if error_line >= lines.len() {
+            return None;
+        }
+
+        let max_line_num = frame_end; // 1-based
+        let gutter_width = max_line_num.to_string().len();
+
+        let mut out = String::new();
+        for i in frame_start..frame_end {
+            if i >= lines.len() {
+                break;
+            }
+            let line_num = i + 1; // 1-based
+            let display_line = lines[i].replace('\t', "  ");
+
+            if i == error_line {
+                out.push_str(&format!(
+                    "{:>width$} | {}\n",
+                    line_num,
+                    display_line,
+                    width = gutter_width
+                ));
+                // Add pointer line
+                let pointer_col = lines[i][..error_col.min(lines[i].len())]
+                    .chars()
+                    .map(|c| if c == '\t' { 2 } else { 1 })
+                    .sum::<usize>();
+                out.push_str(&format!(
+                    "{:>width$} | {}^\n",
+                    "",
+                    " ".repeat(pointer_col),
+                    width = gutter_width
+                ));
+            } else {
+                out.push_str(&format!(
+                    "{:>width$} | {}\n",
+                    line_num,
+                    display_line,
+                    width = gutter_width
+                ));
+            }
+        }
+
+        // Remove trailing newline
+        if out.ends_with('\n') {
+            out.pop();
+        }
+
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes() {
+        assert_eq!(DiagnosticKind::UnexpectedEndOfFile.code(), "unexpected_eof");
+        assert_eq!(DiagnosticKind::InvalidTagName.code(), "tag_invalid_name");
+        assert_eq!(
+            DiagnosticKind::NoElementToClose.code(),
+            "element_invalid_closing_tag"
+        );
+        assert_eq!(DiagnosticKind::UnclosedNode.code(), "element_unclosed");
+        assert_eq!(DiagnosticKind::OnlyOneTopLevelScript.code(), "script_duplicate");
+        assert_eq!(DiagnosticKind::OnlyOneTopLevelStyle.code(), "style_duplicate");
+        assert_eq!(
+            DiagnosticKind::VoidElementInvalidContent.code(),
+            "void_element_invalid_content"
+        );
+        assert_eq!(
+            DiagnosticKind::InternalError("test".into()).code(),
+            "internal_error"
+        );
+    }
+
+    #[test]
+    fn error_messages() {
+        assert_eq!(
+            DiagnosticKind::UnexpectedEndOfFile.message(),
+            "Unexpected end of input"
+        );
+        assert_eq!(
+            DiagnosticKind::NoIfBlockToClose.message(),
+            "Unexpected {/if} \u{2014} there is no matching {#if}"
+        );
+        assert_eq!(
+            DiagnosticKind::InternalError("oops".into()).message(),
+            "Internal compiler error: oops"
+        );
+    }
+
+    #[test]
+    fn svelte_doc_urls() {
+        // Has Svelte doc page
+        assert_eq!(
+            DiagnosticKind::UnexpectedEndOfFile.svelte_doc_url(),
+            Some("https://svelte.dev/e/unexpected_eof".into())
+        );
+        assert_eq!(
+            DiagnosticKind::VoidElementInvalidContent.svelte_doc_url(),
+            Some("https://svelte.dev/e/void_element_invalid_content".into())
+        );
+
+        // No Svelte doc page
+        assert_eq!(DiagnosticKind::UnexpectedToken.svelte_doc_url(), None);
+        assert_eq!(DiagnosticKind::UnknownDirective.svelte_doc_url(), None);
+        assert_eq!(
+            DiagnosticKind::InternalError("x".into()).svelte_doc_url(),
+            None
+        );
+    }
+
+    #[test]
+    fn display_with_url() {
+        let d = Diagnostic::unexpected_end_of_file(Span::new(0, 0));
+        let output = format!("{d}");
+        assert!(output.contains("Unexpected end of input"));
+        assert!(output.contains("https://svelte.dev/e/unexpected_eof"));
+    }
+
+    #[test]
+    fn display_without_url() {
+        let d = Diagnostic::error(DiagnosticKind::UnexpectedToken, Span::new(0, 0));
+        let output = format!("{d}");
+        assert_eq!(output, "Unexpected token");
+    }
+
+    #[test]
+    fn code_frame_basic() {
+        let source = "line1\nline2\nline3\nline4\nline5";
+        let idx = LineIndex::new(source);
+        // Error at start of line3 (byte offset 12)
+        let frame = idx.code_frame(source, Span::new(12, 17)).unwrap();
+        assert!(frame.contains("1 | line1"));
+        assert!(frame.contains("3 | line3"));
+        assert!(frame.contains("5 | line5"));
+        assert!(frame.contains("^"));
+    }
+
+    #[test]
+    fn code_frame_first_line() {
+        let source = "error_here\nline2\nline3";
+        let idx = LineIndex::new(source);
+        let frame = idx.code_frame(source, Span::new(0, 5)).unwrap();
+        assert!(frame.contains("1 | error_here"));
+        assert!(frame.contains("^"));
+        assert!(frame.contains("3 | line3"));
+    }
+
+    #[test]
+    fn code_frame_last_line() {
+        let source = "line1\nline2\nline3\nline4\nerror_here";
+        let idx = LineIndex::new(source);
+        // Error at start of line5 (byte offset = 24)
+        let frame = idx.code_frame(source, Span::new(24, 34)).unwrap();
+        assert!(frame.contains("5 | error_here"));
+        assert!(frame.contains("^"));
+        assert!(frame.contains("3 | line3"));
+    }
+
+    #[test]
+    fn code_frame_with_tabs() {
+        let source = "\tindented";
+        let idx = LineIndex::new(source);
+        let frame = idx.code_frame(source, Span::new(1, 5)).unwrap();
+        // Tab should be replaced with 2 spaces in display
+        assert!(frame.contains("  indented"));
+        // Pointer should account for tab width
+        assert!(frame.contains("  ^"));
     }
 }

--- a/crates/wasm_compiler/src/lib.rs
+++ b/crates/wasm_compiler/src/lib.rs
@@ -8,12 +8,14 @@ use wasm_bindgen::prelude::*;
 
 #[derive(Serialize)]
 struct WasmDiagnostic {
+    code: String,
     message: String,
     severity: String,
     start_line: usize,
     start_col: usize,
     end_line: usize,
     end_col: usize,
+    frame: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -43,13 +45,20 @@ impl WasmCompiler {
             .map(|d| {
                 let (start_line, start_col) = line_index.line_col(d.span.start as usize);
                 let (end_line, end_col) = line_index.line_col(d.span.end as usize);
+                let mut message = d.kind.message();
+                if let Some(url) = d.kind.svelte_doc_url() {
+                    message.push('\n');
+                    message.push_str(&url);
+                }
                 WasmDiagnostic {
-                    message: format!("{:?}", d.kind),
+                    code: d.kind.code().to_string(),
+                    message,
                     severity: format!("{:?}", d.severity),
                     start_line,
                     start_col,
                     end_line,
                     end_col,
+                    frame: line_index.code_frame(source, d.span),
                 }
             })
             .collect();


### PR DESCRIPTION
## Summary
Enhanced diagnostic reporting by adding structured error codes, human-readable messages, documentation links, and visual code frames to help developers quickly identify and understand compilation errors.

## Key Changes
- **DiagnosticKind methods**: Added three new methods to `DiagnosticKind`:
  - `code()`: Returns snake_case error codes matching official Svelte error codes
  - `message()`: Returns human-readable error messages with proper formatting
  - `svelte_doc_url()`: Returns links to Svelte documentation for applicable errors

- **Code frame generation**: Implemented `LineIndex::code_frame()` to render visual error context with:
  - ±2 lines of surrounding context
  - Line numbers with proper alignment
  - Error pointer (^) at the exact error location
  - Tab character handling (converted to 2 spaces for display)

- **Diagnostic display**: Updated `Diagnostic::fmt()` to include error messages and documentation URLs

- **WASM compiler integration**: Enhanced `WasmDiagnostic` struct to expose:
  - `code`: Machine-readable error code
  - `frame`: Visual code frame for IDE/editor integration
  - Improved `message` field with documentation links

- **Comprehensive tests**: Added 8 test cases covering error codes, messages, URLs, display formatting, and code frame rendering across various scenarios (first line, last line, tabs, etc.)

## Notable Details
- Error codes are aligned with official Svelte error codes where applicable
- Code frames intelligently handle edge cases (empty files, out-of-bounds spans, tab characters)
- Documentation URLs follow the pattern `https://svelte.dev/e/{code}` for supported errors
- Tab characters are normalized to 2 spaces in visual output while maintaining accurate pointer positioning

https://claude.ai/code/session_01XDwBnhk1GbU6VDMcphxQDo