### PR TITLE
feat: port use:action directive (Tier 4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -305,11 +305,12 @@ Note: `bind:this` uses a different pattern — NOT getter/setter, uses `build_bi
 
 Theme: action, transition, animation directives. New AST attribute variants + parser + codegen.
 
-### `use:action={params}` — Action directive
+### ~~`use:action={params}` — Action directive~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Attribute::UseDirective { name, expression_span: Option<Span> }`
 - **Codegen**: `$.action(el, () => actionFn, () => params)`
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/UseDirective.js` (~30 lines)
+- [ ] `use:action` with `await` expression (requires `run_after_blockers`) *(discovered during port, deferred)*
 
 ### `transition:name={params}` / `in:` / `out:` — Transitions
 - **Phases**: P, A, T

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -272,6 +272,12 @@ fn walk_attrs<'a>(
                 let source = component.source_text(span);
                 parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
             }
+            Attribute::UseDirective(a) => {
+                if let Some(span) = a.expression_span {
+                    let source = component.source_text(span);
+                    parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+                }
+            }
             Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_) => {}
             // LEGACY(svelte4): on:directive — parse expression if present
             Attribute::OnDirectiveLegacy(a) => {

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element, ExpressionTag, HtmlTag,
-    IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock,
+    IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock, UseDirective,
 };
 use crate::data::AnalysisData;
 use crate::walker::TemplateVisitor;
@@ -99,6 +99,10 @@ impl TemplateVisitor for ReactivityVisitor {
     }
 
     fn visit_bind_directive(&mut self, _dir: &BindDirective, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
+        data.element_flags.needs_ref.insert(el.id);
+    }
+
+    fn visit_use_directive(&mut self, _dir: &UseDirective, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
         data.element_flags.needs_ref.insert(el.id);
     }
 

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element, ExpressionTag, Fragment,
-    HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
+    HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -29,6 +29,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {}
     /// Called after element children have been walked. Use for bottom-up computations.
     fn leave_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -57,6 +58,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
                     visitor.visit_attribute(attr, idx, el, scope, data);
                     if let Attribute::BindDirective(dir) = attr {
                         visitor.visit_bind_directive(dir, el, scope, data);
+                    }
+                    if let Attribute::UseDirective(dir) = attr {
+                        visitor.visit_use_directive(dir, el, scope, data);
                     }
                 }
                 walk_template(&el.fragment, data, scope, visitor);
@@ -146,6 +150,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_bind_directive(dir, el, scope, data);)+
+        }
+        fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_use_directive(dir, el, scope, data);)+
         }
         fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_component_attribute(attr, idx, cn, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -327,6 +327,8 @@ pub enum Attribute {
     StyleDirective(StyleDirective),
     /// bind:name or bind:name={expr}
     BindDirective(BindDirective),
+    /// use:name or use:name={expr}
+    UseDirective(UseDirective),
     /// LEGACY(svelte4): on:event or on:event={handler} or on:event|modifier={handler}
     /// Deprecated in Svelte 5, remove in Svelte 6.
     OnDirectiveLegacy(OnDirectiveLegacy),
@@ -405,6 +407,15 @@ pub struct BindDirective {
     /// Span of the JS expression. None means shorthand (bind:name).
     pub expression_span: Option<Span>,
     pub shorthand: bool,
+}
+
+/// use:name or use:name={expr}
+#[derive(Clone)]
+pub struct UseDirective {
+    /// Directive name (e.g., "tooltip" in `use:tooltip`, "a.b" in `use:a.b`).
+    pub name: String,
+    /// Span of the argument expression. None if no expression (`use:name`).
+    pub expression_span: Option<Span>,
 }
 
 /// LEGACY(svelte4): on:directive syntax. Deprecated in Svelte 5, remove in Svelte 6.

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -2,7 +2,7 @@ use oxc_allocator::{Allocator, Box, CloneIn};
 use oxc_ast::{
     ast::{
         self, Argument, ArrowFunctionExpression, AssignmentTarget,
-        BindingIdentifier, CallExpression, ExportDefaultDeclarationKind,
+        BindingIdentifier, CallExpression, ChainElement, ExportDefaultDeclarationKind,
         Expression, FormalParameters, Function, FunctionType, IdentifierReference,
         ImportDeclarationSpecifier, ImportOrExportKind, ModuleDeclaration,
         NumericLiteral, Program, Statement,
@@ -478,6 +478,19 @@ impl<'a> Builder<'a> {
         let args = args.into_iter().map(|a| self.arg_to_argument(a));
         Expression::CallExpression(self.alloc(
             self.ast.call_expression(SPAN, callee, NONE, self.ast.vec_from_iter(args), false),
+        ))
+    }
+
+    /// Optional call expression: `callee?.(...args)` — ChainExpression wrapping an optional CallExpression.
+    pub fn maybe_call_expr<'short>(
+        &self,
+        callee: Expression<'a>,
+        args: impl IntoIterator<Item = Arg<'a, 'short>>,
+    ) -> Expression<'a> {
+        let args = args.into_iter().map(|a| self.arg_to_argument(a));
+        let call = self.ast.call_expression(SPAN, callee, NONE, self.ast.vec_from_iter(args), true);
+        Expression::ChainExpression(self.alloc(
+            self.ast.chain_expression(SPAN, ChainElement::CallExpression(self.alloc(call))),
         ))
     }
 

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -121,6 +121,9 @@ pub(crate) fn process_attr<'a>(
         Attribute::ShorthandOrSpread(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => {
             // Spread handled by process_attrs_spread; class/style directives by dedicated functions
         }
+        Attribute::UseDirective(ud) => {
+            gen_use_directive(ctx, ud, owner_id, attr_idx, el_name, init);
+        }
         // LEGACY(svelte4): on:directive
         Attribute::OnDirectiveLegacy(od) => {
             gen_on_directive_legacy(ctx, od, owner_id, attr_idx, el_name, after_update);
@@ -702,6 +705,7 @@ pub(crate) fn process_attrs_spread<'a>(
                 continue;
             }
             Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => continue,
+            Attribute::UseDirective(_) => continue,
             // LEGACY(svelte4): on:directive handled separately
             Attribute::OnDirectiveLegacy(_) => continue,
         }
@@ -714,6 +718,67 @@ pub(crate) fn process_attrs_spread<'a>(
 }
 
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// use:action directive codegen
+// ---------------------------------------------------------------------------
+
+/// Generate `$.action(el, ($$node) => name?.($$node), () => expr)`.
+/// Reference: `UseDirective.js`.
+fn gen_use_directive<'a>(
+    ctx: &mut Ctx<'a>,
+    ud: &svelte_ast::UseDirective,
+    owner_id: NodeId,
+    attr_idx: usize,
+    el_name: &str,
+    init: &mut Vec<Statement<'a>>,
+) {
+    // Build handler params: ($$node) or ($$node, $$action_arg)
+    let has_expr = ud.expression_span.is_some();
+    let params = if has_expr {
+        ctx.b.params(["$$node", "$$action_arg"])
+    } else {
+        ctx.b.params(["$$node"])
+    };
+
+    // Build directive name expression (handles dotted names like "a.b")
+    let name_expr = build_directive_name_expr(ctx, &ud.name);
+
+    // Build optional call: name?.($$node) or name?.($$node, $$action_arg)
+    let mut call_args: Vec<Arg<'a, '_>> = vec![Arg::Ident("$$node")];
+    if has_expr {
+        call_args.push(Arg::Ident("$$action_arg"));
+    }
+    let action_call = ctx.b.maybe_call_expr(name_expr, call_args);
+
+    // Wrap in arrow: ($$node) => name?.($$node)
+    let handler = ctx.b.arrow_expr(params, [ctx.b.expr_stmt(action_call)]);
+
+    // Build $.action() args
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Ident(el_name),
+        Arg::Expr(handler),
+    ];
+
+    // Optional third arg: () => expression
+    if has_expr {
+        let expr = get_attr_expr(ctx, owner_id, attr_idx);
+        let thunk = ctx.b.thunk(expr);
+        args.push(Arg::Expr(thunk));
+    }
+
+    init.push(ctx.b.call_stmt("$.action", args));
+}
+
+/// Parse a directive name like "a.b.c" into a member expression.
+fn build_directive_name_expr<'a>(ctx: &Ctx<'a>, name: &str) -> Expression<'a> {
+    let parts: Vec<&str> = name.split('.').collect();
+    let mut expr = ctx.b.rid_expr(parts[0]);
+    for part in &parts[1..] {
+        expr = ctx.b.static_member_expr(expr, part);
+    }
+    expr
+}
+
 // LEGACY(svelte4): on:directive codegen
 // ---------------------------------------------------------------------------
 

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -58,7 +58,7 @@ pub(crate) fn gen_component<'a>(
                 attr_idx: idx,
             },
             Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_)
-            | Attribute::OnDirectiveLegacy(_) => AttrKind::Skip,
+            | Attribute::UseDirective(_) | Attribute::OnDirectiveLegacy(_) => AttrKind::Skip,
         };
         (kind, is_dynamic)
     }).collect();

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -8,7 +8,7 @@ use svelte_ast::{
     Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode, ConstTag,
     ConcatPart, ConcatenationAttribute, Component, EachBlock, Element, OnDirectiveLegacy, StyleDirective, StyleDirectiveValue,
     ExpressionAttribute, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
-    ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
+    ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text, UseDirective,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -886,6 +886,17 @@ impl<'a> Parser<'a> {
                         name: bd.name_span.source_text(self.source).to_string(),
                         expression_span,
                         shorthand: bd.shorthand,
+                    }));
+                }
+                token::Attribute::UseDirective(ud) => {
+                    let expression_span = if ud.shorthand {
+                        None
+                    } else {
+                        Some(ud.expression_span)
+                    };
+                    attributes.push(Attribute::UseDirective(UseDirective {
+                        name: ud.name_span.source_text(self.source).to_string(),
+                        expression_span,
                     }));
                 }
                 // LEGACY(svelte4): on:directive

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -8,6 +8,7 @@ use token::{
     Attribute, AttributeIdentifierType, AttributeValue, BindDirective, ClassDirective,
     Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, OnDirectiveLegacy,
     ScriptTag, StartEachTag, StartIfTag, StartKeyTag, StartTag, StyleDirective, Token, TokenType,
+    UseDirective,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -169,6 +170,8 @@ impl<'a> Scanner<'a> {
                 AttributeIdentifierType::StyleDirective(value_span, value).as_ok()
             } else if AttributeIdentifierType::is_bind_directive(name) {
                 AttributeIdentifierType::BindDirective(value_span, value).as_ok()
+            } else if AttributeIdentifierType::is_use_directive(name) {
+                AttributeIdentifierType::UseDirective(value_span, value).as_ok()
             // LEGACY(svelte4): on:directive
             } else if AttributeIdentifierType::is_on_directive(name) {
                 AttributeIdentifierType::OnDirectiveLegacy(value_span, value).as_ok()
@@ -327,6 +330,7 @@ impl<'a> Scanner<'a> {
                         self.style_directive(span)
                     }
                     AttributeIdentifierType::BindDirective(span, name) => self.bind_directive(span, name),
+                    AttributeIdentifierType::UseDirective(span, _) => self.use_directive(span),
                     // LEGACY(svelte4): on:directive
                     AttributeIdentifierType::OnDirectiveLegacy(span, _) => self.on_directive_legacy(span),
                     AttributeIdentifierType::None => break,
@@ -427,6 +431,33 @@ impl<'a> Scanner<'a> {
         }
 
         Ok(Attribute::BindDirective(BindDirective {
+            name_span,
+            expression_span: name_span,
+            shorthand: true,
+        }))
+    }
+
+    fn use_directive(&mut self, mut name_span: Span) -> Result<Attribute, Diagnostic> {
+        // Consume dotted name segments: use:a.b.c
+        while self.peek() == Some('.') {
+            self.advance(); // consume '.'
+            while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '_') {
+                self.advance();
+            }
+            name_span = Span::new(name_span.start, self.current as u32);
+        }
+
+        if self.match_char('=') {
+            let res = self.expression_tag()?;
+
+            return Ok(Attribute::UseDirective(UseDirective {
+                expression_span: res.expression_span,
+                name_span,
+                shorthand: false,
+            }));
+        }
+
+        Ok(Attribute::UseDirective(UseDirective {
             name_span,
             expression_span: name_span,
             shorthand: true,
@@ -1429,6 +1460,7 @@ mod tests {
                 Attribute::ClassDirective(_) => "$classDirective",
                 Attribute::StyleDirective(sd) => sd.name_span.source_text(source),
                 Attribute::BindDirective(_) => "$bindDirective",
+                Attribute::UseDirective(ud) => ud.name_span.source_text(source),
                 Attribute::OnDirectiveLegacy(od) => od.name_span.source_text(source),
             };
 
@@ -1458,6 +1490,7 @@ mod tests {
                     }
                 },
                 Attribute::BindDirective(bd) => bd.expression_span.source_text(source).to_string(),
+                Attribute::UseDirective(ud) => ud.expression_span.source_text(source).to_string(),
                 Attribute::OnDirectiveLegacy(od) => od.expression_span.source_text(source).to_string(),
             };
 

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -65,6 +65,7 @@ pub enum Attribute {
     ClassDirective(ClassDirective),
     StyleDirective(StyleDirective),
     BindDirective(BindDirective),
+    UseDirective(UseDirective),
     /// LEGACY(svelte4): on:directive syntax. Deprecated in Svelte 5, remove in Svelte 6.
     OnDirectiveLegacy(OnDirectiveLegacy),
 }
@@ -86,6 +87,13 @@ pub struct StyleDirective {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct BindDirective {
+    pub shorthand: bool,
+    pub name_span: Span,
+    pub expression_span: Span,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct UseDirective {
     pub shorthand: bool,
     pub name_span: Span,
     pub expression_span: Span,
@@ -191,6 +199,7 @@ pub enum AttributeIdentifierType<'a> {
     ClassDirective(Span, &'a str),
     StyleDirective(Span, &'a str),
     BindDirective(Span, &'a str),
+    UseDirective(Span, &'a str),
     /// LEGACY(svelte4): on:directive
     OnDirectiveLegacy(Span, &'a str),
     None,
@@ -207,6 +216,10 @@ impl<'a> AttributeIdentifierType<'a> {
 
     pub fn is_bind_directive(name: &str) -> bool {
         name == "bind"
+    }
+
+    pub fn is_use_directive(name: &str) -> bool {
+        name == "use"
     }
 
     /// LEGACY(svelte4): on:directive

--- a/tasks/benchmark/benches/compiler/big_v2.svelte
+++ b/tasks/benchmark/benches/compiler/big_v2.svelte
@@ -1,0 +1,2598 @@
+<script>
+    import { onMount } from "svelte";
+
+    let {
+        title = "Default Title",
+        count = 0,
+        items = [],
+        config = $bindable({}),
+        multiplier = 2,
+        ...rest
+    } = $props();
+
+    let state = $state("");
+    let counter = $state(0);
+
+    counter = 10;
+
+    let doubled = $derived(count * multiplier);
+
+    $effect(() => {
+        console.log("Title:", title, "Count:", count);
+    });
+
+    export const APP_VERSION = "1.0.0";
+
+    export function formatTitle(prefix) {
+        return prefix + ": " + title;
+    }
+
+    function action(node, arg) {
+        return { destroy() {} };
+    }
+</script>
+
+{#snippet badge(text, variant)}
+    <span class="badge" class:primary={variant === "primary"} class:secondary={variant === "secondary"}>
+        {text}
+    </span>
+{/snippet}
+
+{#snippet card(heading, body)}
+    <div class="card">
+        <h3>{heading}</h3>
+        <p>{body}</p>
+        {@render badge("new", "primary")}
+    </div>
+{/snippet}
+
+<div>
+    Chunk 0: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 0.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 0.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 0.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-0">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-0", "secondary")}
+    {@render card(title, "Content for chunk 0")}
+</div>
+
+<div>
+    Chunk 1: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 1.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 1.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 1.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-1">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-1", "secondary")}
+    {@render card(title, "Content for chunk 1")}
+</div>
+
+<div>
+    Chunk 2: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 2.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 2.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 2.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-2">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-2", "secondary")}
+    {@render card(title, "Content for chunk 2")}
+</div>
+
+<div>
+    Chunk 3: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 3.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 3.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 3.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-3">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-3", "secondary")}
+    {@render card(title, "Content for chunk 3")}
+</div>
+
+<div>
+    Chunk 4: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 4.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 4.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 4.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-4">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-4", "secondary")}
+    {@render card(title, "Content for chunk 4")}
+</div>
+
+<div>
+    Chunk 5: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 5.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 5.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 5.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-5">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-5", "secondary")}
+    {@render card(title, "Content for chunk 5")}
+</div>
+
+<div>
+    Chunk 6: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 6.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 6.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 6.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-6">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-6", "secondary")}
+    {@render card(title, "Content for chunk 6")}
+</div>
+
+<div>
+    Chunk 7: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 7.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 7.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 7.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-7">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-7", "secondary")}
+    {@render card(title, "Content for chunk 7")}
+</div>
+
+<div>
+    Chunk 8: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 8.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 8.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 8.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-8">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-8", "secondary")}
+    {@render card(title, "Content for chunk 8")}
+</div>
+
+<div>
+    Chunk 9: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 9.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 9.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 9.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-9">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-9", "secondary")}
+    {@render card(title, "Content for chunk 9")}
+</div>
+
+<div>
+    Chunk 10: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 10.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 10.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 10.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-10">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-10", "secondary")}
+    {@render card(title, "Content for chunk 10")}
+</div>
+
+<div>
+    Chunk 11: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 11.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 11.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 11.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-11">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-11", "secondary")}
+    {@render card(title, "Content for chunk 11")}
+</div>
+
+<div>
+    Chunk 12: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 12.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 12.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 12.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-12">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-12", "secondary")}
+    {@render card(title, "Content for chunk 12")}
+</div>
+
+<div>
+    Chunk 13: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 13.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 13.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 13.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-13">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-13", "secondary")}
+    {@render card(title, "Content for chunk 13")}
+</div>
+
+<div>
+    Chunk 14: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 14.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 14.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 14.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-14">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-14", "secondary")}
+    {@render card(title, "Content for chunk 14")}
+</div>
+
+<div>
+    Chunk 15: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 15.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 15.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 15.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-15">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-15", "secondary")}
+    {@render card(title, "Content for chunk 15")}
+</div>
+
+<div>
+    Chunk 16: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 16.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 16.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 16.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-16">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-16", "secondary")}
+    {@render card(title, "Content for chunk 16")}
+</div>
+
+<div>
+    Chunk 17: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 17.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 17.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 17.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-17">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-17", "secondary")}
+    {@render card(title, "Content for chunk 17")}
+</div>
+
+<div>
+    Chunk 18: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 18.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 18.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 18.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-18">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-18", "secondary")}
+    {@render card(title, "Content for chunk 18")}
+</div>
+
+<div>
+    Chunk 19: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 19.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 19.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 19.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-19">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-19", "secondary")}
+    {@render card(title, "Content for chunk 19")}
+</div>
+
+<div>
+    Chunk 20: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 20.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 20.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 20.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-20">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-20", "secondary")}
+    {@render card(title, "Content for chunk 20")}
+</div>
+
+<div>
+    Chunk 21: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 21.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 21.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 21.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-21">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-21", "secondary")}
+    {@render card(title, "Content for chunk 21")}
+</div>
+
+<div>
+    Chunk 22: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 22.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 22.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 22.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-22">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-22", "secondary")}
+    {@render card(title, "Content for chunk 22")}
+</div>
+
+<div>
+    Chunk 23: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 23.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 23.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 23.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-23">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-23", "secondary")}
+    {@render card(title, "Content for chunk 23")}
+</div>
+
+<div>
+    Chunk 24: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 24.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 24.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 24.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-24">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-24", "secondary")}
+    {@render card(title, "Content for chunk 24")}
+</div>
+
+<div>
+    Chunk 25: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 25.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 25.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 25.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-25">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-25", "secondary")}
+    {@render card(title, "Content for chunk 25")}
+</div>
+
+<div>
+    Chunk 26: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 26.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 26.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 26.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-26">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-26", "secondary")}
+    {@render card(title, "Content for chunk 26")}
+</div>
+
+<div>
+    Chunk 27: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 27.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 27.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 27.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-27">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-27", "secondary")}
+    {@render card(title, "Content for chunk 27")}
+</div>
+
+<div>
+    Chunk 28: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 28.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 28.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 28.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-28">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-28", "secondary")}
+    {@render card(title, "Content for chunk 28")}
+</div>
+
+<div>
+    Chunk 29: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 29.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 29.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 29.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-29">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-29", "secondary")}
+    {@render card(title, "Content for chunk 29")}
+</div>
+
+<div>
+    Chunk 30: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 30.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 30.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 30.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-30">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-30", "secondary")}
+    {@render card(title, "Content for chunk 30")}
+</div>
+
+<div>
+    Chunk 31: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 31.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 31.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 31.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-31">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-31", "secondary")}
+    {@render card(title, "Content for chunk 31")}
+</div>
+
+<div>
+    Chunk 32: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 32.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 32.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 32.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-32">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-32", "secondary")}
+    {@render card(title, "Content for chunk 32")}
+</div>
+
+<div>
+    Chunk 33: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 33.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 33.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 33.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-33">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-33", "secondary")}
+    {@render card(title, "Content for chunk 33")}
+</div>
+
+<div>
+    Chunk 34: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 34.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 34.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 34.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-34">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-34", "secondary")}
+    {@render card(title, "Content for chunk 34")}
+</div>
+
+<div>
+    Chunk 35: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 35.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 35.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 35.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-35">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-35", "secondary")}
+    {@render card(title, "Content for chunk 35")}
+</div>
+
+<div>
+    Chunk 36: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 36.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 36.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 36.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-36">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-36", "secondary")}
+    {@render card(title, "Content for chunk 36")}
+</div>
+
+<div>
+    Chunk 37: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 37.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 37.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 37.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-37">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-37", "secondary")}
+    {@render card(title, "Content for chunk 37")}
+</div>
+
+<div>
+    Chunk 38: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 38.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 38.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 38.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-38">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-38", "secondary")}
+    {@render card(title, "Content for chunk 38")}
+</div>
+
+<div>
+    Chunk 39: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 39.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 39.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 39.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-39">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-39", "secondary")}
+    {@render card(title, "Content for chunk 39")}
+</div>
+
+<div>
+    Chunk 40: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 40.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 40.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 40.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-40">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-40", "secondary")}
+    {@render card(title, "Content for chunk 40")}
+</div>
+
+<div>
+    Chunk 41: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 41.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 41.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 41.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-41">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-41", "secondary")}
+    {@render card(title, "Content for chunk 41")}
+</div>
+
+<div>
+    Chunk 42: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 42.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 42.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 42.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-42">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-42", "secondary")}
+    {@render card(title, "Content for chunk 42")}
+</div>
+
+<div>
+    Chunk 43: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 43.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 43.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 43.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-43">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-43", "secondary")}
+    {@render card(title, "Content for chunk 43")}
+</div>
+
+<div>
+    Chunk 44: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 44.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 44.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 44.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-44">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-44", "secondary")}
+    {@render card(title, "Content for chunk 44")}
+</div>
+
+<div>
+    Chunk 45: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 45.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 45.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 45.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-45">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-45", "secondary")}
+    {@render card(title, "Content for chunk 45")}
+</div>
+
+<div>
+    Chunk 46: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 46.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 46.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 46.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-46">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-46", "secondary")}
+    {@render card(title, "Content for chunk 46")}
+</div>
+
+<div>
+    Chunk 47: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 47.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 47.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 47.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-47">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-47", "secondary")}
+    {@render card(title, "Content for chunk 47")}
+</div>
+
+<div>
+    Chunk 48: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 48.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 48.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 48.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-48">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-48", "secondary")}
+    {@render card(title, "Content for chunk 48")}
+</div>
+
+<div>
+    Chunk 49: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 49.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 49.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 49.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-49">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+
+    {@render badge("chunk-49", "secondary")}
+    {@render card(title, "Content for chunk 49")}
+</div>
+

--- a/tasks/compiler_tests/cases2/use_action_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_basic/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.action(div, ($$node) => tooltip?.($$node));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_basic/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.action(div, ($$node) => tooltip?.($$node));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_basic/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { tooltip } from './actions.js';
+</script>
+
+<div use:tooltip>text</div>

--- a/tasks/compiler_tests/cases2/use_action_dotted/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_dotted/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import { actions } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.action(div, ($$node) => actions.tooltip?.($$node));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_dotted/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_dotted/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import { actions } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.action(div, ($$node) => actions.tooltip?.($$node));
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_dotted/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_dotted/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { actions } from './actions.js';
+</script>
+
+<div use:actions.tooltip>text</div>

--- a/tasks/compiler_tests/cases2/use_action_expression/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_expression/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let config = { text: "hello" };
+	var div = root();
+	$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => config);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_expression/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_expression/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let config = { text: "hello" };
+	var div = root();
+	$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => config);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_expression/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_expression/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { tooltip } from './actions.js';
+	let config = { text: 'hello' };
+</script>
+
+<div use:tooltip={config}>text</div>

--- a/tasks/compiler_tests/cases2/use_action_in_each/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_in_each/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		"a",
+		"b",
+		"c"
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		var div = root_1();
+		$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => $.get(item));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/use_action_in_each/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_in_each/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		"a",
+		"b",
+		"c"
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		var div = root_1();
+		$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => $.get(item));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/use_action_in_each/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_in_each/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { tooltip } from './actions.js';
+	let items = $state(['a', 'b', 'c']);
+</script>
+
+{#each items as item}
+	<div use:tooltip={item}>text</div>
+{/each}

--- a/tasks/compiler_tests/cases2/use_action_in_if/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_in_if/case-rust.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let show = true;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var div = root_1();
+			$.action(div, ($$node) => tooltip?.($$node));
+			$.append($$anchor, div);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/use_action_in_if/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_in_if/case-svelte.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let show = true;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var div = root_1();
+			$.action(div, ($$node) => tooltip?.($$node));
+			$.append($$anchor, div);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/use_action_in_if/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_in_if/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { tooltip } from './actions.js';
+	let show = $state(true);
+</script>
+
+{#if show}
+	<div use:tooltip>text</div>
+{/if}

--- a/tasks/compiler_tests/cases2/use_action_multiple/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_multiple/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+import { focus, tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let config = { text: "hello" };
+	var div = root();
+	$.action(div, ($$node) => focus?.($$node));
+	$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => config);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_multiple/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_multiple/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+import { focus, tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let config = { text: "hello" };
+	var div = root();
+	$.action(div, ($$node) => focus?.($$node));
+	$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => config);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_multiple/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_multiple/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { focus, tooltip } from './actions.js';
+	let config = { text: 'hello' };
+</script>
+
+<div use:focus use:tooltip={config}>text</div>

--- a/tasks/compiler_tests/cases2/use_action_reactive/case-rust.js
+++ b/tasks/compiler_tests/cases2/use_action_reactive/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let config = "hello";
+	var div = root();
+	$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => config);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_reactive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/use_action_reactive/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>text</div>`);
+export default function App($$anchor) {
+	let config = "hello";
+	var div = root();
+	$.action(div, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => config);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/use_action_reactive/case.svelte
+++ b/tasks/compiler_tests/cases2/use_action_reactive/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { tooltip } from './actions.js';
+	let config = $state('hello');
+</script>
+
+<div use:tooltip={config}>text</div>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -347,6 +347,41 @@ fn on_directive_modifiers() {
 }
 
 #[rstest]
+fn use_action_basic() {
+    assert_compiler("use_action_basic");
+}
+
+#[rstest]
+fn use_action_expression() {
+    assert_compiler("use_action_expression");
+}
+
+#[rstest]
+fn use_action_reactive() {
+    assert_compiler("use_action_reactive");
+}
+
+#[rstest]
+fn use_action_dotted() {
+    assert_compiler("use_action_dotted");
+}
+
+#[rstest]
+fn use_action_multiple() {
+    assert_compiler("use_action_multiple");
+}
+
+#[rstest]
+fn use_action_in_if() {
+    assert_compiler("use_action_in_if");
+}
+
+#[rstest]
+fn use_action_in_each() {
+    assert_compiler("use_action_in_each");
+}
+
+#[rstest]
 fn void_elements() {
     assert_compiler("void_elements");
 }

--- a/tasks/generate_benchmark/src/main.rs
+++ b/tasks/generate_benchmark/src/main.rs
@@ -59,6 +59,10 @@ fn write_script(out: &mut String) {
     export function formatTitle(prefix) {
         return prefix + ": " + title;
     }
+
+    function action(node, arg) {
+        return { destroy() {} };
+    }
 </script>
 
 "#,
@@ -133,6 +137,7 @@ fn write_chunk(out: &mut String, i: usize) {
     {{/each}}
 
     <input bind:value={{state}} />
+    <div use:action={{state}}>action target</div>
 
     {{@render badge("chunk-{i}", "secondary")}}
     {{@render card(title, "Content for chunk {i}")}}


### PR DESCRIPTION
Add full support for the use:action={params} directive including parser,
analysis, and codegen. Handles basic actions, expression arguments,
reactive state, dotted names (use:a.b), multiple directives per element,
and use inside {#if} and {#each} blocks. All 7 test cases pass and
match Svelte reference output exactly.

https://claude.ai/code/session_013WftPL7xL3uK7h4Tpp2UtC