### PR TITLE
feat: complete Tier 3 bind directive codegen

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,21 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] SnippetBlock, RenderTag
 - [x] Text node, ExpressionTag
 
+### Bind directives (Tier 3)
+- [x] `bind:value` (input, textarea, select), `bind:checked`, `bind:group`, `bind:files`
+- [x] `bind:indeterminate`, `bind:open` (generic `$.bind_property`)
+- [x] `bind:innerHTML`, `bind:innerText`, `bind:textContent` (contenteditable)
+- [x] `bind:clientWidth/Height`, `bind:offsetWidth/Height` (element size)
+- [x] `bind:contentRect`, `bind:contentBoxSize`, `bind:borderBoxSize`, `bind:devicePixelContentBoxSize` (resize observer)
+- [x] `bind:currentTime`, `bind:paused`, `bind:volume`, `bind:muted`, `bind:playbackRate` (media R/W)
+- [x] `bind:buffered`, `bind:seekable`, `bind:seeking`, `bind:ended`, `bind:readyState`, `bind:played` (media RO)
+- [x] `bind:duration`, `bind:videoWidth`, `bind:videoHeight`, `bind:naturalWidth`, `bind:naturalHeight` (event-based RO)
+- [x] `bind:this` (element reference)
+- [x] `bind:focused`
+- [ ] `bind:property={get, set}` — function bindings (Svelte 5) *(deferred)*
+- [ ] Window bindings: `scrollX`, `scrollY`, `innerWidth`, `innerHeight`, `outerWidth`, `outerHeight`, `online`, `devicePixelRatio` *(requires `<svelte:window>` parser)*
+- [ ] Document bindings: `activeElement`, `fullscreenElement`, `pointerLockElement`, `visibilityState` *(requires `<svelte:document>` parser)*
+
 ### Optimizations
 - [x] Whitespace trimming
 - [x] Merge adjacent text/interpolation
@@ -193,9 +208,11 @@ Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_
 
 ---
 
-## Tier 3 — Bind Directive Completeness
+## Tier 3 — Bind Directive Completeness ✅
 
 Theme: parser/AST already supports `bind:name={expr}`. Need element-aware codegen dispatch per binding type.
+
+**Status**: Codegen complete for all regular-element bindings. Window/document bindings deferred to Tier 4 (requires `<svelte:window>` / `<svelte:document>` parser support).
 
 Key file: `crates/svelte_codegen_client/src/template/attributes.rs`
 Ref: `reference/compiler/phases/3-transform/client/visitors/BindDirective.js`

--- a/crates/svelte_analyze/src/element_flags.rs
+++ b/crates/svelte_analyze/src/element_flags.rs
@@ -36,7 +36,7 @@ impl TemplateVisitor for ElementFlagsVisitor {
             Attribute::StringAttribute(sa) if sa.name == "style" => {
                 data.element_flags.static_style.insert(el.id, sa.value_span);
             }
-            Attribute::BindDirective(_) if el.name == "input" => {
+            Attribute::BindDirective(bd) if el.name == "input" && matches!(bd.name.as_str(), "value" | "checked" | "group") => {
                 data.element_flags.needs_input_defaults.insert(el.id);
             }
             Attribute::ExpressionAttribute(ea) if ea.name == "value" && el.name == "input" => {

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -111,8 +111,11 @@ pub(crate) fn process_attr<'a>(
             ));
         }
         Attribute::BindDirective(bind) => {
-            if let Some(stmt) = gen_bind_directive(ctx, bind, el_name) {
-                after_update.push(stmt);
+            if let Some(placement) = gen_bind_directive(ctx, bind, el_name, tag_name) {
+                match placement {
+                    BindPlacement::AfterUpdate(stmt) => after_update.push(stmt),
+                    BindPlacement::Init(stmt) => init.push(stmt),
+                }
             }
         }
         Attribute::ShorthandOrSpread(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => {
@@ -378,12 +381,21 @@ fn build_style_concat<'a>(
     ctx.b.template_parts_expr(tpl_parts)
 }
 
+/// Where to place a bind directive statement.
+enum BindPlacement<'a> {
+    /// Most bindings: placed after attribute updates.
+    AfterUpdate(Statement<'a>),
+    /// `bind:this`: placed in init (before render effect).
+    Init(Statement<'a>),
+}
+
 /// Generate a bind directive statement (getter/setter + runtime call).
 fn gen_bind_directive<'a>(
     ctx: &mut Ctx<'a>,
     bind: &svelte_ast::BindDirective,
     el_name: &str,
-) -> Option<Statement<'a>> {
+    tag_name: &str,
+) -> Option<BindPlacement<'a>> {
     let var_name = if bind.shorthand {
         bind.name.clone()
     } else if let Some(span) = bind.expression_span {
@@ -392,56 +404,243 @@ fn gen_bind_directive<'a>(
         return None;
     };
 
-    let is_mutated_rune = ctx.is_mutable_rune(&var_name);
-
-    let getter_body = if is_mutated_rune {
-        ctx.b.call_expr("$.get", [Arg::Ident(&var_name)])
-    } else {
-        ctx.b.rid_expr(&var_name)
+    // Build getter: () => $.get(x) for runes, () => x for plain vars
+    let build_getter = |ctx: &mut Ctx<'a>, var: &str| -> Expression<'a> {
+        let body = if ctx.is_mutable_rune(var) {
+            ctx.b.call_expr("$.get", [Arg::Ident(var)])
+        } else {
+            ctx.b.rid_expr(var)
+        };
+        ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
     };
-    let getter = ctx
-        .b
-        .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(getter_body)]);
 
-    let setter_body = if is_mutated_rune {
-        ctx.b
-            .call_expr("$.set", [Arg::Ident(&var_name), Arg::Ident("$$value")])
-    } else {
-        ctx.b.assign_expr(
-            AssignLeft::Ident(var_name),
-            AssignRight::Expr(ctx.b.rid_expr("$$value")),
-        )
+    // Build setter: ($$value) => $.set(x, $$value) for runes, ($$value) => x = $$value for plain
+    let build_setter = |ctx: &mut Ctx<'a>, var: String| -> Expression<'a> {
+        let body = if ctx.is_mutable_rune(&var) {
+            ctx.b.call_expr("$.set", [Arg::Ident(&var), Arg::Ident("$$value")])
+        } else {
+            ctx.b.assign_expr(
+                AssignLeft::Ident(var),
+                AssignRight::Expr(ctx.b.rid_expr("$$value")),
+            )
+        };
+        ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
     };
-    let setter = ctx.b.arrow_expr(
-        ctx.b.params(["$$value"]),
-        [ctx.b.expr_stmt(setter_body)],
-    );
 
     let stmt = match bind.name.as_str() {
-        "checked" => ctx.b.call_stmt(
-            "$.bind_checked",
-            [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
-        ),
+        // --- Input/Form ---
+        "value" if tag_name == "select" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_select_value", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+        "value" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_value", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+        "checked" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_checked", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
         "group" => {
             ctx.needs_binding_group = true;
-            ctx.b.call_stmt(
-                "$.bind_group",
-                [
-                    Arg::Ident("binding_group"),
-                    Arg::Expr(ctx.b.empty_array_expr()),
-                    Arg::Ident(el_name),
-                    Arg::Expr(getter),
-                    Arg::Expr(setter),
-                ],
-            )
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_group", [
+                Arg::Ident("binding_group"),
+                Arg::Expr(ctx.b.empty_array_expr()),
+                Arg::Ident(el_name),
+                Arg::Expr(getter),
+                Arg::Expr(setter),
+            ])
         }
-        _ => ctx.b.call_stmt(
-            "$.bind_value",
-            [Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter)],
-        ),
+        "files" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_files", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+
+        // --- Generic event-based bindings (bidirectional) ---
+        "indeterminate" => {
+            let setter = build_setter(ctx, var_name.clone());
+            let getter = build_getter(ctx, &var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("indeterminate".into()), Arg::Str("change".into()),
+                Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
+            ])
+        }
+        "open" => {
+            let setter = build_setter(ctx, var_name.clone());
+            let getter = build_getter(ctx, &var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("open".into()), Arg::Str("toggle".into()),
+                Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
+            ])
+        }
+
+        // --- Contenteditable ---
+        "innerHTML" | "innerText" | "textContent" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_content_editable", [
+                Arg::Str(bind.name.clone()), Arg::Ident(el_name),
+                Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+
+        // --- Dimension bindings (element size, readonly) ---
+        "clientWidth" | "clientHeight" | "offsetWidth" | "offsetHeight" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_element_size", [
+                Arg::Ident(el_name), Arg::Str(bind.name.clone()), Arg::Expr(setter),
+            ])
+        }
+
+        // --- Dimension bindings (resize observer, readonly) ---
+        "contentRect" | "contentBoxSize" | "borderBoxSize" | "devicePixelContentBoxSize" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_resize_observer", [
+                Arg::Ident(el_name), Arg::Str(bind.name.clone()), Arg::Expr(setter),
+            ])
+        }
+
+        // --- Media R/W bindings ---
+        "currentTime" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_current_time", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+        "playbackRate" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_playback_rate", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+        "paused" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_paused", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+        "volume" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_volume", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+        "muted" => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_muted", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
+
+        // --- Media RO bindings (setter only) ---
+        "buffered" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_buffered", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+        "seekable" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_seekable", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+        "seeking" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_seeking", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+        "ended" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_ended", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+        "readyState" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_ready_state", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+        "played" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_played", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+
+        // --- Media/Image RO event-based bindings (bind_property, no bidirectional) ---
+        "duration" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("duration".into()), Arg::Str("durationchange".into()),
+                Arg::Ident(el_name), Arg::Expr(setter),
+            ])
+        }
+        "videoWidth" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("videoWidth".into()), Arg::Str("resize".into()),
+                Arg::Ident(el_name), Arg::Expr(setter),
+            ])
+        }
+        "videoHeight" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("videoHeight".into()), Arg::Str("resize".into()),
+                Arg::Ident(el_name), Arg::Expr(setter),
+            ])
+        }
+        "naturalWidth" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("naturalWidth".into()), Arg::Str("load".into()),
+                Arg::Ident(el_name), Arg::Expr(setter),
+            ])
+        }
+        "naturalHeight" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("naturalHeight".into()), Arg::Str("load".into()),
+                Arg::Ident(el_name), Arg::Expr(setter),
+            ])
+        }
+
+        // --- Misc ---
+        "focused" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_focused", [Arg::Ident(el_name), Arg::Expr(setter)])
+        }
+
+        // --- bind:this ---
+        "this" => {
+            let setter = build_setter(ctx, var_name.clone());
+            let getter = build_getter(ctx, &var_name);
+            let stmt = ctx.b.call_stmt("$.bind_this", [
+                Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
+            ]);
+            return Some(BindPlacement::Init(stmt));
+        }
+
+        // Fallback for unknown bindings
+        _ => {
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_value", [
+                Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
+            ])
+        }
     };
 
-    Some(stmt)
+    Some(BindPlacement::AfterUpdate(stmt))
 }
 
 
@@ -494,8 +693,11 @@ pub(crate) fn process_attrs_spread<'a>(
                 props.push(ObjProp::Shorthand(name_alloc));
             }
             Attribute::BindDirective(bind) => {
-                if let Some(stmt) = gen_bind_directive(ctx, bind, el_name) {
-                    after_update.push(stmt);
+                if let Some(placement) = gen_bind_directive(ctx, bind, el_name, &el.name) {
+                    match placement {
+                        BindPlacement::AfterUpdate(stmt) => after_update.push(stmt),
+                        BindPlacement::Init(stmt) => init.push(stmt),
+                    }
                 }
                 continue;
             }

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -44,6 +44,12 @@ use render_tag::gen_render_tag;
 use const_tag::emit_const_tags;
 use traverse::traverse_items;
 
+/// Check if template HTML needs `importNode` (flag bit 2).
+/// `<video>` requires `importNode` instead of `cloneNode`.
+fn needs_import_node(html: &str) -> bool {
+    html.contains("<video")
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
@@ -150,11 +156,12 @@ fn gen_root_single_element<'a>(
 
     let el = ctx.element(el_id);
     let html = element_html(ctx, el);
-    hoisted.push(ctx.b.var_stmt(
-        tpl_name,
-        ctx.b
-            .call_expr("$.from_html", [Arg::Expr(ctx.b.template_str_expr(&html))]),
-    ));
+    let from_html = if needs_import_node(&html) {
+        ctx.b.call_expr("$.from_html", [Arg::Expr(ctx.b.template_str_expr(&html)), Arg::Num(2.0)])
+    } else {
+        ctx.b.call_expr("$.from_html", [Arg::Expr(ctx.b.template_str_expr(&html))])
+    };
+    hoisted.push(ctx.b.var_stmt(tpl_name, from_html));
 
     let el_name_str = ctx.element(el_id).name.clone();
     let el_name = ctx.gen_ident(&el_name_str);
@@ -235,11 +242,12 @@ fn gen_root_mixed<'a>(
     }
 
     let html = fragment_html(ctx, FragmentKey::Root);
+    let flags = if needs_import_node(&html) { 3.0 } else { 1.0 };
     hoisted.push(ctx.b.var_stmt(
         tpl_name,
         ctx.b.call_expr(
             "$.from_html",
-            [Arg::Expr(ctx.b.template_str_expr(&html)), Arg::Num(1.0)],
+            [Arg::Expr(ctx.b.template_str_expr(&html)), Arg::Num(flags)],
         ),
     ));
 
@@ -336,11 +344,12 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
             ctx.module_hoisted.extend(sub_hoisted);
 
             // Hoist AFTER children so inner templates come first (bottom-up order)
-            ctx.module_hoisted.push(ctx.b.var_stmt(
-                &tpl_name,
-                ctx.b
-                    .call_expr("$.from_html", [Arg::Expr(ctx.b.template_str_expr(&html))]),
-            ));
+            let from_html = if needs_import_node(&html) {
+                ctx.b.call_expr("$.from_html", [Arg::Expr(ctx.b.template_str_expr(&html)), Arg::Num(2.0)])
+            } else {
+                ctx.b.call_expr("$.from_html", [Arg::Expr(ctx.b.template_str_expr(&html))])
+            };
+            ctx.module_hoisted.push(ctx.b.var_stmt(&tpl_name, from_html));
 
             // Prepend const tags from body, then element code
             body.push(ctx.b.var_stmt(&el_name, ctx.b.call_expr(&tpl_name, [])));
@@ -408,11 +417,12 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
             }
 
             let html = fragment_html(ctx, key);
+            let flags = if needs_import_node(&html) { 3.0 } else { 1.0 };
             let tpl_stmt = ctx.b.var_stmt(
                 &tpl_name,
                 ctx.b.call_expr(
                     "$.from_html",
-                    [Arg::Expr(ctx.b.template_str_expr(&html)), Arg::Num(1.0)],
+                    [Arg::Expr(ctx.b.template_str_expr(&html)), Arg::Num(flags)],
                 ),
             );
 

--- a/tasks/compiler_tests/cases2/bind_content_editable/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_content_editable/case-rust.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div contenteditable=""></div> <div contenteditable=""></div> <div contenteditable=""></div>`, 1);
+export default function App($$anchor) {
+	let html = $.state("");
+	let text = $.state("");
+	let content = $.state("");
+	var fragment = root();
+	var div = $.first_child(fragment);
+	var div_1 = $.sibling(div, 2);
+	var div_2 = $.sibling(div_1, 2);
+	$.bind_content_editable("innerHTML", div, () => $.get(html), ($$value) => $.set(html, $$value));
+	$.bind_content_editable("innerText", div_1, () => $.get(text), ($$value) => $.set(text, $$value));
+	$.bind_content_editable("textContent", div_2, () => $.get(content), ($$value) => $.set(content, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_content_editable/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_content_editable/case-svelte.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div contenteditable=""></div> <div contenteditable=""></div> <div contenteditable=""></div>`, 1);
+export default function App($$anchor) {
+	let html = $.state("");
+	let text = $.state("");
+	let content = $.state("");
+	var fragment = root();
+	var div = $.first_child(fragment);
+	var div_1 = $.sibling(div, 2);
+	var div_2 = $.sibling(div_1, 2);
+	$.bind_content_editable("innerHTML", div, () => $.get(html), ($$value) => $.set(html, $$value));
+	$.bind_content_editable("innerText", div_1, () => $.get(text), ($$value) => $.set(text, $$value));
+	$.bind_content_editable("textContent", div_2, () => $.get(content), ($$value) => $.set(content, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_content_editable/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_content_editable/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	let html = $state('');
+	let text = $state('');
+	let content = $state('');
+</script>
+
+<div contenteditable bind:innerHTML={html}></div>
+
+<div contenteditable bind:innerText={text}></div>
+
+<div contenteditable bind:textContent={content}></div>

--- a/tasks/compiler_tests/cases2/bind_element_size/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_element_size/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div></div> <div></div>`, 1);
+export default function App($$anchor) {
+	let w = $.state(0);
+	let h = $.state(0);
+	var fragment = root();
+	var div = $.first_child(fragment);
+	var div_1 = $.sibling(div, 2);
+	$.bind_element_size(div, "clientWidth", ($$value) => $.set(w, $$value));
+	$.bind_element_size(div, "clientHeight", ($$value) => $.set(h, $$value));
+	$.bind_element_size(div_1, "offsetWidth", ($$value) => $.set(w, $$value));
+	$.bind_element_size(div_1, "offsetHeight", ($$value) => $.set(h, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_element_size/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_element_size/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div></div> <div></div>`, 1);
+export default function App($$anchor) {
+	let w = $.state(0);
+	let h = $.state(0);
+	var fragment = root();
+	var div = $.first_child(fragment);
+	var div_1 = $.sibling(div, 2);
+	$.bind_element_size(div, "clientWidth", ($$value) => $.set(w, $$value));
+	$.bind_element_size(div, "clientHeight", ($$value) => $.set(h, $$value));
+	$.bind_element_size(div_1, "offsetWidth", ($$value) => $.set(w, $$value));
+	$.bind_element_size(div_1, "offsetHeight", ($$value) => $.set(h, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_element_size/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_element_size/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let w = $state(0);
+	let h = $state(0);
+</script>
+
+<div bind:clientWidth={w} bind:clientHeight={h}></div>
+
+<div bind:offsetWidth={w} bind:offsetHeight={h}></div>

--- a/tasks/compiler_tests/cases2/bind_files/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_files/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="file"/>`);
+export default function App($$anchor) {
+	let files = $.state(void 0);
+	var input = root();
+	$.bind_files(input, () => $.get(files), ($$value) => $.set(files, $$value));
+	$.append($$anchor, input);
+}

--- a/tasks/compiler_tests/cases2/bind_files/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_files/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="file"/>`);
+export default function App($$anchor) {
+	let files = $.state(void 0);
+	var input = root();
+	$.bind_files(input, () => $.get(files), ($$value) => $.set(files, $$value));
+	$.append($$anchor, input);
+}

--- a/tasks/compiler_tests/cases2/bind_files/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_files/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let files = $state();
+</script>
+
+<input type="file" bind:files />

--- a/tasks/compiler_tests/cases2/bind_focused/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_focused/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button></button>`);
+export default function App($$anchor) {
+	let focused = $.state(false);
+	var button = root();
+	$.bind_focused(button, ($$value) => $.set(focused, $$value));
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/bind_focused/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_focused/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button></button>`);
+export default function App($$anchor) {
+	let focused = $.state(false);
+	var button = root();
+	$.bind_focused(button, ($$value) => $.set(focused, $$value));
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/bind_focused/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_focused/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let focused = $state(false);
+</script>
+
+<button bind:focused></button>

--- a/tasks/compiler_tests/cases2/bind_img/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_img/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<img/>`);
+export default function App($$anchor) {
+	let naturalWidth = $.state(0);
+	let naturalHeight = $.state(0);
+	var img = root();
+	$.bind_property("naturalWidth", "load", img, ($$value) => $.set(naturalWidth, $$value));
+	$.bind_property("naturalHeight", "load", img, ($$value) => $.set(naturalHeight, $$value));
+	$.append($$anchor, img);
+}

--- a/tasks/compiler_tests/cases2/bind_img/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_img/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<img/>`);
+export default function App($$anchor) {
+	let naturalWidth = $.state(0);
+	let naturalHeight = $.state(0);
+	var img = root();
+	$.bind_property("naturalWidth", "load", img, ($$value) => $.set(naturalWidth, $$value));
+	$.bind_property("naturalHeight", "load", img, ($$value) => $.set(naturalHeight, $$value));
+	$.append($$anchor, img);
+}

--- a/tasks/compiler_tests/cases2/bind_img/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_img/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let naturalWidth = $state(0);
+	let naturalHeight = $state(0);
+</script>
+
+<img bind:naturalWidth bind:naturalHeight />

--- a/tasks/compiler_tests/cases2/bind_media_property/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_media_property/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<audio></audio> <video></video>`, 3);
+export default function App($$anchor) {
+	let duration = $.state(0);
+	let videoWidth = $.state(0);
+	let videoHeight = $.state(0);
+	var fragment = root();
+	var audio = $.first_child(fragment);
+	var video = $.sibling(audio, 2);
+	$.bind_property("duration", "durationchange", audio, ($$value) => $.set(duration, $$value));
+	$.bind_property("videoWidth", "resize", video, ($$value) => $.set(videoWidth, $$value));
+	$.bind_property("videoHeight", "resize", video, ($$value) => $.set(videoHeight, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_media_property/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_media_property/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<audio></audio> <video></video>`, 3);
+export default function App($$anchor) {
+	let duration = $.state(0);
+	let videoWidth = $.state(0);
+	let videoHeight = $.state(0);
+	var fragment = root();
+	var audio = $.first_child(fragment);
+	var video = $.sibling(audio, 2);
+	$.bind_property("duration", "durationchange", audio, ($$value) => $.set(duration, $$value));
+	$.bind_property("videoWidth", "resize", video, ($$value) => $.set(videoWidth, $$value));
+	$.bind_property("videoHeight", "resize", video, ($$value) => $.set(videoHeight, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_media_property/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_media_property/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let duration = $state(0);
+	let videoWidth = $state(0);
+	let videoHeight = $state(0);
+</script>
+
+<audio bind:duration></audio>
+
+<video bind:videoWidth bind:videoHeight></video>

--- a/tasks/compiler_tests/cases2/bind_media_ro/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_media_ro/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<audio></audio>`);
+export default function App($$anchor) {
+	let buffered = $.state(void 0);
+	let seekable = $.state(void 0);
+	let seeking = $.state(false);
+	let ended = $.state(false);
+	let readyState = $.state(0);
+	let played = $.state(void 0);
+	var audio = root();
+	$.bind_buffered(audio, ($$value) => $.set(buffered, $$value));
+	$.bind_seekable(audio, ($$value) => $.set(seekable, $$value));
+	$.bind_seeking(audio, ($$value) => $.set(seeking, $$value));
+	$.bind_ended(audio, ($$value) => $.set(ended, $$value));
+	$.bind_ready_state(audio, ($$value) => $.set(readyState, $$value));
+	$.bind_played(audio, ($$value) => $.set(played, $$value));
+	$.append($$anchor, audio);
+}

--- a/tasks/compiler_tests/cases2/bind_media_ro/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_media_ro/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<audio></audio>`);
+export default function App($$anchor) {
+	let buffered = $.state(void 0);
+	let seekable = $.state(void 0);
+	let seeking = $.state(false);
+	let ended = $.state(false);
+	let readyState = $.state(0);
+	let played = $.state(void 0);
+	var audio = root();
+	$.bind_buffered(audio, ($$value) => $.set(buffered, $$value));
+	$.bind_seekable(audio, ($$value) => $.set(seekable, $$value));
+	$.bind_seeking(audio, ($$value) => $.set(seeking, $$value));
+	$.bind_ended(audio, ($$value) => $.set(ended, $$value));
+	$.bind_ready_state(audio, ($$value) => $.set(readyState, $$value));
+	$.bind_played(audio, ($$value) => $.set(played, $$value));
+	$.append($$anchor, audio);
+}

--- a/tasks/compiler_tests/cases2/bind_media_ro/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_media_ro/case.svelte
@@ -1,0 +1,17 @@
+<script>
+	let buffered = $state();
+	let seekable = $state();
+	let seeking = $state(false);
+	let ended = $state(false);
+	let readyState = $state(0);
+	let played = $state();
+</script>
+
+<audio
+	bind:buffered
+	bind:seekable
+	bind:seeking
+	bind:ended
+	bind:readyState
+	bind:played
+></audio>

--- a/tasks/compiler_tests/cases2/bind_media_rw/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_media_rw/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<audio></audio>`);
+export default function App($$anchor) {
+	let currentTime = $.state(0);
+	let paused = $.state(true);
+	let volume = $.state(1);
+	let muted = $.state(false);
+	let playbackRate = $.state(1);
+	var audio = root();
+	$.bind_current_time(audio, () => $.get(currentTime), ($$value) => $.set(currentTime, $$value));
+	$.bind_paused(audio, () => $.get(paused), ($$value) => $.set(paused, $$value));
+	$.bind_volume(audio, () => $.get(volume), ($$value) => $.set(volume, $$value));
+	$.bind_muted(audio, () => $.get(muted), ($$value) => $.set(muted, $$value));
+	$.bind_playback_rate(audio, () => $.get(playbackRate), ($$value) => $.set(playbackRate, $$value));
+	$.append($$anchor, audio);
+}

--- a/tasks/compiler_tests/cases2/bind_media_rw/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_media_rw/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<audio></audio>`);
+export default function App($$anchor) {
+	let currentTime = $.state(0);
+	let paused = $.state(true);
+	let volume = $.state(1);
+	let muted = $.state(false);
+	let playbackRate = $.state(1);
+	var audio = root();
+	$.bind_current_time(audio, () => $.get(currentTime), ($$value) => $.set(currentTime, $$value));
+	$.bind_paused(audio, () => $.get(paused), ($$value) => $.set(paused, $$value));
+	$.bind_volume(audio, () => $.get(volume), ($$value) => $.set(volume, $$value));
+	$.bind_muted(audio, () => $.get(muted), ($$value) => $.set(muted, $$value));
+	$.bind_playback_rate(audio, () => $.get(playbackRate), ($$value) => $.set(playbackRate, $$value));
+	$.append($$anchor, audio);
+}

--- a/tasks/compiler_tests/cases2/bind_media_rw/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_media_rw/case.svelte
@@ -1,0 +1,15 @@
+<script>
+	let currentTime = $state(0);
+	let paused = $state(true);
+	let volume = $state(1);
+	let muted = $state(false);
+	let playbackRate = $state(1);
+</script>
+
+<audio
+	bind:currentTime
+	bind:paused
+	bind:volume
+	bind:muted
+	bind:playbackRate
+></audio>

--- a/tasks/compiler_tests/cases2/bind_property/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_property/case-rust.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="checkbox"/> <details></details>`, 1);
+export default function App($$anchor) {
+	let indeterminate = $.state(false);
+	let open = $.state(true);
+	var fragment = root();
+	var input = $.first_child(fragment);
+	var details = $.sibling(input, 2);
+	$.bind_property("indeterminate", "change", input, ($$value) => $.set(indeterminate, $$value), () => $.get(indeterminate));
+	$.bind_property("open", "toggle", details, ($$value) => $.set(open, $$value), () => $.get(open));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_property/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_property/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="checkbox"/> <details></details>`, 1);
+export default function App($$anchor) {
+	let indeterminate = $.state(false);
+	let open = $.state(true);
+	var fragment = root();
+	var input = $.first_child(fragment);
+	var details = $.sibling(input, 2);
+	$.bind_property("indeterminate", "change", input, ($$value) => $.set(indeterminate, $$value), () => $.get(indeterminate));
+	$.bind_property("open", "toggle", details, ($$value) => $.set(open, $$value), () => $.get(open));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_property/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_property/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let indeterminate = $state(false);
+	let open = $state(true);
+</script>
+
+<input type="checkbox" bind:indeterminate />
+
+<details bind:open></details>

--- a/tasks/compiler_tests/cases2/bind_resize_observer/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_resize_observer/case-rust.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div></div> <div></div>`, 1);
+export default function App($$anchor) {
+	let rect = $.state(void 0);
+	let box_size = $.state(void 0);
+	var fragment = root();
+	var div = $.first_child(fragment);
+	var div_1 = $.sibling(div, 2);
+	$.bind_resize_observer(div, "contentRect", ($$value) => $.set(rect, $$value));
+	$.bind_resize_observer(div_1, "contentBoxSize", ($$value) => $.set(box_size, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_resize_observer/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_resize_observer/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div></div> <div></div>`, 1);
+export default function App($$anchor) {
+	let rect = $.state(void 0);
+	let box_size = $.state(void 0);
+	var fragment = root();
+	var div = $.first_child(fragment);
+	var div_1 = $.sibling(div, 2);
+	$.bind_resize_observer(div, "contentRect", ($$value) => $.set(rect, $$value));
+	$.bind_resize_observer(div_1, "contentBoxSize", ($$value) => $.set(box_size, $$value));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/bind_resize_observer/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_resize_observer/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let rect = $state();
+	let box_size = $state();
+</script>
+
+<div bind:contentRect={rect}></div>
+
+<div bind:contentBoxSize={box_size}></div>

--- a/tasks/compiler_tests/cases2/bind_select_value/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_select_value/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<select></select>`);
+export default function App($$anchor) {
+	let selected = $.state("a");
+	var select = root();
+	$.bind_select_value(select, () => $.get(selected), ($$value) => $.set(selected, $$value));
+	$.append($$anchor, select);
+}

--- a/tasks/compiler_tests/cases2/bind_select_value/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_select_value/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<select></select>`);
+export default function App($$anchor) {
+	let selected = $.state("a");
+	var select = root();
+	$.bind_select_value(select, () => $.get(selected), ($$value) => $.set(selected, $$value));
+	$.append($$anchor, select);
+}

--- a/tasks/compiler_tests/cases2/bind_select_value/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_select_value/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let selected = $state('a');
+</script>
+
+<select bind:value={selected}></select>

--- a/tasks/compiler_tests/cases2/bind_this/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_this/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<canvas></canvas>`);
+export default function App($$anchor) {
+	let el = $.state(void 0);
+	var canvas = root();
+	$.bind_this(canvas, ($$value) => $.set(el, $$value), () => $.get(el));
+	$.append($$anchor, canvas);
+}

--- a/tasks/compiler_tests/cases2/bind_this/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_this/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<canvas></canvas>`);
+export default function App($$anchor) {
+	let el = $.state(void 0);
+	var canvas = root();
+	$.bind_this(canvas, ($$value) => $.set(el, $$value), () => $.get(el));
+	$.append($$anchor, canvas);
+}

--- a/tasks/compiler_tests/cases2/bind_this/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_this/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let el = $state();
+</script>
+
+<canvas bind:this={el}></canvas>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -411,6 +411,66 @@ fn class_expr_with_directives() {
     assert_compiler("class_expr_with_directives");
 }
 
+#[rstest]
+fn bind_select_value() {
+    assert_compiler("bind_select_value");
+}
+
+#[rstest]
+fn bind_files() {
+    assert_compiler("bind_files");
+}
+
+#[rstest]
+fn bind_property() {
+    assert_compiler("bind_property");
+}
+
+#[rstest]
+fn bind_content_editable() {
+    assert_compiler("bind_content_editable");
+}
+
+#[rstest]
+fn bind_element_size() {
+    assert_compiler("bind_element_size");
+}
+
+#[rstest]
+fn bind_resize_observer() {
+    assert_compiler("bind_resize_observer");
+}
+
+#[rstest]
+fn bind_media_rw() {
+    assert_compiler("bind_media_rw");
+}
+
+#[rstest]
+fn bind_media_ro() {
+    assert_compiler("bind_media_ro");
+}
+
+#[rstest]
+fn bind_media_property() {
+    assert_compiler("bind_media_property");
+}
+
+#[rstest]
+fn bind_img() {
+    assert_compiler("bind_img");
+}
+
+#[rstest]
+fn bind_this() {
+    assert_compiler("bind_this");
+}
+
+#[rstest]
+fn bind_focused() {
+    assert_compiler("bind_focused");
+}
+
 // ---------------------------------------------------------------------------
 // Module compilation tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Expand gen_bind_directive to handle all regular-element binding types:
- Input/form: bind:value (select), bind:files, bind:indeterminate, bind:open
- Contenteditable: bind:innerHTML, bind:innerText, bind:textContent
- Dimensions: bind:clientWidth/Height, bind:offsetWidth/Height (element size)
- Resize observer: bind:contentRect, bind:contentBoxSize, etc.
- Media R/W: bind:currentTime, bind:paused, bind:volume, bind:muted, bind:playbackRate
- Media RO: bind:buffered, bind:seekable, bind:seeking, bind:ended, bind:readyState, bind:played
- Event-based RO: bind:duration, bind:videoWidth/Height, bind:naturalWidth/Height
- bind:this (placed in init, not after_update)
- bind:focused

Also fixes:
- remove_input_defaults only emitted for bind:value/checked/group (not all bind directives)
- from_html flag 2 (TEMPLATE_USE_IMPORT_NODE) added for <video> elements
- BindPlacement enum for init vs after_update statement placement

12 new test cases, all 89 compiler tests pass.

https://claude.ai/code/session_014Z7n8Cxsve6TKg5BJiWRce