### PR TITLE
feat: port $state.raw(val) rune

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ Key file: `crates/svelte_codegen_client/src/script.rs`
 |---|---------|-----------|--------|-------|
 | 1 | ~~`$effect(fn)`~~ | `$.user_effect(fn)` | S | ✅ Done |
 | 2 | ~~`$effect.pre(fn)`~~ | `$.user_pre_effect(fn)` | S | ✅ Done |
-| 3 | `$state.raw(val)` | `$.state(val)` (no `$.proxy()`) | S | Add `RuneKind::StateRaw`, skip proxy wrapping |
+| 3 | ~~`$state.raw(val)`~~ | `$.state(val)` (no `$.proxy()`) | S | ✅ Done. Deferred: destructuring (shared gap with `$state`), class fields, `$state.frozen` rename validation |
 | 4 | `$state.snapshot(val)` | `$.snapshot(val)` | S | Inline call rewrite, not a declarator |
 | 5 | `$effect.tracking()` | `$.effect_tracking()` | S | Trivial call rewrite, no args |
 | 6 | `$effect.root(fn)` | `$.effect_root(fn)` | S | Simple callee rewrite, pass through args |

--- a/TODO.md
+++ b/TODO.md
@@ -4,23 +4,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 1. `$state.raw(val)` rune
+## 1. `class` attribute — Object/array syntax (Svelte 5)
 
-**Why first**: простой рун, паттерн уже есть в script.rs.
-
-**What to change**:
-- `svelte_analyze/src/parse_js.rs`: добавить `RuneKind::StateRaw`
-- `svelte_codegen_client/src/script.rs`: `$state.raw(val)` → `$.state(val)` (без `$.proxy()`)
-
-**Reference**: `reference/compiler/phases/3-transform/client/visitors/VariableDeclaration.js`
-
-**Runtime**: `$.state()`
-
----
-
-## 2. `class` attribute — Object/array syntax (Svelte 5)
-
-**Why third**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
+**Why first**: новый синтаксис `class={{ active: isActive }}` и `class={[base, active && "active"]}`.
 
 **What to change**:
 - `svelte_parser/src/lib.rs`: detect object/array expression in `class` attribute value
@@ -30,9 +16,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 3. `$state.snapshot(val)` rune
+## 2. `$state.snapshot(val)` rune
 
-**Why fourth**: простая перезапись вызова, паттерн уже есть в script.rs.
+**Why second**: простая перезапись вызова, паттерн уже есть в script.rs.
 
 **What to change**:
 - `svelte_analyze/src/parse_js.rs`: detect `$state.snapshot(val)` as inline call rewrite
@@ -44,9 +30,9 @@ Next 5 features to implement, in priority order.
 
 ---
 
-## 4. `$effect.tracking()` rune
+## 3. `$effect.tracking()` rune
 
-**Why fifth**: тривиальная перезапись вызова, без аргументов.
+**Why third**: тривиальная перезапись вызова, без аргументов.
 
 **What to change**:
 - `svelte_analyze/src/parse_js.rs`: detect `$effect.tracking()` as inline call rewrite
@@ -55,3 +41,30 @@ Next 5 features to implement, in priority order.
 **Reference**: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`
 
 **Runtime**: `$.effect_tracking()`
+
+---
+
+## 4. `$effect.root(fn)` rune
+
+**Why fourth**: простая перезапись вызова, аналогична `$effect.pre`.
+
+**What to change**:
+- `svelte_codegen_client/src/script.rs`: `$effect.root(fn)` → `$.effect_root(fn)`
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`
+
+**Runtime**: `$.effect_root()`
+
+---
+
+## 5. `$inspect(vals)` rune
+
+**Why fifth**: dev-mode only — strip in prod. Needs `dev` compiler option.
+
+**What to change**:
+- `svelte_analyze/src/parse_js.rs`: detect `$inspect(...)` as inline call rewrite
+- `svelte_codegen_client/src/script.rs`: `$inspect(val)` → `$.inspect(val)` (dev) / strip (prod)
+
+**Reference**: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`
+
+**Runtime**: `$.inspect()`

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -577,7 +577,7 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
                     call.callee = self.b.rid_expr("$.derived");
                     node.init = Some(Expression::CallExpression(call));
                 }
-                RuneKind::State => {
+                RuneKind::State | RuneKind::StateRaw => {
                     if mutated {
                         call.callee = self.b.rid_expr("$.state");
 
@@ -603,7 +603,7 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
                             std::mem::swap(&mut call.arguments[0], &mut dummy);
                             dummy.into_expression()
                         };
-                        let value = if Self::should_proxy(&value) {
+                        let value = if kind == RuneKind::State && Self::should_proxy(&value) {
                             self.b.call_expr("$.proxy", [Arg::Expr(value)])
                         } else {
                             value
@@ -734,7 +734,7 @@ impl<'a> ScriptTransformer<'_, 'a> {
                 ]);
                 return;
             }
-            if let Some((_, mutated)) = self.rune_for_ref(id) {
+            if let Some((kind, mutated)) = self.rune_for_ref(id) {
                 if mutated {
                     let name = id.name.as_str().to_string();
                     let right = self.b.move_expr(&mut assign.right);
@@ -753,7 +753,7 @@ impl<'a> ScriptTransformer<'_, 'a> {
                         }
                     };
 
-                    let needs_proxy = Self::should_proxy(&value);
+                    let needs_proxy = kind != RuneKind::StateRaw && Self::should_proxy(&value);
                     *node = crate::rune_transform::transform_rune_set(self.b, &name, value, needs_proxy);
                     return;
                 }

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -113,6 +113,7 @@ pub enum DeclarationKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuneKind {
     State,
+    StateRaw,
     Derived,
     DerivedBy,
     Effect,
@@ -845,6 +846,7 @@ fn detect_rune(expr: &Expression<'_>) -> Option<RuneKind> {
                     let prop = member.property.name.as_str();
                     return match (obj.name.as_str(), prop) {
                         ("$derived", "by") => Some(RuneKind::DerivedBy),
+                        ("$state", "raw") => Some(RuneKind::StateRaw),
                         _ => None,
                     };
                 }

--- a/tasks/compiler_tests/cases2/state_raw/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_raw/case-rust.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let count = $.state(0);
+	let items = $.state([
+		1,
+		2,
+		3
+	]);
+	let empty = void 0;
+	let readonly_obj = { x: 1 };
+	$.set(count, 10);
+	$.set(count, $.get(count) + 5);
+	$.set(items, [
+		4,
+		5,
+		6
+	]);
+	var div = root();
+	var text = $.child(div, true);
+	$.reset(div);
+	$.template_effect(() => $.set_text(text, $.get(count)));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/state_raw/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_raw/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let count = $.state(0);
+	let items = $.state([
+		1,
+		2,
+		3
+	]);
+	let empty = void 0;
+	let readonly_obj = { x: 1 };
+	$.set(count, 10);
+	$.set(count, $.get(count) + 5);
+	$.set(items, [
+		4,
+		5,
+		6
+	]);
+	var div = root();
+	var text = $.child(div, true);
+	$.reset(div);
+	$.template_effect(() => $.set_text(text, $.get(count)));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/state_raw/case.svelte
+++ b/tasks/compiler_tests/cases2/state_raw/case.svelte
@@ -1,0 +1,12 @@
+<script>
+    let count = $state.raw(0);
+    let items = $state.raw([1, 2, 3]);
+    let empty = $state.raw();
+    let readonly_obj = $state.raw({ x: 1 });
+
+    count = 10;
+    count += 5;
+    items = [4, 5, 6];
+</script>
+
+<div>{count}</div>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -77,6 +77,11 @@ fn state_runes() {
 }
 
 #[rstest]
+fn state_raw() {
+    assert_compiler("state_raw");
+}
+
+#[rstest]
 fn each_block() {
     assert_compiler("each_block");
 }


### PR DESCRIPTION
$state.raw(val) → $.state(val) without $.proxy() wrapping.
Handles mutated/unmutated declarations and skips proxy on reassignment.
Deferred: destructuring, class fields, $state.frozen rename validation.

https://claude.ai/code/session_01JGoD1j4GmcnyqCMQYzvyrC