### PR TITLE
feat: port @const destructuring support ({@const { x, y } = obj})

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ version = "0.1.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
+ "oxc_parser",
  "oxc_semantic",
  "oxc_span",
  "pretty_assertions",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@ Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_
 - **Analyze**: Scope integration — const binding visible in subsequent template nodes within same block
 - **Codegen**: `const x = $.derived(() => expr)` — always wraps in derived
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/ConstTag.js` (~134 lines, destructuring support)
-- **Deferred**: Object/array destructuring, dev mode `$.tag()`, placement validation
+- **Deferred**: ~~Object/array destructuring~~, dev mode `$.tag()`, placement validation
 
 ### ~~`style:prop={value}` — Style directive~~ ✅
 - **Phases**: P, A, T

--- a/crates/svelte_analyze/Cargo.toml
+++ b/crates/svelte_analyze/Cargo.toml
@@ -10,6 +10,7 @@ svelte_diagnostics = { path = "../svelte_diagnostics" }
 svelte_span = { path = "../svelte_span" }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -5,7 +5,6 @@ use svelte_ast::NodeId;
 use svelte_js::{ExpressionInfo, ScriptInfo};
 use svelte_span::Span;
 
-pub use oxc_semantic::SymbolId;
 
 use crate::scope::ComponentScoping;
 
@@ -162,8 +161,6 @@ pub struct ConstTagData {
     pub by_fragment: FxHashMap<FragmentKey, Vec<NodeId>>,
     /// Destructuring info per const tag (only present for destructured tags).
     pub destructured: FxHashMap<NodeId, ConstDestructure>,
-    /// Maps each SymbolId of a destructured const binding to its temp var name.
-    pub binding_to_temp: FxHashMap<SymbolId, String>,
 }
 
 impl ConstTagData {
@@ -172,7 +169,6 @@ impl ConstTagData {
             names: FxHashMap::default(),
             by_fragment: FxHashMap::default(),
             destructured: FxHashMap::default(),
-            binding_to_temp: FxHashMap::default(),
         }
     }
 

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -160,8 +160,6 @@ pub struct ConstTagData {
     pub destructured_temp: FxHashMap<NodeId, String>,
     /// Maps each SymbolId of a destructured const binding to its temp var name.
     pub binding_to_temp: FxHashMap<SymbolId, String>,
-    /// Counter for generating unique temp var names.
-    temp_counter: usize,
 }
 
 impl ConstTagData {
@@ -173,23 +171,11 @@ impl ConstTagData {
             pattern_text: FxHashMap::default(),
             destructured_temp: FxHashMap::default(),
             binding_to_temp: FxHashMap::default(),
-            temp_counter: 0,
         }
     }
 
     pub fn names(&self, id: NodeId) -> Option<&Vec<String>> { self.names.get(&id) }
     pub fn by_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.by_fragment.get(key) }
-
-    /// Generate the next unique temp var name: "computed_const", "computed_const_1", ...
-    pub fn next_temp_name(&mut self) -> String {
-        let name = if self.temp_counter == 0 {
-            "computed_const".to_string()
-        } else {
-            format!("computed_const_{}", self.temp_counter)
-        };
-        self.temp_counter += 1;
-        name
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -148,16 +148,20 @@ impl SnippetData {
     pub fn is_hoistable(&self, id: NodeId) -> bool { self.hoistable.contains(&id) }
 }
 
+/// Per-node destructuring info for a const tag.
+pub struct ConstDestructure {
+    /// LHS pattern text, e.g. "{ x, y }" or "[a, b]".
+    pub pattern_text: String,
+    /// Generated temp var name, e.g. "computed_const". Populated during build_scoping.
+    pub temp_name: String,
+}
+
 /// ConstTag analysis: declared names and per-fragment grouping.
 pub struct ConstTagData {
     pub names: FxHashMap<NodeId, Vec<String>>,
     pub by_fragment: FxHashMap<FragmentKey, Vec<NodeId>>,
-    /// Const tags that use destructuring patterns (object or array).
-    pub destructured: FxHashSet<NodeId>,
-    /// Pattern text for destructured const tags, e.g. "{ x, y }" or "[a, b]".
-    pub pattern_text: FxHashMap<NodeId, String>,
-    /// Pre-assigned temp var names for destructured const tags.
-    pub destructured_temp: FxHashMap<NodeId, String>,
+    /// Destructuring info per const tag (only present for destructured tags).
+    pub destructured: FxHashMap<NodeId, ConstDestructure>,
     /// Maps each SymbolId of a destructured const binding to its temp var name.
     pub binding_to_temp: FxHashMap<SymbolId, String>,
 }
@@ -167,9 +171,7 @@ impl ConstTagData {
         Self {
             names: FxHashMap::default(),
             by_fragment: FxHashMap::default(),
-            destructured: FxHashSet::default(),
-            pattern_text: FxHashMap::default(),
-            destructured_temp: FxHashMap::default(),
+            destructured: FxHashMap::default(),
             binding_to_temp: FxHashMap::default(),
         }
     }

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -5,6 +5,8 @@ use svelte_ast::NodeId;
 use svelte_js::{ExpressionInfo, ScriptInfo};
 use svelte_span::Span;
 
+pub use oxc_semantic::SymbolId;
+
 use crate::scope::ComponentScoping;
 
 // ---------------------------------------------------------------------------
@@ -150,6 +152,16 @@ impl SnippetData {
 pub struct ConstTagData {
     pub names: FxHashMap<NodeId, Vec<String>>,
     pub by_fragment: FxHashMap<FragmentKey, Vec<NodeId>>,
+    /// Const tags that use destructuring patterns (object or array).
+    pub destructured: FxHashSet<NodeId>,
+    /// Pattern text for destructured const tags, e.g. "{ x, y }" or "[a, b]".
+    pub pattern_text: FxHashMap<NodeId, String>,
+    /// Pre-assigned temp var names for destructured const tags.
+    pub destructured_temp: FxHashMap<NodeId, String>,
+    /// Maps each SymbolId of a destructured const binding to its temp var name.
+    pub binding_to_temp: FxHashMap<SymbolId, String>,
+    /// Counter for generating unique temp var names.
+    temp_counter: usize,
 }
 
 impl ConstTagData {
@@ -157,11 +169,27 @@ impl ConstTagData {
         Self {
             names: FxHashMap::default(),
             by_fragment: FxHashMap::default(),
+            destructured: FxHashSet::default(),
+            pattern_text: FxHashMap::default(),
+            destructured_temp: FxHashMap::default(),
+            binding_to_temp: FxHashMap::default(),
+            temp_counter: 0,
         }
     }
 
     pub fn names(&self, id: NodeId) -> Option<&Vec<String>> { self.names.get(&id) }
     pub fn by_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.by_fragment.get(key) }
+
+    /// Generate the next unique temp var name: "computed_const", "computed_const_1", ...
+    pub fn next_temp_name(&mut self) -> String {
+        let name = if self.temp_counter == 0 {
+            "computed_const".to_string()
+        } else {
+            format!("computed_const_{}", self.temp_counter)
+        };
+        self.temp_counter += 1;
+        name
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -303,10 +303,13 @@ fn parse_const_tag<'a>(
 
     data.const_tags.names.insert(tag.id, names);
     if is_destructured {
-        data.const_tags.destructured.insert(tag.id);
         let pattern_end = assign.left.span().end as usize;
-        let pattern_text = decl_text[..pattern_end].trim();
-        data.const_tags.pattern_text.insert(tag.id, pattern_text.to_string());
+        let pattern_text = decl_text[..pattern_end].trim().to_string();
+        // temp_name is populated later in build_scoping (needs scope access)
+        data.const_tags.destructured.insert(tag.id, crate::data::ConstDestructure {
+            pattern_text,
+            temp_name: String::new(),
+        });
     }
 }
 

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -1,4 +1,7 @@
 use oxc_allocator::Allocator;
+use oxc_ast::ast::{AssignmentTarget, AssignmentTargetMaybeDefault, Expression};
+use oxc_parser::Parser as OxcParser;
+use oxc_span::{GetSpan, SourceType};
 use svelte_ast::{Attribute, Component, ConcatPart, Fragment, Node, NodeId, ScriptLanguage};
 use svelte_diagnostics::Diagnostic;
 use svelte_js::{ExpressionInfo, ExpressionKind};
@@ -180,15 +183,7 @@ fn walk_node<'a>(
             walk_fragment(alloc, &block.fragment, component, data, parsed, diags);
         }
         Node::ConstTag(tag) => {
-            let decl_text = component.source_text(tag.declaration_span);
-            // Split "name = expr" at the first '=' to extract identifier and init expression
-            if let Some(eq_pos) = decl_text.find('=') {
-                let name = decl_text[..eq_pos].trim().to_string();
-                let init_text = decl_text[eq_pos + 1..].trim();
-                let init_offset = tag.declaration_span.start + (decl_text.len() - decl_text[eq_pos + 1..].trim_start().len()) as u32;
-                parse_expr(alloc, init_text, init_offset, tag.id, data, parsed, diags);
-                data.const_tags.names.insert(tag.id, vec![name]);
-            }
+            parse_const_tag(alloc, tag, component, data, parsed, diags);
         }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
@@ -262,5 +257,142 @@ fn walk_attrs<'a>(
                 }
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConstTag parsing — handles both simple identifiers and destructuring
+// ---------------------------------------------------------------------------
+
+fn parse_const_tag<'a>(
+    alloc: &'a Allocator,
+    tag: &svelte_ast::ConstTag,
+    component: &Component,
+    data: &mut AnalysisData,
+    parsed: &mut ParsedExprs<'a>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let decl_text = component.source_text(tag.declaration_span);
+
+    // Parse the full declaration text as an expression using a temp allocator.
+    // "x = expr" or "{ x, y } = expr" are valid AssignmentExpressions.
+    let temp_alloc = Allocator::default();
+    let temp_src: &str = temp_alloc.alloc_str(decl_text);
+    let Ok(full_expr) = OxcParser::new(&temp_alloc, temp_src, SourceType::default())
+        .parse_expression()
+    else {
+        return;
+    };
+
+    let Expression::AssignmentExpression(assign) = &full_expr else {
+        return;
+    };
+
+    // Extract names from LHS
+    let mut names = Vec::new();
+    let is_destructured = extract_target_names(&assign.left, &mut names);
+
+    // Get init expression boundaries from RHS span
+    let init_start = assign.right.span().start as usize;
+    let init_text = decl_text[init_start..].trim();
+    let init_offset = tag.declaration_span.start
+        + (decl_text.len() - decl_text[init_start..].trim_start().len()) as u32;
+
+    // Parse init into main allocator (existing pipeline)
+    parse_expr(alloc, init_text, init_offset, tag.id, data, parsed, diags);
+
+    data.const_tags.names.insert(tag.id, names);
+    if is_destructured {
+        data.const_tags.destructured.insert(tag.id);
+        let pattern_end = assign.left.span().end as usize;
+        let pattern_text = decl_text[..pattern_end].trim();
+        data.const_tags.pattern_text.insert(tag.id, pattern_text.to_string());
+        // Assign temp var name now (before build_scoping, which needs it for binding_to_temp)
+        let temp_name = data.const_tags.next_temp_name();
+        data.const_tags.destructured_temp.insert(tag.id, temp_name);
+    }
+}
+
+/// Extract identifier names from an assignment target.
+/// Returns true if the target is a destructuring pattern.
+fn extract_target_names(target: &AssignmentTarget, names: &mut Vec<String>) -> bool {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(id) => {
+            names.push(id.name.as_str().to_string());
+            false
+        }
+        AssignmentTarget::ObjectAssignmentTarget(obj) => {
+            for prop in &obj.properties {
+                extract_assignment_property_names(prop, names);
+            }
+            if let Some(rest) = &obj.rest {
+                extract_target_name(&rest.target, names);
+            }
+            true
+        }
+        AssignmentTarget::ArrayAssignmentTarget(arr) => {
+            for elem in arr.elements.iter().flatten() {
+                extract_maybe_default_name(elem, names);
+            }
+            if let Some(rest) = &arr.rest {
+                extract_target_name(&rest.target, names);
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+fn extract_assignment_property_names(
+    prop: &oxc_ast::ast::AssignmentTargetProperty,
+    names: &mut Vec<String>,
+) {
+    match prop {
+        oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(id) => {
+            names.push(id.binding.name.as_str().to_string());
+        }
+        oxc_ast::ast::AssignmentTargetProperty::AssignmentTargetPropertyProperty(p) => {
+            extract_maybe_default_name(&p.binding, names);
+        }
+    }
+}
+
+fn extract_maybe_default_name(target: &AssignmentTargetMaybeDefault, names: &mut Vec<String>) {
+    match target {
+        AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(d) => {
+            extract_target_name(&d.binding, names);
+        }
+        _ => {
+            // AssignmentTargetMaybeDefault also implements Into<AssignmentTarget>
+            // but for simple targets, try direct match
+            if let AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) = target {
+                names.push(id.name.as_str().to_string());
+            }
+        }
+    }
+}
+
+fn extract_target_name(target: &AssignmentTarget, names: &mut Vec<String>) {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(id) => {
+            names.push(id.name.as_str().to_string());
+        }
+        AssignmentTarget::ObjectAssignmentTarget(obj) => {
+            for prop in &obj.properties {
+                extract_assignment_property_names(prop, names);
+            }
+            if let Some(rest) = &obj.rest {
+                extract_target_name(&rest.target, names);
+            }
+        }
+        AssignmentTarget::ArrayAssignmentTarget(arr) => {
+            for elem in arr.elements.iter().flatten() {
+                extract_maybe_default_name(elem, names);
+            }
+            if let Some(rest) = &arr.rest {
+                extract_target_name(&rest.target, names);
+            }
+        }
+        _ => {}
     }
 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -307,9 +307,6 @@ fn parse_const_tag<'a>(
         let pattern_end = assign.left.span().end as usize;
         let pattern_text = decl_text[..pattern_end].trim();
         data.const_tags.pattern_text.insert(tag.id, pattern_text.to_string());
-        // Assign temp var name now (before build_scoping, which needs it for binding_to_temp)
-        let temp_name = data.const_tags.next_temp_name();
-        data.const_tags.destructured_temp.insert(tag.id, temp_name);
     }
 }
 

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -12,6 +12,9 @@ pub struct Rune {
     pub kind: RuneKind,
     /// Symbols referenced in the init expression. Only populated for Derived/DerivedBy.
     pub derived_deps: Vec<SymbolId>,
+    /// For destructured const members: the SymbolId of the temp derived variable.
+    /// Reads become `$.get(temp).name` instead of `$.get(name)`.
+    pub member_of: Option<SymbolId>,
 }
 
 /// Unified scope tree for script + template, wrapping `oxc_semantic::Scoping`.
@@ -96,7 +99,7 @@ impl ComponentScoping {
     // -- Rune tracking --
 
     pub fn mark_rune(&mut self, id: SymbolId, kind: RuneKind) {
-        self.runes.insert(id, Rune { kind, derived_deps: Vec::new() });
+        self.runes.insert(id, Rune { kind, derived_deps: Vec::new(), member_of: None });
     }
 
     pub fn set_derived_deps(&mut self, id: SymbolId, deps: Vec<SymbolId>) {
@@ -111,6 +114,23 @@ impl ComponentScoping {
 
     pub fn is_rune(&self, id: SymbolId) -> bool {
         self.runes.contains_key(&id)
+    }
+
+    /// Mark a rune as a destructured member of another symbol (the temp derived var).
+    pub fn mark_member_of(&mut self, id: SymbolId, parent: SymbolId) {
+        if let Some(rune) = self.runes.get_mut(&id) {
+            rune.member_of = Some(parent);
+        }
+    }
+
+    /// For destructured const members: returns the SymbolId of the temp derived variable.
+    pub fn rune_member_of(&self, id: SymbolId) -> Option<SymbolId> {
+        self.runes.get(&id).and_then(|r| r.member_of)
+    }
+
+    /// Get the name of a symbol.
+    pub fn symbol_name(&self, id: SymbolId) -> &str {
+        self.scoping.symbol_name(id)
     }
 
     /// Register a template reference into OXC Scoping.
@@ -211,22 +231,14 @@ pub fn build_scoping(component: &Component, data: &mut AnalysisData) {
     // Take temporarily to avoid split borrow on `data`
     let const_tag_names = std::mem::take(&mut data.const_tags.names);
     let destructured_ids: FxHashSet<NodeId> = data.const_tags.destructured.keys().copied().collect();
-    let mut const_sym_ids: Vec<(NodeId, String, SymbolId)> = Vec::new();
     let mut generated_temps: Vec<(NodeId, String)> = Vec::new();
-    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, &destructured_ids, &mut const_sym_ids, &mut generated_temps);
+    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, &destructured_ids, &mut generated_temps);
     data.const_tags.names = const_tag_names;
 
-    // Store generated temp names and build binding_to_temp mapping
-    for (node_id, temp_name) in &generated_temps {
-        if let Some(info) = data.const_tags.destructured.get_mut(node_id) {
-            info.temp_name = temp_name.clone();
-        }
-    }
-    for (node_id, _name, sym_id) in &const_sym_ids {
-        if let Some(info) = data.const_tags.destructured.get(node_id) {
-            if !info.temp_name.is_empty() {
-                data.const_tags.binding_to_temp.insert(*sym_id, info.temp_name.clone());
-            }
+    // Store generated temp names back into ConstDestructure
+    for (node_id, temp_name) in generated_temps {
+        if let Some(info) = data.const_tags.destructured.get_mut(&node_id) {
+            info.temp_name = temp_name;
         }
     }
 }
@@ -238,7 +250,6 @@ fn walk_template_scopes(
     current_scope: ScopeId,
     const_tag_names: &FxHashMap<NodeId, Vec<String>>,
     destructured_ids: &FxHashSet<NodeId>,
-    const_sym_ids: &mut Vec<(NodeId, String, SymbolId)>,
     generated_temps: &mut Vec<(NodeId, String)>,
 ) {
     for node in &fragment.nodes {
@@ -257,30 +268,30 @@ fn walk_template_scopes(
                     scoping.add_binding(child_scope, idx_name);
                 }
 
-                walk_template_scopes(&block.body, component, scoping, child_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                walk_template_scopes(&block.body, component, scoping, child_scope, const_tag_names, destructured_ids, generated_temps);
 
                 // Fallback uses parent scope (no context/index vars)
                 if let Some(fb) = &block.fallback {
-                    walk_template_scopes(fb, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                    walk_template_scopes(fb, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
                 }
             }
             Node::Element(el) => {
-                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
             }
             Node::ComponentNode(cn) => {
-                walk_template_scopes(&cn.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                walk_template_scopes(&cn.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
             }
             Node::IfBlock(block) => {
-                walk_template_scopes(&block.consequent, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                walk_template_scopes(&block.consequent, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
                 if let Some(alt) = &block.alternate {
-                    walk_template_scopes(alt, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                    walk_template_scopes(alt, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
                 }
             }
             Node::SnippetBlock(block) => {
-                walk_template_scopes(&block.body, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                walk_template_scopes(&block.body, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
             }
             Node::KeyBlock(block) => {
-                walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
+                walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, generated_temps);
             }
             Node::ConstTag(tag) => {
                 if let Some(names) = const_tag_names.get(&tag.id) {
@@ -290,14 +301,18 @@ fn walk_template_scopes(
                         let temp_name = scoping.generate("computed_const", current_scope);
                         let temp_sym = scoping.add_binding(current_scope, &temp_name);
                         scoping.mark_rune(temp_sym, RuneKind::Derived);
+                        // Add each destructured name as a rune that points to the temp var
+                        for name in names {
+                            let sym_id = scoping.add_binding(current_scope, name);
+                            scoping.mark_rune(sym_id, RuneKind::Derived);
+                            scoping.mark_member_of(sym_id, temp_sym);
+                        }
                         generated_temps.push((tag.id, temp_name));
-                    }
-                    for name in names {
-                        let sym_id = scoping.add_binding(current_scope, name);
-                        if !is_destructured {
+                    } else {
+                        for name in names {
+                            let sym_id = scoping.add_binding(current_scope, name);
                             scoping.mark_rune(sym_id, RuneKind::Derived);
                         }
-                        const_sym_ids.push((tag.id, name.clone(), sym_id));
                     }
                 }
             }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 pub use oxc_semantic::{ScopeId, SymbolId};
 use oxc_semantic::{NodeId as OxcNodeId, Reference as OxcReference, ReferenceFlags as OxcReferenceFlags, ScopeFlags, Scoping, SymbolFlags};
@@ -149,6 +149,20 @@ impl ComponentScoping {
         self.symbol_scope_id(sym_id) != self.root_scope_id()
     }
 
+    // -- Unique name generation --
+
+    /// Generate a unique name that doesn't conflict with any binding in the scope chain.
+    /// Similar to Svelte's `scope.generate()`.
+    pub fn generate(&self, base: &str, scope: ScopeId) -> String {
+        let mut candidate = base.to_string();
+        let mut counter = 1u32;
+        while self.find_binding(scope, &candidate).is_some() {
+            candidate = format!("{}_{}", base, counter);
+            counter += 1;
+        }
+        candidate
+    }
+
     // -- Name-based lookup for codegen (works with names, not SymbolIds) --
 
     /// Lookup rune kind + mutated status by variable name (root scope).
@@ -196,11 +210,16 @@ pub fn build_scoping(component: &Component, data: &mut AnalysisData) {
     let root = data.scoping.root_scope_id();
     // Take const_tag_names temporarily to avoid split borrow on `data`
     let const_tag_names = std::mem::take(&mut data.const_tags.names);
+    let destructured_ids = &data.const_tags.destructured;
     let mut const_sym_ids: Vec<(NodeId, String, SymbolId)> = Vec::new();
-    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, &mut const_sym_ids);
+    let mut generated_temps: Vec<(NodeId, String)> = Vec::new();
+    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, destructured_ids, &mut const_sym_ids, &mut generated_temps);
     data.const_tags.names = const_tag_names;
 
-    // Build binding_to_temp: map each destructured const binding's SymbolId to its temp var name
+    // Store generated temp names and build binding_to_temp mapping
+    for (node_id, temp_name) in &generated_temps {
+        data.const_tags.destructured_temp.insert(*node_id, temp_name.clone());
+    }
     for (node_id, _name, sym_id) in &const_sym_ids {
         if let Some(temp_name) = data.const_tags.destructured_temp.get(node_id) {
             data.const_tags.binding_to_temp.insert(*sym_id, temp_name.clone());
@@ -214,7 +233,9 @@ fn walk_template_scopes(
     scoping: &mut ComponentScoping,
     current_scope: ScopeId,
     const_tag_names: &FxHashMap<NodeId, Vec<String>>,
+    destructured_ids: &FxHashSet<NodeId>,
     const_sym_ids: &mut Vec<(NodeId, String, SymbolId)>,
+    generated_temps: &mut Vec<(NodeId, String)>,
 ) {
     for node in &fragment.nodes {
         match node {
@@ -232,36 +253,46 @@ fn walk_template_scopes(
                     scoping.add_binding(child_scope, idx_name);
                 }
 
-                walk_template_scopes(&block.body, component, scoping, child_scope, const_tag_names, const_sym_ids);
+                walk_template_scopes(&block.body, component, scoping, child_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
 
                 // Fallback uses parent scope (no context/index vars)
                 if let Some(fb) = &block.fallback {
-                    walk_template_scopes(fb, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                    walk_template_scopes(fb, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
                 }
             }
             Node::Element(el) => {
-                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
             }
             Node::ComponentNode(cn) => {
-                walk_template_scopes(&cn.fragment, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                walk_template_scopes(&cn.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
             }
             Node::IfBlock(block) => {
-                walk_template_scopes(&block.consequent, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                walk_template_scopes(&block.consequent, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
                 if let Some(alt) = &block.alternate {
-                    walk_template_scopes(alt, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                    walk_template_scopes(alt, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
                 }
             }
             Node::SnippetBlock(block) => {
-                walk_template_scopes(&block.body, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                walk_template_scopes(&block.body, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
             }
             Node::KeyBlock(block) => {
-                walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names, const_sym_ids);
+                walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names, destructured_ids, const_sym_ids, generated_temps);
             }
             Node::ConstTag(tag) => {
                 if let Some(names) = const_tag_names.get(&tag.id) {
+                    let is_destructured = destructured_ids.contains(&tag.id);
+                    if is_destructured {
+                        // Generate unique temp name, checking scope for conflicts
+                        let temp_name = scoping.generate("computed_const", current_scope);
+                        let temp_sym = scoping.add_binding(current_scope, &temp_name);
+                        scoping.mark_rune(temp_sym, RuneKind::Derived);
+                        generated_temps.push((tag.id, temp_name));
+                    }
                     for name in names {
                         let sym_id = scoping.add_binding(current_scope, name);
-                        scoping.mark_rune(sym_id, RuneKind::Derived);
+                        if !is_destructured {
+                            scoping.mark_rune(sym_id, RuneKind::Derived);
+                        }
                         const_sym_ids.push((tag.id, name.clone(), sym_id));
                     }
                 }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -196,8 +196,16 @@ pub fn build_scoping(component: &Component, data: &mut AnalysisData) {
     let root = data.scoping.root_scope_id();
     // Take const_tag_names temporarily to avoid split borrow on `data`
     let const_tag_names = std::mem::take(&mut data.const_tags.names);
-    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names);
+    let mut const_sym_ids: Vec<(NodeId, String, SymbolId)> = Vec::new();
+    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, &mut const_sym_ids);
     data.const_tags.names = const_tag_names;
+
+    // Build binding_to_temp: map each destructured const binding's SymbolId to its temp var name
+    for (node_id, _name, sym_id) in &const_sym_ids {
+        if let Some(temp_name) = data.const_tags.destructured_temp.get(node_id) {
+            data.const_tags.binding_to_temp.insert(*sym_id, temp_name.clone());
+        }
+    }
 }
 
 fn walk_template_scopes(
@@ -206,6 +214,7 @@ fn walk_template_scopes(
     scoping: &mut ComponentScoping,
     current_scope: ScopeId,
     const_tag_names: &FxHashMap<NodeId, Vec<String>>,
+    const_sym_ids: &mut Vec<(NodeId, String, SymbolId)>,
 ) {
     for node in &fragment.nodes {
         match node {
@@ -223,36 +232,37 @@ fn walk_template_scopes(
                     scoping.add_binding(child_scope, idx_name);
                 }
 
-                walk_template_scopes(&block.body, component, scoping, child_scope, const_tag_names);
+                walk_template_scopes(&block.body, component, scoping, child_scope, const_tag_names, const_sym_ids);
 
                 // Fallback uses parent scope (no context/index vars)
                 if let Some(fb) = &block.fallback {
-                    walk_template_scopes(fb, component, scoping, current_scope, const_tag_names);
+                    walk_template_scopes(fb, component, scoping, current_scope, const_tag_names, const_sym_ids);
                 }
             }
             Node::Element(el) => {
-                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names);
+                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names, const_sym_ids);
             }
             Node::ComponentNode(cn) => {
-                walk_template_scopes(&cn.fragment, component, scoping, current_scope, const_tag_names);
+                walk_template_scopes(&cn.fragment, component, scoping, current_scope, const_tag_names, const_sym_ids);
             }
             Node::IfBlock(block) => {
-                walk_template_scopes(&block.consequent, component, scoping, current_scope, const_tag_names);
+                walk_template_scopes(&block.consequent, component, scoping, current_scope, const_tag_names, const_sym_ids);
                 if let Some(alt) = &block.alternate {
-                    walk_template_scopes(alt, component, scoping, current_scope, const_tag_names);
+                    walk_template_scopes(alt, component, scoping, current_scope, const_tag_names, const_sym_ids);
                 }
             }
             Node::SnippetBlock(block) => {
-                walk_template_scopes(&block.body, component, scoping, current_scope, const_tag_names);
+                walk_template_scopes(&block.body, component, scoping, current_scope, const_tag_names, const_sym_ids);
             }
             Node::KeyBlock(block) => {
-                walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names);
+                walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names, const_sym_ids);
             }
             Node::ConstTag(tag) => {
                 if let Some(names) = const_tag_names.get(&tag.id) {
                     for name in names {
                         let sym_id = scoping.add_binding(current_scope, name);
                         scoping.mark_rune(sym_id, RuneKind::Derived);
+                        const_sym_ids.push((tag.id, name.clone(), sym_id));
                     }
                 }
             }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -208,21 +208,25 @@ pub fn build_scoping(component: &Component, data: &mut AnalysisData) {
 
     // Walk template to add each-block scopes and const bindings
     let root = data.scoping.root_scope_id();
-    // Take const_tag_names temporarily to avoid split borrow on `data`
+    // Take temporarily to avoid split borrow on `data`
     let const_tag_names = std::mem::take(&mut data.const_tags.names);
-    let destructured_ids = &data.const_tags.destructured;
+    let destructured_ids: FxHashSet<NodeId> = data.const_tags.destructured.keys().copied().collect();
     let mut const_sym_ids: Vec<(NodeId, String, SymbolId)> = Vec::new();
     let mut generated_temps: Vec<(NodeId, String)> = Vec::new();
-    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, destructured_ids, &mut const_sym_ids, &mut generated_temps);
+    walk_template_scopes(&component.fragment, component, &mut data.scoping, root, &const_tag_names, &destructured_ids, &mut const_sym_ids, &mut generated_temps);
     data.const_tags.names = const_tag_names;
 
     // Store generated temp names and build binding_to_temp mapping
     for (node_id, temp_name) in &generated_temps {
-        data.const_tags.destructured_temp.insert(*node_id, temp_name.clone());
+        if let Some(info) = data.const_tags.destructured.get_mut(node_id) {
+            info.temp_name = temp_name.clone();
+        }
     }
     for (node_id, _name, sym_id) in &const_sym_ids {
-        if let Some(temp_name) = data.const_tags.destructured_temp.get(node_id) {
-            data.const_tags.binding_to_temp.insert(*sym_id, temp_name.clone());
+        if let Some(info) = data.const_tags.destructured.get(node_id) {
+            if !info.temp_name.is_empty() {
+                data.const_tags.binding_to_temp.insert(*sym_id, info.temp_name.clone());
+            }
         }
     }
 }

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -238,6 +238,29 @@ impl<'a> Builder<'a> {
         Statement::VariableDeclaration(self.alloc(declaration))
     }
 
+    /// `const { a, b } = init;` — object destructuring const declaration (shorthand properties).
+    pub fn const_object_destruct_stmt(&self, names: &[&str], init: Expression<'a>) -> Statement<'a> {
+        let properties: Vec<_> = names.iter().map(|name| {
+            let key = ast::PropertyKey::StaticIdentifier(self.alloc(
+                self.ast.identifier_name(SPAN, self.ast.atom(*name)),
+            ));
+            let value = self.ast.binding_pattern_binding_identifier(SPAN, self.ast.atom(*name));
+            self.ast.binding_property(SPAN, key, value, true, false)
+        }).collect();
+        let object_pattern = self.ast.object_pattern(SPAN, self.ast.vec_from_iter(properties), NONE);
+        let pattern = ast::BindingPattern::ObjectPattern(self.alloc(object_pattern));
+        let decl = self.ast.variable_declarator(
+            SPAN, VariableDeclarationKind::Const, pattern, NONE, Some(init), false,
+        );
+        let declaration = self.ast.variable_declaration(
+            SPAN,
+            VariableDeclarationKind::Const,
+            self.ast.vec_from_array([decl]),
+            false,
+        );
+        Statement::VariableDeclaration(self.alloc(declaration))
+    }
+
     fn var_decl_stmt(
         &self,
         name: &str,

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -230,7 +230,7 @@ impl<'a> Ctx<'a> {
 
     pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis.const_tags.names(id) }
     pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis.const_tags.by_fragment(key) }
-    pub fn is_const_destructured(&self, id: NodeId) -> bool { self.analysis.const_tags.destructured.contains(&id) }
-    pub fn const_tag_temp_name(&self, id: NodeId) -> Option<&str> { self.analysis.const_tags.destructured_temp.get(&id).map(|s| s.as_str()) }
-    pub fn const_tag_pattern_text(&self, id: NodeId) -> Option<&str> { self.analysis.const_tags.pattern_text.get(&id).map(|s| s.as_str()) }
+    pub fn is_const_destructured(&self, id: NodeId) -> bool { self.analysis.const_tags.destructured.contains_key(&id) }
+    pub fn const_tag_temp_name(&self, id: NodeId) -> Option<&str> { self.analysis.const_tags.destructured.get(&id).map(|d| d.temp_name.as_str()) }
+    pub fn const_tag_pattern_text(&self, id: NodeId) -> Option<&str> { self.analysis.const_tags.destructured.get(&id).map(|d| d.pattern_text.as_str()) }
 }

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -230,4 +230,7 @@ impl<'a> Ctx<'a> {
 
     pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis.const_tags.names(id) }
     pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis.const_tags.by_fragment(key) }
+    pub fn is_const_destructured(&self, id: NodeId) -> bool { self.analysis.const_tags.destructured.contains(&id) }
+    pub fn const_tag_temp_name(&self, id: NodeId) -> Option<&str> { self.analysis.const_tags.destructured_temp.get(&id).map(|s| s.as_str()) }
+    pub fn const_tag_pattern_text(&self, id: NodeId) -> Option<&str> { self.analysis.const_tags.pattern_text.get(&id).map(|s| s.as_str()) }
 }

--- a/crates/svelte_codegen_client/src/template/const_tag.rs
+++ b/crates/svelte_codegen_client/src/template/const_tag.rs
@@ -2,7 +2,7 @@ use oxc_ast::ast::Statement;
 
 use svelte_analyze::FragmentKey;
 
-use crate::builder::Arg;
+use crate::builder::{Arg, ObjProp};
 use crate::context::Ctx;
 
 use super::expression::get_node_expr;
@@ -22,13 +22,47 @@ pub(crate) fn emit_const_tags<'a>(
     for id in ids {
         let names = ctx.const_tag_names(id).cloned().unwrap_or_default();
         let init_expr = get_node_expr(ctx, id);
+        let is_destructured = ctx.is_const_destructured(id);
 
-        // Simple identifier: const name = $.derived(() => init_expr)
-        if names.len() == 1 {
+        if !is_destructured && names.len() == 1 {
+            // Simple identifier: const name = $.derived(() => init_expr)
             let thunk = ctx.b.thunk(init_expr);
             let derived = ctx.b.call_expr("$.derived", [Arg::Expr(thunk)]);
             stmts.push(ctx.b.const_stmt(&names[0], derived));
+        } else if is_destructured {
+            // Destructuring: const computed_const = $.derived(() => {
+            //   const { x, y } = init_expr;
+            //   return { x, y };
+            // })
+            let temp_name = ctx.const_tag_temp_name(id)
+                .unwrap_or("computed_const")
+                .to_string();
+            let pattern_text = ctx.const_tag_pattern_text(id).map(|s| s.to_string());
+
+            // Determine if object or array destructuring from pattern text
+            let is_array = pattern_text.as_deref().map_or(false, |t| t.starts_with('['));
+            let name_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+
+            // Build: const { x, y } = init_expr;  (or const [a, b] = init_expr;)
+            let destruct_stmt = if is_array {
+                ctx.b.const_array_destruct_stmt(&name_refs, init_expr)
+            } else {
+                ctx.b.const_object_destruct_stmt(&name_refs, init_expr)
+            };
+
+            // Build: return { x, y };
+            let props: Vec<ObjProp<'a>> = names.iter().map(|n| {
+                let alloc_name = ctx.b.alloc_str(n);
+                ObjProp::Shorthand(alloc_name)
+            }).collect();
+            let obj = ctx.b.object_expr(props);
+            let ret = ctx.b.return_stmt(obj);
+
+            // Build: () => { const { x, y } = init; return { x, y }; }
+            let arrow = ctx.b.arrow_block_expr(ctx.b.no_params(), [destruct_stmt, ret]);
+            let derived = ctx.b.call_expr("$.derived", [Arg::Expr(arrow)]);
+
+            stmts.push(ctx.b.const_stmt(&temp_name, derived));
         }
-        // Destructuring deferred — only simple identifiers for now
     }
 }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -245,6 +245,12 @@ fn transform_expr<'a>(
 
             // Look up in scope tree
             if let Some(sym_id) = ctx.analysis.scoping.find_binding(scope, name) {
+                // Destructured const var → $.get(temp).prop
+                if let Some(temp_name) = ctx.analysis.const_tags.binding_to_temp.get(&sym_id) {
+                    *expr = rune_refs::make_computed_const_get(ctx.alloc, temp_name, name);
+                    return;
+                }
+
                 let is_root = ctx.analysis.scoping.symbol_scope_id(sym_id)
                     == ctx.analysis.scoping.root_scope_id();
 

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -245,8 +245,9 @@ fn transform_expr<'a>(
 
             // Look up in scope tree
             if let Some(sym_id) = ctx.analysis.scoping.find_binding(scope, name) {
-                // Destructured const var → $.get(temp).prop
-                if let Some(temp_name) = ctx.analysis.const_tags.binding_to_temp.get(&sym_id) {
+                // Destructured const member → $.get(temp).prop
+                if let Some(parent_sym) = ctx.analysis.scoping.rune_member_of(sym_id) {
+                    let temp_name = ctx.analysis.scoping.symbol_name(parent_sym);
                     *expr = rune_refs::make_computed_const_get(ctx.alloc, temp_name, name);
                     return;
                 }

--- a/crates/svelte_transform/src/rune_refs.rs
+++ b/crates/svelte_transform/src/rune_refs.rs
@@ -65,6 +65,20 @@ pub fn make_props_access<'a>(alloc: &'a Allocator, prop_name: &str) -> Expressio
     ))
 }
 
+/// Build `$.get(temp_var).prop_name` — member access on a derived destructured const.
+pub fn make_computed_const_get<'a>(
+    alloc: &'a Allocator,
+    temp_var: &str,
+    prop_name: &str,
+) -> Expression<'a> {
+    let get_call = make_rune_get(alloc, temp_var);
+    let ast = AstBuilder::new(alloc);
+    let property = ast.identifier_name(SPAN, ast.atom(prop_name));
+    Expression::StaticMemberExpression(ast.alloc(
+        ast.static_member_expression(SPAN, get_call, property, false),
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/tasks/compiler_tests/cases2/const_tag_destructure/case-rust.js
+++ b/tasks/compiler_tests/cases2/const_tag_destructure/case-rust.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => $$props.items, $.index, ($$anchor, item) => {
+		const computed_const = $.derived(() => {
+			const { x, y } = $.get(item);
+			return {
+				x,
+				y
+			};
+		});
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(computed_const).x));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/const_tag_destructure/case-svelte.js
+++ b/tasks/compiler_tests/cases2/const_tag_destructure/case-svelte.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => $$props.items, $.index, ($$anchor, item) => {
+		const computed_const = $.derived(() => {
+			const { x, y } = $.get(item);
+			return {
+				x,
+				y
+			};
+		});
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(computed_const).x));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/const_tag_destructure/case.svelte
+++ b/tasks/compiler_tests/cases2/const_tag_destructure/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let { items } = $props();
+</script>
+
+{#each items as item}
+	{@const { x, y } = item}
+	<p>{x}</p>
+{/each}

--- a/tasks/compiler_tests/cases2/const_tag_destructure_shadow/case-rust.js
+++ b/tasks/compiler_tests/cases2/const_tag_destructure_shadow/case-rust.js
@@ -1,0 +1,25 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root = $.from_html(`<!> <p></p>`, 1);
+export default function App($$anchor, $$props) {
+	let computed_const = "shadow";
+	var fragment = root();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => $$props.items, $.index, ($$anchor, item) => {
+		const computed_const_1 = $.derived(() => {
+			const { x, y } = $.get(item);
+			return {
+				x,
+				y
+			};
+		});
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(computed_const_1).x));
+		$.append($$anchor, p);
+	});
+	var p_1 = $.sibling(node, 2);
+	p_1.textContent = "shadow";
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/const_tag_destructure_shadow/case-svelte.js
+++ b/tasks/compiler_tests/cases2/const_tag_destructure_shadow/case-svelte.js
@@ -1,0 +1,25 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root = $.from_html(`<!> <p></p>`, 1);
+export default function App($$anchor, $$props) {
+	let computed_const = "shadow";
+	var fragment = root();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => $$props.items, $.index, ($$anchor, item) => {
+		const computed_const_1 = $.derived(() => {
+			const { x, y } = $.get(item);
+			return {
+				x,
+				y
+			};
+		});
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(computed_const_1).x));
+		$.append($$anchor, p);
+	});
+	var p_1 = $.sibling(node, 2);
+	p_1.textContent = "shadow";
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/const_tag_destructure_shadow/case.svelte
+++ b/tasks/compiler_tests/cases2/const_tag_destructure_shadow/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	let { items } = $props();
+	let computed_const = $state('shadow');
+</script>
+
+{#each items as item}
+	{@const { x, y } = item}
+	<p>{x}</p>
+{/each}
+<p>{computed_const}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -340,3 +340,8 @@ fn store_write() {
 fn const_tag() {
     assert_compiler("const_tag");
 }
+
+#[rstest]
+fn const_tag_destructure() {
+    assert_compiler("const_tag_destructure");
+}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -345,3 +345,8 @@ fn const_tag() {
 fn const_tag_destructure() {
     assert_compiler("const_tag_destructure");
 }
+
+#[rstest]
+fn const_tag_destructure_shadow() {
+    assert_compiler("const_tag_destructure_shadow");
+}


### PR DESCRIPTION
Adds object and array destructuring for {@const} tags. Destructured
const tags emit a temp derived variable with the destructured bindings
returned as an object, and reads become $.get(temp).prop.

- Parse full declaration text as AssignmentExpression via OXC
- Extract LHS names and detect destructuring patterns
- Generate temp var names (computed_const, computed_const_1, ...)
- Map destructured bindings to temp vars via SymbolId in scope analysis
- Transform reads: $.get(computed_const).x instead of $.get(x)
- Codegen: $.derived(() => { const { x, y } = init; return { x, y }; })
- Add const_object_destruct_stmt to Builder

https://claude.ai/code/session_01VTaLE29CGEUfNpZgA6yJ3x