### PR TITLE
refactor: add accessor methods to AnalysisData sub-structs and Ctx shortcuts

### DIFF
--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -87,6 +87,16 @@ impl ElementFlags {
             dynamic_attrs: FxHashSet::default(),
         }
     }
+
+    pub fn has_spread(&self, id: NodeId) -> bool { self.has_spread.contains(&id) }
+    pub fn has_class_directives(&self, id: NodeId) -> bool { self.has_class_directives.contains(&id) }
+    pub fn has_style_directives(&self, id: NodeId) -> bool { self.has_style_directives.contains(&id) }
+    pub fn needs_input_defaults(&self, id: NodeId) -> bool { self.needs_input_defaults.contains(&id) }
+    pub fn needs_var(&self, id: NodeId) -> bool { self.needs_var.contains(&id) }
+    pub fn needs_ref(&self, id: NodeId) -> bool { self.needs_ref.contains(&id) }
+    pub fn is_dynamic_attr(&self, id: NodeId, idx: usize) -> bool { self.dynamic_attrs.contains(&(id, idx)) }
+    pub fn static_class(&self, id: NodeId) -> Option<Span> { self.static_class.get(&id).copied() }
+    pub fn static_style(&self, id: NodeId) -> Option<Span> { self.static_style.get(&id).copied() }
 }
 
 /// Fragment lowering results and content classification.
@@ -104,6 +114,18 @@ impl FragmentData {
             has_dynamic_children: FxHashSet::default(),
         }
     }
+
+    pub fn content_type(&self, key: &FragmentKey) -> ContentType {
+        self.content_types.get(key).copied().unwrap_or(ContentType::Empty)
+    }
+
+    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool {
+        self.has_dynamic_children.contains(key)
+    }
+
+    pub fn lowered(&self, key: &FragmentKey) -> Option<&LoweredFragment> {
+        self.lowered.get(key)
+    }
 }
 
 /// Snippet analysis: parameter names and hoistability.
@@ -119,6 +141,9 @@ impl SnippetData {
             hoistable: FxHashSet::default(),
         }
     }
+
+    pub fn params(&self, id: NodeId) -> Option<&Vec<String>> { self.params.get(&id) }
+    pub fn is_hoistable(&self, id: NodeId) -> bool { self.hoistable.contains(&id) }
 }
 
 /// ConstTag analysis: declared names and per-fragment grouping.
@@ -134,6 +159,9 @@ impl ConstTagData {
             by_fragment: FxHashMap::default(),
         }
     }
+
+    pub fn names(&self, id: NodeId) -> Option<&Vec<String>> { self.names.get(&id) }
+    pub fn by_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.by_fragment.get(key) }
 }
 
 // ---------------------------------------------------------------------------
@@ -198,6 +226,12 @@ impl AnalysisData {
 }
 
 impl AnalysisData {
+    pub fn is_dynamic(&self, id: NodeId) -> bool { self.dynamic_nodes.contains(&id) }
+    pub fn is_elseif_alt(&self, id: NodeId) -> bool { self.alt_is_elseif.contains(&id) }
+    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> { self.expressions.get(&id) }
+    pub fn attr_expression(&self, id: NodeId, idx: usize) -> Option<&ExpressionInfo> { self.attr_expressions.get(&(id, idx)) }
+    pub fn known_value(&self, name: &str) -> Option<&String> { self.known_values.get(name) }
+
     pub fn is_rune(&self, name: &str) -> bool {
         self.scoping.rune_info_by_name(name).is_some()
     }

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -1,8 +1,9 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::Statement;
-use svelte_analyze::{AnalysisData, FragmentKey, LoweredFragment, ParsedExprs};
+use svelte_analyze::{AnalysisData, ContentType, FragmentKey, LoweredFragment, ParsedExprs};
 use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
+use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 
 use crate::builder::Builder;
@@ -198,4 +199,35 @@ impl<'a> Ctx<'a> {
         }
     }
 
+    // -- Analysis shortcuts --
+
+    pub fn is_dynamic(&self, id: NodeId) -> bool { self.analysis.is_dynamic(id) }
+    pub fn is_elseif_alt(&self, id: NodeId) -> bool { self.analysis.is_elseif_alt(id) }
+    pub fn is_mutable_rune(&self, name: &str) -> bool { self.analysis.is_mutable_rune(name) }
+    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> { self.analysis.expression(id) }
+    pub fn known_value(&self, name: &str) -> Option<&String> { self.analysis.known_value(name) }
+
+    // -- Fragment shortcuts --
+
+    pub fn content_type(&self, key: &FragmentKey) -> ContentType { self.analysis.fragments.content_type(key) }
+    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool { self.analysis.fragments.has_dynamic_children(key) }
+
+    // -- Element flag shortcuts --
+
+    pub fn has_spread(&self, id: NodeId) -> bool { self.analysis.element_flags.has_spread(id) }
+    pub fn has_class_directives(&self, id: NodeId) -> bool { self.analysis.element_flags.has_class_directives(id) }
+    pub fn has_style_directives(&self, id: NodeId) -> bool { self.analysis.element_flags.has_style_directives(id) }
+    pub fn needs_input_defaults(&self, id: NodeId) -> bool { self.analysis.element_flags.needs_input_defaults(id) }
+    pub fn needs_var(&self, id: NodeId) -> bool { self.analysis.element_flags.needs_var(id) }
+    pub fn is_dynamic_attr(&self, id: NodeId, idx: usize) -> bool { self.analysis.element_flags.is_dynamic_attr(id, idx) }
+
+    // -- Snippet shortcuts --
+
+    pub fn snippet_params(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis.snippets.params(id) }
+    pub fn is_snippet_hoistable(&self, id: NodeId) -> bool { self.analysis.snippets.is_hoistable(id) }
+
+    // -- ConstTag shortcuts --
+
+    pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis.const_tags.names(id) }
+    pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis.const_tags.by_fragment(key) }
 }

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -111,7 +111,7 @@ pub(crate) fn process_class_directives<'a>(
     init: &mut Vec<Statement<'a>>,
     update: &mut Vec<Statement<'a>>,
 ) {
-    if !ctx.analysis.element_flags.has_class_directives.contains(&el.id) {
+    if !ctx.has_class_directives(el.id) {
         return;
     }
 
@@ -126,12 +126,8 @@ pub(crate) fn process_class_directives<'a>(
         .collect();
 
     // Find static class value from precomputed span
-    let static_class = ctx
-        .analysis
-        .element_flags
-        .static_class
-        .get(&el.id)
-        .map(|span| ctx.component.source_text(*span).to_string())
+    let static_class = ctx.analysis.element_flags.static_class(el.id)
+        .map(|span| ctx.component.source_text(span).to_string())
         .unwrap_or_default();
 
     let mut props: Vec<ObjProp<'a>> = Vec::new();
@@ -151,7 +147,7 @@ pub(crate) fn process_class_directives<'a>(
             (ctx.b.rid_expr(name), true)
         };
 
-        let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
+        let is_mutated_rune = ctx.is_mutable_rune(name);
 
         let name_alloc = ctx.b.alloc_str(name);
 
@@ -205,7 +201,7 @@ pub(crate) fn process_style_directives<'a>(
 ) {
     use svelte_ast::StyleDirectiveValue;
 
-    if !ctx.analysis.element_flags.has_style_directives.contains(&el.id) {
+    if !ctx.has_style_directives(el.id) {
         return;
     }
 
@@ -220,12 +216,8 @@ pub(crate) fn process_style_directives<'a>(
         .collect();
 
     // Find static style value from precomputed span
-    let static_style = ctx
-        .analysis
-        .element_flags
-        .static_style
-        .get(&el.id)
-        .map(|span| ctx.component.source_text(*span).to_string())
+    let static_style = ctx.analysis.element_flags.static_style(el.id)
+        .map(|span| ctx.component.source_text(span).to_string())
         .unwrap_or_default();
 
     let mut normal_props: Vec<ObjProp<'a>> = Vec::new();
@@ -238,7 +230,7 @@ pub(crate) fn process_style_directives<'a>(
 
         match &sd.value {
             StyleDirectiveValue::Shorthand => {
-                let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
+                let is_mutated_rune = ctx.is_mutable_rune(name);
                 if is_mutated_rune {
                     let get_call = ctx.b.call_expr("$.get", [Arg::Ident(name)]);
                     target.push(ObjProp::KeyValue(name_alloc, get_call));
@@ -248,7 +240,7 @@ pub(crate) fn process_style_directives<'a>(
             }
             StyleDirectiveValue::Expression(span) => {
                 let parsed = get_attr_expr(ctx, el.id, *attr_idx);
-                let is_mutated_rune = ctx.analysis.is_mutable_rune(name);
+                let is_mutated_rune = ctx.is_mutable_rune(name);
                 let expr_text = ctx.component.source_text(*span).trim();
                 let same_name = expr_text == name.as_str();
 
@@ -320,7 +312,7 @@ fn build_style_concat<'a>(
             svelte_ast::ConcatPart::Dynamic(span) => {
                 // Check if the dynamic expression is a simple mutated rune reference
                 let expr_text = ctx.component.source_text(*span).trim();
-                let is_mutated_rune = ctx.analysis.is_mutable_rune(expr_text);
+                let is_mutated_rune = ctx.is_mutable_rune(expr_text);
 
                 if is_mutated_rune {
                     // Drain the pre-parsed expression (it's just `shade` as an identifier)
@@ -353,7 +345,7 @@ fn gen_bind_directive<'a>(
         return None;
     };
 
-    let is_mutated_rune = ctx.analysis.is_mutable_rune(&var_name);
+    let is_mutated_rune = ctx.is_mutable_rune(&var_name);
 
     let getter_body = if is_mutated_rune {
         ctx.b.call_expr("$.get", [Arg::Ident(&var_name)])

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -35,7 +35,7 @@ pub(crate) fn gen_component<'a>(
 
     // Collect attribute info while borrowing ctx immutably
     let attr_infos: Vec<(AttrKind<'_>, bool)> = cn.attributes.iter().enumerate().map(|(idx, attr)| {
-        let is_dynamic = ctx.analysis.element_flags.dynamic_attrs.contains(&(id, idx));
+        let is_dynamic = ctx.is_dynamic_attr(id, idx);
         let kind = match attr {
             Attribute::StringAttribute(a) => AttrKind::String {
                 name: &a.name,
@@ -121,10 +121,7 @@ pub(crate) fn gen_component<'a>(
     }
 
     // Add children snippet if component has non-empty fragment
-    let children_ct = ctx.analysis.fragments.content_types
-        .get(&FragmentKey::ComponentNode(id))
-        .copied()
-        .unwrap_or(ContentType::Empty);
+    let children_ct = ctx.content_type(&FragmentKey::ComponentNode(id));
 
     if children_ct != ContentType::Empty {
         let frag_key = FragmentKey::ComponentNode(id);

--- a/crates/svelte_codegen_client/src/template/const_tag.rs
+++ b/crates/svelte_codegen_client/src/template/const_tag.rs
@@ -15,12 +15,12 @@ pub(crate) fn emit_const_tags<'a>(
     key: FragmentKey,
     stmts: &mut Vec<Statement<'a>>,
 ) {
-    let Some(ids) = ctx.analysis.const_tags.by_fragment.get(&key).cloned() else {
+    let Some(ids) = ctx.const_tags_for_fragment(&key).cloned() else {
         return;
     };
 
     for id in ids {
-        let names = ctx.analysis.const_tags.names.get(&id).cloned().unwrap_or_default();
+        let names = ctx.const_tag_names(id).cloned().unwrap_or_default();
         let init_expr = get_node_expr(ctx, id);
 
         // Simple identifier: const name = $.derived(() => init_expr)

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -36,7 +36,7 @@ pub(crate) fn gen_each_block<'a>(
     let mut flags: u32 = EACH_ITEM_IMMUTABLE;
 
     // If the collection expression references any variable, items need reactive wrapping
-    let expr_has_refs = ctx.analysis.expressions.get(&block_id)
+    let expr_has_refs = ctx.expression(block_id)
         .is_some_and(|info| !info.references.is_empty());
     if expr_has_refs {
         flags |= EACH_ITEM_REACTIVE;

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -25,16 +25,10 @@ pub(crate) fn process_element<'a>(
 ) {
     let el = ctx.element(el_id);
     let child_key = FragmentKey::Element(el_id);
-    let ct = ctx
-        .analysis
-        .fragments
-        .content_types
-        .get(&child_key)
-        .copied()
-        .unwrap_or(ContentType::Empty);
+    let ct = ctx.content_type(&child_key);
 
     // $.remove_input_defaults for <input> elements with bind or dynamic value attribute
-    if ctx.analysis.element_flags.needs_input_defaults.contains(&el_id) {
+    if ctx.needs_input_defaults(el_id) {
         init.push(ctx.b.call_stmt(
             "$.remove_input_defaults",
             [Arg::Ident(el_name)],
@@ -42,14 +36,14 @@ pub(crate) fn process_element<'a>(
     }
 
     // Attributes — spread path or per-attribute path
-    if ctx.analysis.element_flags.has_spread.contains(&el_id) {
+    if ctx.has_spread(el_id) {
         let el_clone = el.clone_without_fragment();
         process_attrs_spread(ctx, &el_clone, el_name, init, after_update);
     } else {
         let attr_count = el.attributes.len();
         let mut attr_dynamic = Vec::with_capacity(attr_count);
         for idx in 0..attr_count {
-            attr_dynamic.push(ctx.analysis.element_flags.dynamic_attrs.contains(&(el_id, idx)));
+            attr_dynamic.push(ctx.is_dynamic_attr(el_id, idx));
         }
         let el = ctx.element(el_id);
         let tag = el.name.clone();
@@ -67,7 +61,7 @@ pub(crate) fn process_element<'a>(
     process_style_directives(ctx, &el.clone_without_fragment(), el_name, init, update);
 
     // Children
-    let has_state = ctx.analysis.fragments.has_dynamic_children.contains(&child_key);
+    let has_state = ctx.has_dynamic_children(&child_key);
     match ct {
         ContentType::Empty | ContentType::StaticText => {}
 
@@ -165,7 +159,7 @@ pub(crate) fn process_element<'a>(
 pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
-        svelte_analyze::FragmentItem::Element(id) => ctx.analysis.element_flags.needs_var.contains(id),
+        svelte_analyze::FragmentItem::Element(id) => ctx.needs_var(*id),
         svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) => {
             true
         }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -75,9 +75,9 @@ pub(crate) fn build_concat<'a>(ctx: &mut Ctx<'a>, item: &FragmentItem) -> Expres
 
 /// Try to resolve an expression tag to a compile-time known value.
 fn try_resolve_known(ctx: &Ctx<'_>, nid: NodeId) -> Option<String> {
-    let info = ctx.analysis.expressions.get(&nid)?;
+    let info = ctx.expression(nid)?;
     if let ExpressionKind::Identifier(name) = &info.kind {
-        ctx.analysis.known_values.get(name.as_str()).cloned()
+        ctx.known_value(name.as_str()).cloned()
     } else {
         None
     }
@@ -234,7 +234,7 @@ pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
         FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) => {
-            ctx.analysis.dynamic_nodes.contains(id)
+            ctx.is_dynamic(*id)
         }
     }
 }
@@ -242,7 +242,7 @@ pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
 pub(crate) fn parts_are_dynamic(parts: &[ConcatPart], ctx: &Ctx<'_>) -> bool {
     parts.iter().any(|p| {
         if let ConcatPart::Expr(id) = p {
-            ctx.analysis.dynamic_nodes.contains(id)
+            ctx.is_dynamic(*id)
         } else {
             false
         }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -11,7 +11,7 @@ use super::expression::static_text_of;
 
 /// Build the HTML string for a fragment (used in `$.template(...)`).
 pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
-    let Some(lf) = ctx.analysis.fragments.lowered.get(&key) else {
+    let Some(lf) = ctx.analysis.fragments.lowered(&key) else {
         return String::new();
     };
     let mut html = String::new();
@@ -41,8 +41,8 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
 
 /// Build the HTML string for a single element (opening tag + attrs + children + closing tag).
 pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
-    let has_spread = ctx.analysis.element_flags.has_spread.contains(&el.id);
-    let has_class_directives = ctx.analysis.element_flags.has_class_directives.contains(&el.id);
+    let has_spread = ctx.has_spread(el.id);
+    let has_class_directives = ctx.has_class_directives(el.id);
 
     let mut html = String::new();
     write!(html, "<{}", el.name).unwrap();
@@ -85,14 +85,8 @@ pub(crate) fn element_html(ctx: &Ctx<'_>, el: &Element) -> String {
     }
 
     let child_key = FragmentKey::Element(el.id);
-    let ct = ctx
-        .analysis
-        .fragments
-        .content_types
-        .get(&child_key)
-        .copied()
-        .unwrap_or(ContentType::Empty);
-    let has_state = ctx.analysis.fragments.has_dynamic_children.contains(&child_key);
+    let ct = ctx.content_type(&child_key);
+    let has_state = ctx.has_dynamic_children(&child_key);
 
     match ct {
         ContentType::Empty => {}

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -43,7 +43,7 @@ pub(crate) fn gen_if_block<'a>(
         }
 
         let alternate_key = FragmentKey::IfAlternate(current);
-        let alt_is_elseif = ctx.analysis.alt_is_elseif.contains(&current);
+        let alt_is_elseif = ctx.is_elseif_alt(current);
 
         if alt_is_elseif {
             let nested_id = ctx.lowered_fragment(&alternate_key).first_if_block_id().unwrap();

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -53,13 +53,7 @@ use traverse::traverse_items;
 /// `hoistable_snippets` are module-level snippet declarations.
 pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Statement<'a>>, Vec<Statement<'a>>, Vec<Statement<'a>>) {
     let key = FragmentKey::Root;
-    let ct = ctx
-        .analysis
-        .fragments
-        .content_types
-        .get(&key)
-        .copied()
-        .unwrap_or(ContentType::Empty);
+    let ct = ctx.content_type(&key);
 
     // Consume "root" name for all content types to keep numbering consistent
     let tpl_name = ctx.gen_ident("root");
@@ -70,12 +64,12 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
     let mut hoistable_snippet_ids = Vec::new();
     for node in &ctx.component.fragment.nodes {
         if let svelte_ast::Node::SnippetBlock(block) = node {
-            if let Some(params) = ctx.analysis.snippets.params.get(&block.id) {
+            if let Some(params) = ctx.analysis.snippets.params(block.id) {
                 for param in params {
                     ctx.gen_ident(param);
                 }
             }
-            if ctx.analysis.snippets.hoistable.contains(&block.id) {
+            if ctx.is_snippet_hoistable(block.id) {
                 hoistable_snippet_ids.push(block.id);
             } else {
                 instance_snippet_ids.push(block.id);
@@ -281,13 +275,7 @@ fn gen_root_mixed<'a>(
 
 /// Generate statements for a fragment, destined for `($$anchor) => { ... }`.
 pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<Statement<'a>> {
-    let ct = ctx
-        .analysis
-        .fragments
-        .content_types
-        .get(&key)
-        .copied()
-        .unwrap_or(ContentType::Empty);
+    let ct = ctx.content_type(&key);
 
     // Consume "root" name for all content types to keep numbering consistent
     let tpl_name = ctx.gen_ident("root");


### PR DESCRIPTION
Encapsulate deep field access (ctx.analysis.element_flags.X.contains(),
ctx.analysis.fragments.Y.get(), etc.) behind accessor methods on sub-structs
(ElementFlags, FragmentData, SnippetData, ConstTagData, AnalysisData) and
delegate shortcuts on Ctx. Codegen no longer reaches into another crate's
internal structure — ~30 call sites simplified.

https://claude.ai/code/session_01QRcSStRg7wcMm9PJwkUNPF