### PR TITLE
Port {@attach fn} element attachment (Svelte 5.29+)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -335,12 +335,14 @@ Theme: action, transition, animation directives. New AST attribute variants + pa
 - [ ] Validation: `animate:` only valid inside keyed `{#each}` blocks *(discovered during port, deferred)*
 - [ ] Validation: duplicate `animate:` directives on same element *(discovered during port, deferred)*
 
-### `{@attach fn}` — Element attachment (Svelte 5.29+)
+### ~~`{@attach fn}` — Element attachment (Svelte 5.29+)~~ ✅
 - **Phases**: P, A, T
-- **AST**: `Node::AttachTag { id, span, expression_span }` (within element children)
-- **Codegen**: `$.attach(el, fn)`
+- **AST**: `Attribute::AttachTag { expression_span }` (in element attributes array)
+- **Codegen**: `$.attach(el, () => fn)`
 - **Notes**: Modern alternative to `use:action`. Re-runs on reactive dependency changes. Conditional with falsy values.
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/AttachTag.js`
+- [ ] `{@attach}` on component nodes — generates `$.attachment()` property in props *(deferred)*
+- [ ] `{@attach}` with async/blockers — `$.run_after_blockers()` wrapping *(deferred)*
 
 ---
 

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -308,6 +308,11 @@ fn walk_attrs<'a>(
                     parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
                 }
             }
+            Attribute::AttachTag(a) => {
+                let span = a.expression_span;
+                let source = component.source_text(span);
+                parse_attr_expr(alloc, source, span.start, key, data, parsed, diags);
+            }
         }
     }
 }

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    AnimateDirective, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element,
-    ExpressionTag, HtmlTag, IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock,
+    AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
+    Element, ExpressionTag, HtmlTag, IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock,
     TransitionDirective, UseDirective,
 };
 use crate::data::AnalysisData;
@@ -112,6 +112,10 @@ impl TemplateVisitor for ReactivityVisitor {
     }
 
     fn visit_animate_directive(&mut self, _dir: &AnimateDirective, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
+        data.element_flags.needs_ref.insert(el.id);
+    }
+
+    fn visit_attach_tag(&mut self, _tag: &AttachTag, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
         data.element_flags.needs_ref.insert(el.id);
     }
 

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    AnimateDirective, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock, Element,
-    ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
+    AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
+    Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
     TransitionDirective, UseDirective,
 };
 
@@ -33,6 +33,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_transition_directive(&mut self, dir: &TransitionDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_animate_directive(&mut self, dir: &AnimateDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_attach_tag(&mut self, tag: &AttachTag, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {}
     /// Called after element children have been walked. Use for bottom-up computations.
     fn leave_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -70,6 +71,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
                     }
                     if let Attribute::AnimateDirective(dir) = attr {
                         visitor.visit_animate_directive(dir, el, scope, data);
+                    }
+                    if let Attribute::AttachTag(tag) = attr {
+                        visitor.visit_attach_tag(tag, el, scope, data);
                     }
                 }
                 walk_template(&el.fragment, data, scope, visitor);
@@ -168,6 +172,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_animate_directive(&mut self, dir: &AnimateDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_animate_directive(dir, el, scope, data);)+
+        }
+        fn visit_attach_tag(&mut self, tag: &AttachTag, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_attach_tag(tag, el, scope, data);)+
         }
         fn visit_component_attribute(&mut self, attr: &Attribute, idx: usize, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_component_attribute(attr, idx, cn, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -336,6 +336,8 @@ pub enum Attribute {
     TransitionDirective(TransitionDirective),
     /// animate:name or animate:name={expr}
     AnimateDirective(AnimateDirective),
+    /// {@attach expr} — element attachment (Svelte 5.29+)
+    AttachTag(AttachTag),
 }
 
 #[derive(Clone)]
@@ -464,6 +466,14 @@ pub struct AnimateDirective {
     pub name: String,
     /// Span of the argument expression. None if no expression (`animate:name`).
     pub expression_span: Option<Span>,
+}
+
+/// {@attach expr} — element attachment (Svelte 5.29+).
+/// Modern alternative to `use:action`. Re-runs on reactive dependency changes.
+#[derive(Clone)]
+pub struct AttachTag {
+    /// Span of the JS expression inside `{@attach expr}`.
+    pub expression_span: Span,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -29,6 +29,10 @@ fn build_directive_prop<'a>(
 }
 
 /// Process a single attribute (non-spread path).
+///
+/// `init` — simple attributes when non-dynamic (before children).
+/// `directive_init` — directive statements like $.attach, $.action, $.bind_* (after children).
+/// `after_update` — transition, animate, on:event directives (after template_effect).
 pub(crate) fn process_attr<'a>(
     ctx: &mut Ctx<'a>,
     attr: &Attribute,
@@ -39,6 +43,7 @@ pub(crate) fn process_attr<'a>(
     is_dyn: bool,
     init: &mut Vec<Statement<'a>>,
     update: &mut Vec<Statement<'a>>,
+    directive_init: &mut Vec<Statement<'a>>,
     after_update: &mut Vec<Statement<'a>>,
 ) {
     let target = if is_dyn {
@@ -114,7 +119,7 @@ pub(crate) fn process_attr<'a>(
             if let Some(placement) = gen_bind_directive(ctx, bind, el_name, tag_name) {
                 match placement {
                     BindPlacement::AfterUpdate(stmt) => after_update.push(stmt),
-                    BindPlacement::Init(stmt) => init.push(stmt),
+                    BindPlacement::Init(stmt) => directive_init.push(stmt),
                 }
             }
         }
@@ -122,7 +127,7 @@ pub(crate) fn process_attr<'a>(
             // Spread handled by process_attrs_spread; class/style directives by dedicated functions
         }
         Attribute::UseDirective(ud) => {
-            gen_use_directive(ctx, ud, owner_id, attr_idx, el_name, init);
+            gen_use_directive(ctx, ud, owner_id, attr_idx, el_name, directive_init);
         }
         // LEGACY(svelte4): on:directive
         Attribute::OnDirectiveLegacy(od) => {
@@ -133,6 +138,9 @@ pub(crate) fn process_attr<'a>(
         }
         Attribute::AnimateDirective(ad) => {
             gen_animate_directive(ctx, ad, owner_id, attr_idx, el_name, after_update);
+        }
+        Attribute::AttachTag(_) => {
+            gen_attach_tag(ctx, owner_id, attr_idx, el_name, directive_init);
         }
     }
 }
@@ -716,6 +724,7 @@ pub(crate) fn process_attrs_spread<'a>(
             Attribute::OnDirectiveLegacy(_) => continue,
             Attribute::TransitionDirective(_) => continue,
             Attribute::AnimateDirective(_) => continue,
+            Attribute::AttachTag(_) => continue,
         }
     }
 
@@ -775,6 +784,24 @@ fn gen_use_directive<'a>(
     }
 
     init.push(ctx.b.call_stmt("$.action", args));
+}
+
+// ---------------------------------------------------------------------------
+// {@attach expr} codegen
+// ---------------------------------------------------------------------------
+
+/// Generate `$.attach(el, () => expr)`.
+/// Reference: `AttachTag.js`.
+fn gen_attach_tag<'a>(
+    ctx: &mut Ctx<'a>,
+    owner_id: NodeId,
+    attr_idx: usize,
+    el_name: &str,
+    init: &mut Vec<Statement<'a>>,
+) {
+    let expr = get_attr_expr(ctx, owner_id, attr_idx);
+    let thunk = ctx.b.thunk(expr);
+    init.push(ctx.b.call_stmt("$.attach", [Arg::Ident(el_name), Arg::Expr(thunk)]));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -60,7 +60,8 @@ pub(crate) fn gen_component<'a>(
             Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_)
             | Attribute::UseDirective(_) | Attribute::OnDirectiveLegacy(_)
             | Attribute::TransitionDirective(_)
-            | Attribute::AnimateDirective(_) => AttrKind::Skip,
+            | Attribute::AnimateDirective(_)
+            | Attribute::AttachTag(_) => AttrKind::Skip,
         };
         (kind, is_dynamic)
     }).collect();

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -14,6 +14,12 @@ use super::expression::{build_concat, emit_trailing_next};
 use super::traverse::traverse_items;
 
 /// Process an element's attributes and children.
+///
+/// Statement ordering matches the Svelte reference compiler's two-state model:
+/// - Simple attributes ($.set_attribute, etc.) → parent state → before children
+/// - Directives ($.attach, $.action, $.bind_*) → element_state → after children
+///
+/// Merge order: simple attrs → children init → directive init → updates → after_update
 pub(crate) fn process_element<'a>(
     ctx: &mut Ctx<'a>,
     el_id: NodeId,
@@ -35,7 +41,11 @@ pub(crate) fn process_element<'a>(
         ));
     }
 
-    // Attributes — spread path or per-attribute path
+    // --- Attributes (simple attrs go into init/update directly; directives into separate buffers) ---
+    // Directive init/after_update are collected separately and merged after children.
+    let mut directive_init: Vec<Statement<'a>> = Vec::new();
+    let mut directive_after_update: Vec<Statement<'a>> = Vec::new();
+
     if ctx.has_spread(el_id) {
         let el_clone = el.clone_without_fragment();
         process_attrs_spread(ctx, &el_clone, el_name, init, after_update);
@@ -48,7 +58,7 @@ pub(crate) fn process_element<'a>(
         let el = ctx.element(el_id);
         let tag = el.name.clone();
         for (idx, attr) in el.attributes.iter().enumerate() {
-            process_attr(ctx, attr, el_id, idx, el_name, &tag, attr_dynamic[idx], init, update, after_update);
+            process_attr(ctx, attr, el_id, idx, el_name, &tag, attr_dynamic[idx], init, update, &mut directive_init, &mut directive_after_update);
         }
     }
 
@@ -60,7 +70,7 @@ pub(crate) fn process_element<'a>(
     let el = ctx.element(el_id);
     process_style_directives(ctx, &el.clone_without_fragment(), el_name, init, update);
 
-    // Children
+    // --- Children ---
     let has_state = ctx.has_dynamic_children(&child_key);
     match ct {
         ContentType::Empty | ContentType::StaticText => {}
@@ -144,6 +154,10 @@ pub(crate) fn process_element<'a>(
             update.extend(child_update);
         }
     }
+
+    // --- Merge directive statements after children (matching Svelte's element_state merge) ---
+    init.extend(directive_init);
+    after_update.extend(directive_after_update);
 }
 
 /// Check if a fragment item needs a DOM variable.

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -943,6 +943,11 @@ impl<'a> Parser<'a> {
                         expression_span,
                     }));
                 }
+                token::Attribute::AttachTag(at) => {
+                    attributes.push(Attribute::AttachTag(svelte_ast::AttachTag {
+                        expression_span: at.expression_span,
+                    }));
+                }
             }
         }
 

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -5,8 +5,8 @@ use std::{iter::Peekable, str::Chars, vec};
 pub use svelte_ast::is_void;
 
 use token::{
-    AnimateDirective, Attribute, AttributeIdentifierType, AttributeValue, BindDirective,
-    ClassDirective, Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute,
+    AnimateDirective, AttachTagToken, Attribute, AttributeIdentifierType, AttributeValue,
+    BindDirective, ClassDirective, Concatenation, ConcatenationPart, ExpressionTag, HTMLAttribute,
     OnDirectiveLegacy, ScriptTag, StartEachTag, StartIfTag, StartKeyTag, StartTag,
     StyleDirective, Token, TokenType, TransitionDirective, UseDirective,
 };
@@ -315,7 +315,11 @@ impl<'a> Scanner<'a> {
             let peeked = self.peek();
 
             let attr_result = if peeked == Some('{') {
-                self.expression_tag().map(Attribute::ExpressionTag)
+                if self.source[self.current..].starts_with("{@attach") {
+                    self.attach_tag_attribute().map(Attribute::AttachTag)
+                } else {
+                    self.expression_tag().map(Attribute::ExpressionTag)
+                }
             } else {
                 let name = match self.attribute_identifier() {
                     Ok(name) => name,
@@ -570,6 +574,21 @@ impl<'a> Scanner<'a> {
             expression_span: SPAN,
             has_expression: false,
         }))
+    }
+
+    /// Parse `{@attach expr}` in the attribute position.
+    fn attach_tag_attribute(&mut self) -> Result<AttachTagToken, Diagnostic> {
+        debug_assert!(self.source[self.current..].starts_with("{@attach"));
+
+        // Consume `{@attach`
+        for _ in 0.."{@attach".len() {
+            self.advance();
+        }
+
+        self.skip_whitespace();
+        let expression_span = self.collect_js_expression()?;
+
+        Ok(AttachTagToken { expression_span })
     }
 
     fn attribute_value(&mut self) -> Result<AttributeValue, Diagnostic> {
@@ -1542,6 +1561,7 @@ mod tests {
                 Attribute::OnDirectiveLegacy(od) => od.name_span.source_text(source),
                 Attribute::TransitionDirective(td) => td.name_span.source_text(source),
                 Attribute::AnimateDirective(ad) => ad.name_span.source_text(source),
+                Attribute::AttachTag(_) => "$attachTag",
             };
 
             let value: String = match attribute {
@@ -1574,6 +1594,7 @@ mod tests {
                 Attribute::OnDirectiveLegacy(od) => od.expression_span.source_text(source).to_string(),
                 Attribute::TransitionDirective(td) => td.expression_span.source_text(source).to_string(),
                 Attribute::AnimateDirective(ad) => ad.expression_span.source_text(source).to_string(),
+                Attribute::AttachTag(at) => at.expression_span.source_text(source).to_string(),
             };
 
             assert_eq!(name, *expected_name);

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -70,6 +70,8 @@ pub enum Attribute {
     OnDirectiveLegacy(OnDirectiveLegacy),
     TransitionDirective(TransitionDirective),
     AnimateDirective(AnimateDirective),
+    /// {@attach expr} — element attachment (Svelte 5.29+)
+    AttachTag(AttachTagToken),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -80,6 +82,13 @@ pub struct AnimateDirective {
     pub expression_span: Span,
     /// Whether an expression was provided.
     pub has_expression: bool,
+}
+
+/// {@attach expr} — element attachment (Svelte 5.29+)
+#[derive(Debug, PartialEq, Eq)]
+pub struct AttachTagToken {
+    /// Span of the JS expression inside `{@attach expr}`.
+    pub expression_span: Span,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/tasks/compiler_tests/cases2/attach_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_basic/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.attach(div, () => tooltip);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_basic/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.attach(div, () => tooltip);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_basic/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { tooltip } from './actions.js';
+</script>
+
+<div {@attach tooltip}>hello</div>

--- a/tasks/compiler_tests/cases2/attach_conditional/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_conditional/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	let enabled = true;
+	var div = root();
+	$.attach(div, () => enabled && tooltip);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_conditional/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_conditional/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	let enabled = true;
+	var div = root();
+	$.attach(div, () => enabled && tooltip);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_conditional/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_conditional/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { tooltip } from './actions.js';
+	let enabled = $state(true);
+</script>
+
+<div {@attach enabled && tooltip}>hello</div>

--- a/tasks/compiler_tests/cases2/attach_in_each/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_in_each/case-rust.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		"a",
+		"b",
+		"c"
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.attach(div, () => tooltip);
+		$.template_effect(() => $.set_text(text, $.get(item)));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/attach_in_each/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_in_each/case-svelte.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div> </div>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		"a",
+		"b",
+		"c"
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		var div = root_1();
+		var text = $.child(div, true);
+		$.reset(div);
+		$.attach(div, () => tooltip);
+		$.template_effect(() => $.set_text(text, $.get(item)));
+		$.append($$anchor, div);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/attach_in_each/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_in_each/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { tooltip } from './actions.js';
+	let items = $state(['a', 'b', 'c']);
+</script>
+
+{#each items as item}
+	<div {@attach tooltip}>{item}</div>
+{/each}

--- a/tasks/compiler_tests/cases2/attach_in_if/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_in_if/case-rust.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	let show = true;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var div = root_1();
+			$.attach(div, () => tooltip);
+			$.append($$anchor, div);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/attach_in_if/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_in_if/case-svelte.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+var root_1 = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	let show = true;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var div = root_1();
+			$.attach(div, () => tooltip);
+			$.append($$anchor, div);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/attach_in_if/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_in_if/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { tooltip } from './actions.js';
+	let show = $state(true);
+</script>
+
+{#if show}
+	<div {@attach tooltip}>hello</div>
+{/if}

--- a/tasks/compiler_tests/cases2/attach_inline_arrow/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_inline_arrow/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>content</div>`);
+export default function App($$anchor) {
+	let message = "hello";
+	var div = root();
+	$.attach(div, () => (el) => {
+		el.textContent = message;
+	});
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_inline_arrow/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_inline_arrow/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div>content</div>`);
+export default function App($$anchor) {
+	let message = "hello";
+	var div = root();
+	$.attach(div, () => (el) => {
+		el.textContent = message;
+	});
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_inline_arrow/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_inline_arrow/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	let message = $state('hello');
+</script>
+
+<div {@attach (el) => {
+	el.textContent = message;
+}}>content</div>

--- a/tasks/compiler_tests/cases2/attach_multiple/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_multiple/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip, highlight } from "./actions.js";
+var root = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.attach(div, () => tooltip);
+	$.attach(div, () => highlight);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_multiple/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_multiple/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { tooltip, highlight } from "./actions.js";
+var root = $.from_html(`<div>hello</div>`);
+export default function App($$anchor) {
+	var div = root();
+	$.attach(div, () => tooltip);
+	$.attach(div, () => highlight);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/attach_multiple/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_multiple/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { tooltip, highlight } from './actions.js';
+</script>
+
+<div {@attach tooltip} {@attach highlight}>hello</div>

--- a/tasks/compiler_tests/cases2/attach_with_directives/case-rust.js
+++ b/tasks/compiler_tests/cases2/attach_with_directives/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+import { fade } from "svelte/transition";
+var root = $.from_html(`<input/>`);
+export default function App($$anchor) {
+	let value = $.state("");
+	var input = root();
+	$.remove_input_defaults(input);
+	$.attach(input, () => tooltip);
+	$.bind_value(input, () => $.get(value), ($$value) => $.set(value, $$value));
+	$.transition(3, input, () => fade);
+	$.append($$anchor, input);
+}

--- a/tasks/compiler_tests/cases2/attach_with_directives/case-svelte.js
+++ b/tasks/compiler_tests/cases2/attach_with_directives/case-svelte.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+import { tooltip } from "./actions.js";
+import { fade } from "svelte/transition";
+var root = $.from_html(`<input/>`);
+export default function App($$anchor) {
+	let value = $.state("");
+	var input = root();
+	$.remove_input_defaults(input);
+	$.attach(input, () => tooltip);
+	$.bind_value(input, () => $.get(value), ($$value) => $.set(value, $$value));
+	$.transition(3, input, () => fade);
+	$.append($$anchor, input);
+}

--- a/tasks/compiler_tests/cases2/attach_with_directives/case.svelte
+++ b/tasks/compiler_tests/cases2/attach_with_directives/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { tooltip } from './actions.js';
+	import { fade } from 'svelte/transition';
+	let value = $state('');
+</script>
+
+<input {@attach tooltip} bind:value transition:fade />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -585,6 +585,45 @@ fn animate_reactive_params() {
 }
 
 // ---------------------------------------------------------------------------
+// Attach tag tests
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn attach_basic() {
+    assert_compiler("attach_basic");
+}
+
+#[rstest]
+fn attach_inline_arrow() {
+    assert_compiler("attach_inline_arrow");
+}
+
+#[rstest]
+fn attach_conditional() {
+    assert_compiler("attach_conditional");
+}
+
+#[rstest]
+fn attach_multiple() {
+    assert_compiler("attach_multiple");
+}
+
+#[rstest]
+fn attach_with_directives() {
+    assert_compiler("attach_with_directives");
+}
+
+#[rstest]
+fn attach_in_if() {
+    assert_compiler("attach_in_if");
+}
+
+#[rstest]
+fn attach_in_each() {
+    assert_compiler("attach_in_each");
+}
+
+// ---------------------------------------------------------------------------
 // Module compilation tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Full pipeline: parser → analysis → codegen for {@attach expr} on regular elements.
Generates $.attach(el, () => expr) matching Svelte reference output.

Also fixes element init ordering: directive statements ($.attach, $.action,
$.bind_*) are now placed after child traversal ($.child/$.reset), matching
the Svelte compiler's two-state model (element_state vs child_state).

7 test cases: basic, inline arrow, conditional, multiple, with directives,
inside if/each blocks.

https://claude.ai/code/session_01P5q1fj6YghzemzZraQdoVt