### PR TITLE
Port animate:name={params} directive (FLIP animations)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,12 +326,14 @@ Theme: action, transition, animation directives. New AST attribute variants + pa
 - [ ] Validation: duplicate transition directives *(discovered during port, deferred)*
 - [ ] Validation: conflicting transition: + in:/out: on same element *(discovered during port, deferred)*
 
-### `animate:name={params}` — FLIP animations
+### `animate:name={params}` — FLIP animations [x]
 - **Phases**: P, A, T
 - **AST**: `Attribute::AnimateDirective { name, expression_span: Option<Span> }`
 - **Constraint**: Only valid inside keyed `{#each}` blocks (validation needed)
 - **Codegen**: `$.animation(el, animateFn, () => params)`
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/AnimateDirective.js`
+- [ ] Validation: `animate:` only valid inside keyed `{#each}` blocks *(discovered during port, deferred)*
+- [ ] Validation: duplicate `animate:` directives on same element *(discovered during port, deferred)*
 
 ### `{@attach fn}` — Element attachment (Svelte 5.29+)
 - **Phases**: P, A, T

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -20,6 +20,8 @@ pub struct ParsedExprs<'a> {
     pub attr_exprs: FxHashMap<(NodeId, usize), Expression<'a>>,
     /// ConcatenationAttribute dynamic parts: (owner_id, attr_index, part_index).
     pub concat_part_exprs: FxHashMap<(NodeId, usize, usize), Expression<'a>>,
+    /// EachBlock key expressions: keyed by EachBlock NodeId.
+    pub key_exprs: FxHashMap<NodeId, Expression<'a>>,
     /// Pre-parsed script Program AST. Consumed by codegen via `Option::take()`.
     pub script_program: Option<oxc_ast::ast::Program<'a>>,
 }
@@ -30,6 +32,7 @@ impl<'a> ParsedExprs<'a> {
             exprs: FxHashMap::default(),
             attr_exprs: FxHashMap::default(),
             concat_part_exprs: FxHashMap::default(),
+            key_exprs: FxHashMap::default(),
             script_program: None,
         }
     }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -158,6 +158,16 @@ fn walk_node<'a>(
         Node::EachBlock(block) => {
             let source = component.source_text(block.expression_span);
             parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
+            if let Some(key_span) = block.key_span {
+                let key_source = component.source_text(key_span);
+                let arena_source: &'a str = alloc.alloc_str(key_source);
+                match svelte_js::analyze_expression_with_alloc(alloc, arena_source, key_span.start) {
+                    Ok((_info, expr)) => {
+                        parsed.key_exprs.insert(block.id, expr);
+                    }
+                    Err(diag) => diags.push(diag),
+                }
+            }
             walk_fragment(alloc, &block.body, component, data, parsed, diags);
             if let Some(fb) = &block.fallback {
                 walk_fragment(alloc, fb, component, data, parsed, diags);
@@ -287,6 +297,12 @@ fn walk_attrs<'a>(
                 }
             }
             Attribute::TransitionDirective(a) => {
+                if let Some(span) = a.expression_span {
+                    let source = component.source_text(span);
+                    parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+                }
+            }
+            Attribute::AnimateDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
                     parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,7 +1,8 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element, ExpressionTag, HtmlTag,
-    IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock, TransitionDirective, UseDirective,
+    AnimateDirective, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element,
+    ExpressionTag, HtmlTag, IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock,
+    TransitionDirective, UseDirective,
 };
 use crate::data::AnalysisData;
 use crate::walker::TemplateVisitor;
@@ -107,6 +108,10 @@ impl TemplateVisitor for ReactivityVisitor {
     }
 
     fn visit_transition_directive(&mut self, _dir: &TransitionDirective, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
+        data.element_flags.needs_ref.insert(el.id);
+    }
+
+    fn visit_animate_directive(&mut self, _dir: &AnimateDirective, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
         data.element_flags.needs_ref.insert(el.id);
     }
 

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,7 +1,8 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element, ExpressionTag, Fragment,
-    HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock, TransitionDirective, UseDirective,
+    AnimateDirective, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element,
+    ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
+    TransitionDirective, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -31,6 +32,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_transition_directive(&mut self, dir: &TransitionDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_animate_directive(&mut self, dir: &AnimateDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {}
     /// Called after element children have been walked. Use for bottom-up computations.
     fn leave_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -65,6 +67,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
                     }
                     if let Attribute::TransitionDirective(dir) = attr {
                         visitor.visit_transition_directive(dir, el, scope, data);
+                    }
+                    if let Attribute::AnimateDirective(dir) = attr {
+                        visitor.visit_animate_directive(dir, el, scope, data);
                     }
                 }
                 walk_template(&el.fragment, data, scope, visitor);
@@ -160,6 +165,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_transition_directive(&mut self, dir: &TransitionDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_transition_directive(dir, el, scope, data);)+
+        }
+        fn visit_animate_directive(&mut self, dir: &AnimateDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_animate_directive(dir, el, scope, data);)+
         }
         fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_component_attribute(attr, idx, cn, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -334,6 +334,8 @@ pub enum Attribute {
     OnDirectiveLegacy(OnDirectiveLegacy),
     /// transition:name, in:name, or out:name
     TransitionDirective(TransitionDirective),
+    /// animate:name or animate:name={expr}
+    AnimateDirective(AnimateDirective),
 }
 
 #[derive(Clone)]
@@ -453,6 +455,15 @@ pub struct TransitionDirective {
     pub modifiers: Vec<String>,
     /// Whether this is `transition:`, `in:`, or `out:`.
     pub direction: TransitionDirection,
+}
+
+/// animate:name or animate:name={expr}
+#[derive(Clone)]
+pub struct AnimateDirective {
+    /// Directive name (e.g., "flip" in `animate:flip`, "custom.fn" in `animate:custom.fn`).
+    pub name: String,
+    /// Span of the argument expression. None if no expression (`animate:name`).
+    pub expression_span: Option<Span>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -131,6 +131,9 @@ pub(crate) fn process_attr<'a>(
         Attribute::TransitionDirective(td) => {
             gen_transition_directive(ctx, td, owner_id, attr_idx, el_name, after_update);
         }
+        Attribute::AnimateDirective(ad) => {
+            gen_animate_directive(ctx, ad, owner_id, attr_idx, el_name, after_update);
+        }
     }
 }
 
@@ -712,6 +715,7 @@ pub(crate) fn process_attrs_spread<'a>(
             // LEGACY(svelte4): on:directive handled separately
             Attribute::OnDirectiveLegacy(_) => continue,
             Attribute::TransitionDirective(_) => continue,
+            Attribute::AnimateDirective(_) => continue,
         }
     }
 
@@ -811,6 +815,35 @@ fn gen_transition_directive<'a>(
     }
 
     after_update.push(ctx.b.call_stmt("$.transition", args));
+}
+
+/// Generate `$.animation(el, () => animateFn, () => params)`.
+/// Reference: `AnimateDirective.js`.
+fn gen_animate_directive<'a>(
+    ctx: &mut Ctx<'a>,
+    ad: &svelte_ast::AnimateDirective,
+    owner_id: NodeId,
+    attr_idx: usize,
+    el_name: &str,
+    after_update: &mut Vec<Statement<'a>>,
+) {
+    let name_expr = build_directive_name_expr(ctx, &ad.name);
+    let name_thunk = ctx.b.thunk(name_expr);
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Ident(el_name),
+        Arg::Expr(name_thunk),
+    ];
+
+    if ad.expression_span.is_some() {
+        let expr = get_attr_expr(ctx, owner_id, attr_idx);
+        let thunk = ctx.b.thunk(expr);
+        args.push(Arg::Expr(thunk));
+    } else {
+        args.push(Arg::Expr(ctx.b.null_expr()));
+    }
+
+    after_update.push(ctx.b.call_stmt("$.animation", args));
 }
 
 /// Parse a directive name like "a.b.c" into a member expression.

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -59,7 +59,8 @@ pub(crate) fn gen_component<'a>(
             },
             Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_)
             | Attribute::UseDirective(_) | Attribute::OnDirectiveLegacy(_)
-            | Attribute::TransitionDirective(_) => AttrKind::Skip,
+            | Attribute::TransitionDirective(_)
+            | Attribute::AnimateDirective(_) => AttrKind::Skip,
         };
         (kind, is_dynamic)
     }).collect();

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -3,7 +3,7 @@
 use oxc_ast::ast::{Expression, Statement};
 
 use svelte_analyze::FragmentKey;
-use svelte_ast::NodeId;
+use svelte_ast::{Attribute, Node, NodeId};
 
 use crate::builder::Arg;
 use crate::context::Ctx;
@@ -15,7 +15,7 @@ use super::gen_fragment;
 const EACH_ITEM_REACTIVE: u32 = 1;
 // const EACH_INDEX_REACTIVE: u32 = 2;
 const EACH_IS_CONTROLLED: u32 = 4;
-// const EACH_IS_ANIMATED: u32 = 8;
+const EACH_IS_ANIMATED: u32 = 8;
 const EACH_ITEM_IMMUTABLE: u32 = 16;
 
 /// Generate statements for an `{#each ...}` block.
@@ -45,6 +45,17 @@ pub(crate) fn gen_each_block<'a>(
         flags |= EACH_IS_CONTROLLED;
     }
 
+    // animate: can only appear on elements that are the sole child of a keyed each block
+    if block.key_span.is_some() && block.body.nodes.iter().any(|node| {
+        if let Node::Element(el) = node {
+            el.attributes.iter().any(|a| matches!(a, Attribute::AnimateDirective(_)))
+        } else {
+            false
+        }
+    }) {
+        flags |= EACH_IS_ANIMATED;
+    }
+
     let expr_source = ctx.component.source_text(expr_span).trim();
     let collection_fn = if ctx.prop_sources.contains(expr_source) {
         // Prop getter is already a function — pass directly without thunk
@@ -53,6 +64,14 @@ pub(crate) fn gen_each_block<'a>(
         let collection = get_node_expr(ctx, block_id);
         ctx.b
             .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(collection)])
+    };
+
+    // Key function: keyed each uses (item) => key_expr, unkeyed uses $.index
+    let key_fn = if let Some(key_expr) = ctx.parsed.key_exprs.remove(&block_id) {
+        let key_body = ctx.b.expr_stmt(key_expr);
+        ctx.b.arrow_expr(ctx.b.params([&context_name]), [key_body])
+    } else {
+        ctx.b.rid_expr("$.index")
     };
 
     let frag_body = gen_fragment(ctx, body_key);
@@ -67,7 +86,7 @@ pub(crate) fn gen_each_block<'a>(
             Arg::Expr(anchor),
             Arg::Num(flags as f64),
             Arg::Expr(collection_fn),
-            Arg::IdentRef(ctx.b.rid("$.index")),
+            Arg::Expr(key_fn),
             Arg::Expr(frag_fn),
         ],
     ));

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -5,11 +5,12 @@ use scanner::{
 use svelte_span::Span;
 
 use svelte_ast::{
-    Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment, ComponentNode, ConstTag,
-    ConcatPart, ConcatenationAttribute, Component, EachBlock, Element, OnDirectiveLegacy, StyleDirective, StyleDirectiveValue,
-    ExpressionAttribute, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script,
-    ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text,
-    TransitionDirective, TransitionDirection, UseDirective,
+    AnimateDirective, Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment,
+    ComponentNode, ConstTag, ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
+    OnDirectiveLegacy, StyleDirective, StyleDirectiveValue, ExpressionAttribute, Fragment, HtmlTag,
+    IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script, ScriptContext,
+    ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text, TransitionDirective,
+    TransitionDirection, UseDirective,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -929,6 +930,17 @@ impl<'a> Parser<'a> {
                         expression_span,
                         modifiers: td.modifiers.iter().map(|m| m.source_text(self.source).to_string()).collect(),
                         direction,
+                    }));
+                }
+                token::Attribute::AnimateDirective(ad) => {
+                    let expression_span = if ad.has_expression {
+                        Some(ad.expression_span)
+                    } else {
+                        None
+                    };
+                    attributes.push(Attribute::AnimateDirective(AnimateDirective {
+                        name: ad.name_span.source_text(self.source).to_string(),
+                        expression_span,
                     }));
                 }
             }

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -5,10 +5,10 @@ use std::{iter::Peekable, str::Chars, vec};
 pub use svelte_ast::is_void;
 
 use token::{
-    Attribute, AttributeIdentifierType, AttributeValue, BindDirective, ClassDirective,
-    Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute, OnDirectiveLegacy,
-    ScriptTag, StartEachTag, StartIfTag, StartKeyTag, StartTag, StyleDirective, Token, TokenType,
-    TransitionDirective, UseDirective,
+    AnimateDirective, Attribute, AttributeIdentifierType, AttributeValue, BindDirective,
+    ClassDirective, Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute,
+    OnDirectiveLegacy, ScriptTag, StartEachTag, StartIfTag, StartKeyTag, StartTag,
+    StyleDirective, Token, TokenType, TransitionDirective, UseDirective,
 };
 
 use svelte_diagnostics::Diagnostic;
@@ -177,6 +177,8 @@ impl<'a> Scanner<'a> {
                 AttributeIdentifierType::OnDirectiveLegacy(value_span, value).as_ok()
             } else if AttributeIdentifierType::is_transition_directive(name) {
                 AttributeIdentifierType::TransitionDirective(value_span, name).as_ok()
+            } else if AttributeIdentifierType::is_animate_directive(name) {
+                AttributeIdentifierType::AnimateDirective(value_span, value).as_ok()
             } else {
                 Diagnostic::unknown_directive(Span::new(colon_pos as u32, self.current as u32)).as_err()
             }
@@ -337,6 +339,9 @@ impl<'a> Scanner<'a> {
                     AttributeIdentifierType::OnDirectiveLegacy(span, _) => self.on_directive_legacy(span),
                     AttributeIdentifierType::TransitionDirective(span, prefix) => {
                         self.transition_directive(span, prefix)
+                    }
+                    AttributeIdentifierType::AnimateDirective(span, _) => {
+                        self.animate_directive(span)
                     }
                     AttributeIdentifierType::None => break,
                 }
@@ -537,6 +542,33 @@ impl<'a> Scanner<'a> {
             modifiers,
             has_expression: false,
             direction_prefix: prefix.to_string(),
+        }))
+    }
+
+    /// Parse `animate:name={expr}` or `animate:name`.
+    fn animate_directive(&mut self, mut name_span: Span) -> Result<Attribute, Diagnostic> {
+        // Consume dotted name segments: animate:a.b.c
+        while self.peek() == Some('.') {
+            self.advance(); // consume '.'
+            while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '_') {
+                self.advance();
+            }
+            name_span = Span::new(name_span.start, self.current as u32);
+        }
+
+        if self.match_char('=') {
+            let res = self.expression_tag()?;
+            return Ok(Attribute::AnimateDirective(AnimateDirective {
+                name_span,
+                expression_span: res.expression_span,
+                has_expression: true,
+            }));
+        }
+
+        Ok(Attribute::AnimateDirective(AnimateDirective {
+            name_span,
+            expression_span: SPAN,
+            has_expression: false,
         }))
     }
 
@@ -1509,6 +1541,7 @@ mod tests {
                 Attribute::UseDirective(ud) => ud.name_span.source_text(source),
                 Attribute::OnDirectiveLegacy(od) => od.name_span.source_text(source),
                 Attribute::TransitionDirective(td) => td.name_span.source_text(source),
+                Attribute::AnimateDirective(ad) => ad.name_span.source_text(source),
             };
 
             let value: String = match attribute {
@@ -1540,6 +1573,7 @@ mod tests {
                 Attribute::UseDirective(ud) => ud.expression_span.source_text(source).to_string(),
                 Attribute::OnDirectiveLegacy(od) => od.expression_span.source_text(source).to_string(),
                 Attribute::TransitionDirective(td) => td.expression_span.source_text(source).to_string(),
+                Attribute::AnimateDirective(ad) => ad.expression_span.source_text(source).to_string(),
             };
 
             assert_eq!(name, *expected_name);

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -69,6 +69,17 @@ pub enum Attribute {
     /// LEGACY(svelte4): on:directive syntax. Deprecated in Svelte 5, remove in Svelte 6.
     OnDirectiveLegacy(OnDirectiveLegacy),
     TransitionDirective(TransitionDirective),
+    AnimateDirective(AnimateDirective),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AnimateDirective {
+    /// Name after "animate:" (e.g., "flip" in `animate:flip`).
+    pub name_span: Span,
+    /// Expression span if `={expr}` was provided.
+    pub expression_span: Span,
+    /// Whether an expression was provided.
+    pub has_expression: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -219,6 +230,8 @@ pub enum AttributeIdentifierType<'a> {
     OnDirectiveLegacy(Span, &'a str),
     /// transition:, in:, or out: directive
     TransitionDirective(Span, &'a str),
+    /// animate: directive
+    AnimateDirective(Span, &'a str),
     None,
 }
 
@@ -246,6 +259,10 @@ impl<'a> AttributeIdentifierType<'a> {
 
     pub fn is_transition_directive(name: &str) -> bool {
         name == "transition" || name == "in" || name == "out"
+    }
+
+    pub fn is_animate_directive(name: &str) -> bool {
+        name == "animate"
     }
 
     pub fn is_empty(&self) -> bool {

--- a/tasks/compiler_tests/cases2/animate_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/animate_basic/case-rust.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import { flip } from "svelte/animate";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => flip, null);
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/animate_basic/case-svelte.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import { flip } from "svelte/animate";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => flip, null);
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/animate_basic/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { flip } from 'svelte/animate';
+	let items = $state([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
+</script>
+
+{#each items as item (item.id)}
+	<div animate:flip>{item.name}</div>
+{/each}

--- a/tasks/compiler_tests/cases2/animate_dotted_name/case-rust.js
+++ b/tasks/compiler_tests/cases2/animate_dotted_name/case-rust.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import { animations } from "./utils";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => animations.flip, null);
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_dotted_name/case-svelte.js
+++ b/tasks/compiler_tests/cases2/animate_dotted_name/case-svelte.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import { animations } from "./utils";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => animations.flip, null);
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_dotted_name/case.svelte
+++ b/tasks/compiler_tests/cases2/animate_dotted_name/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { animations } from './utils';
+	let items = $state([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
+</script>
+
+{#each items as item (item.id)}
+	<div animate:animations.flip>{item.name}</div>
+{/each}

--- a/tasks/compiler_tests/cases2/animate_params/case-rust.js
+++ b/tasks/compiler_tests/cases2/animate_params/case-rust.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import { flip } from "svelte/animate";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => flip, () => ({ duration: 300 }));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_params/case-svelte.js
+++ b/tasks/compiler_tests/cases2/animate_params/case-svelte.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import { flip } from "svelte/animate";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => flip, () => ({ duration: 300 }));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_params/case.svelte
+++ b/tasks/compiler_tests/cases2/animate_params/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { flip } from 'svelte/animate';
+	let items = $state([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
+</script>
+
+{#each items as item (item.id)}
+	<div animate:flip={{ duration: 300 }}>{item.name}</div>
+{/each}

--- a/tasks/compiler_tests/cases2/animate_reactive_params/case-rust.js
+++ b/tasks/compiler_tests/cases2/animate_reactive_params/case-rust.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+import { flip } from "svelte/animate";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	let duration = 300;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => flip, () => ({ duration }));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_reactive_params/case-svelte.js
+++ b/tasks/compiler_tests/cases2/animate_reactive_params/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+import { flip } from "svelte/animate";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([{
+		id: 1,
+		name: "a"
+	}, {
+		id: 2,
+		name: "b"
+	}]);
+	let duration = 300;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 25, () => items, (item) => item.id, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(item).name));
+		$.animation(div, () => flip, () => ({ duration }));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/animate_reactive_params/case.svelte
+++ b/tasks/compiler_tests/cases2/animate_reactive_params/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { flip } from 'svelte/animate';
+	let items = $state([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
+	let duration = $state(300);
+</script>
+
+{#each items as item (item.id)}
+	<div animate:flip={{ duration: duration }}>{item.name}</div>
+{/each}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -561,6 +561,30 @@ fn transition_reactive_params() {
 }
 
 // ---------------------------------------------------------------------------
+// Animate directive tests
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn animate_basic() {
+    assert_compiler("animate_basic");
+}
+
+#[rstest]
+fn animate_params() {
+    assert_compiler("animate_params");
+}
+
+#[rstest]
+fn animate_dotted_name() {
+    assert_compiler("animate_dotted_name");
+}
+
+#[rstest]
+fn animate_reactive_params() {
+    assert_compiler("animate_reactive_params");
+}
+
+// ---------------------------------------------------------------------------
 // Module compilation tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Add full pipeline for animate: directives: scanner → parser → AST → analyze → codegen.
Also adds keyed each block support (key function generation) and EACH_IS_ANIMATED flag.

- AST: AnimateDirective struct with name and optional expression_span
- Scanner/Parser: animate: prefix detection, dotted name support, expression parsing
- Analyze: needs_ref for animated elements, key expression parsing for each blocks
- Codegen: $.animation(el, () => fn, () => params | null) in after_update
- Each: EACH_IS_ANIMATED flag (8) set when keyed each has animated children
- Each: keyed each blocks now emit (item) => key_expr instead of $.index
- Tests: animate_basic, animate_params, animate_dotted_name, animate_reactive_params

https://claude.ai/code/session_01RJjNcptsk7bghSWFhecrks