### PR TITLE
Port <svelte:options> — parser extraction and validation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -350,10 +350,12 @@ Theme: action, transition, animation directives. New AST attribute variants + pa
 
 Theme: `<svelte:*>` elements for global bindings, dynamic elements, head management, error boundaries.
 
-### `<svelte:options>` — Compiler options tag
+### ~~`<svelte:options>` — Compiler options tag~~ ✅
 - **Phases**: P only (no codegen)
-- **Attributes**: `runes={true|false}`, `namespace="html"|"svg"|"mathml"`, `customElement="tag-name"`, `css="injected"`
-- **Notes**: Parse early, store on component metadata
+- **Attributes**: `runes={true|false}`, `namespace="html"|"svg"|"mathml"`, `customElement="tag-name"`, `css="injected"`, `preserveWhitespace`, `immutable`, `accessors`
+- **Notes**: Parse early, store on component metadata. Scanner extended for `svelte:*` tag names. Validation for unknown attrs, invalid values, no children, tag names.
+- [ ] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties *(deferred — expression span stored, analysis-phase parsing needed)*
+- [ ] `namespace` affecting codegen: `$.from_svg()` / `$.from_mathml()` instead of `$.from_html()` *(deferred — requires codegen changes)*
 
 ### `<svelte:head>` — Document head
 - **Phases**: P, A, T

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -534,6 +534,8 @@ pub struct SvelteOptions {
     pub accessors: Option<bool>,
     /// Preserve whitespace in template.
     pub preserve_whitespace: Option<bool>,
+    /// Raw attributes from the `<svelte:options>` tag, preserved for tooling.
+    pub attributes: Vec<Attribute>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -21,6 +21,7 @@ pub struct Component {
     pub fragment: Fragment,
     pub script: Option<Script>,
     pub css: Option<RawBlock>,
+    pub options: Option<SvelteOptions>,
     /// Full source text of the .svelte file.
     pub source: String,
     next_node_id: u32,
@@ -33,6 +34,7 @@ impl Component {
             fragment,
             script,
             css,
+            options: None,
             source,
             next_node_id: 0,
         }
@@ -508,6 +510,51 @@ pub enum ScriptLanguage {
 pub struct RawBlock {
     pub span: Span,
     pub content_span: Span,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteOptions — parsed from <svelte:options> tag
+// ---------------------------------------------------------------------------
+
+/// Component-level options parsed from `<svelte:options .../>`.
+/// Stored on `Component.options` after extraction from the fragment.
+pub struct SvelteOptions {
+    pub span: Span,
+    /// Whether this component uses runes mode. `None` = inherit from compiler options.
+    pub runes: Option<bool>,
+    /// Component namespace: "html" (default), "svg", or "mathml".
+    pub namespace: Option<Namespace>,
+    /// CSS injection mode. Currently only "injected" is valid.
+    pub css: Option<CssMode>,
+    /// Custom element tag name (simple string form).
+    pub custom_element: Option<CustomElementConfig>,
+    /// LEGACY(svelte4): immutable mode. Deprecated in Svelte 5.
+    pub immutable: Option<bool>,
+    /// LEGACY(svelte4): accessors mode. Deprecated in Svelte 5.
+    pub accessors: Option<bool>,
+    /// Preserve whitespace in template.
+    pub preserve_whitespace: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Namespace {
+    Html,
+    Svg,
+    Mathml,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CssMode {
+    Injected,
+}
+
+/// Custom element configuration from `<svelte:options customElement=...>`.
+pub enum CustomElementConfig {
+    /// Simple string form: `customElement="my-tag"`
+    Tag(String),
+    /// Object form: `customElement={{ tag: "...", ... }}`
+    /// Stores the expression span for deferred parsing in analysis.
+    Expression(Span),
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_diagnostics/src/lib.rs
+++ b/crates/svelte_diagnostics/src/lib.rs
@@ -28,6 +28,14 @@ pub enum DiagnosticKind {
     NoEachBlockToClose,
     NoKeyBlockToClose,
     VoidElementInvalidContent,
+    // svelte:options errors
+    SvelteOptionsUnknownAttribute(String),
+    SvelteOptionsInvalidAttributeValue(String),
+    SvelteOptionsInvalidCustomElementTag,
+    SvelteOptionsReservedTagName,
+    SvelteOptionsNoChildren,
+    SvelteOptionsInvalidAttribute,
+    SvelteOptionsDuplicate,
     // Internal compiler errors
     InternalError(String),
 }
@@ -54,6 +62,13 @@ impl DiagnosticKind {
             Self::NoEachBlockToClose => "block_unexpected_close",
             Self::NoKeyBlockToClose => "block_unexpected_close",
             Self::VoidElementInvalidContent => "void_element_invalid_content",
+            Self::SvelteOptionsUnknownAttribute(_) => "svelte_options_unknown_attribute",
+            Self::SvelteOptionsInvalidAttributeValue(_) => "svelte_options_invalid_attribute_value",
+            Self::SvelteOptionsInvalidCustomElementTag => "svelte_options_invalid_customelement",
+            Self::SvelteOptionsReservedTagName => "svelte_options_reserved_tagname",
+            Self::SvelteOptionsNoChildren => "svelte_options_children_forbidden",
+            Self::SvelteOptionsInvalidAttribute => "svelte_options_invalid_attribute",
+            Self::SvelteOptionsDuplicate => "svelte_options_duplicate",
             Self::InternalError(_) => "internal_error",
         }
     }
@@ -96,6 +111,27 @@ impl DiagnosticKind {
             Self::VoidElementInvalidContent => {
                 "Void elements cannot have children or closing tags".into()
             }
+            Self::SvelteOptionsUnknownAttribute(name) => {
+                format!("<svelte:options> unknown attribute '{name}'")
+            }
+            Self::SvelteOptionsInvalidAttributeValue(expected) => {
+                format!("Value must be {expected}")
+            }
+            Self::SvelteOptionsInvalidCustomElementTag => {
+                "\"tag\" must be a valid custom element name".into()
+            }
+            Self::SvelteOptionsReservedTagName => {
+                "\"tag\" cannot be a reserved custom element name".into()
+            }
+            Self::SvelteOptionsNoChildren => {
+                "<svelte:options> cannot have children".into()
+            }
+            Self::SvelteOptionsInvalidAttribute => {
+                "<svelte:options> can only have static attributes".into()
+            }
+            Self::SvelteOptionsDuplicate => {
+                "A component can have a single <svelte:options> element".into()
+            }
             Self::InternalError(msg) => format!("Internal compiler error: {msg}"),
         }
     }
@@ -117,7 +153,14 @@ impl DiagnosticKind {
             | Self::OnlyOneTopLevelStyle
             | Self::NoEachBlockToClose
             | Self::NoKeyBlockToClose
-            | Self::VoidElementInvalidContent => {
+            | Self::VoidElementInvalidContent
+            | Self::SvelteOptionsUnknownAttribute(_)
+            | Self::SvelteOptionsInvalidAttributeValue(_)
+            | Self::SvelteOptionsInvalidCustomElementTag
+            | Self::SvelteOptionsReservedTagName
+            | Self::SvelteOptionsNoChildren
+            | Self::SvelteOptionsInvalidAttribute
+            | Self::SvelteOptionsDuplicate => {
                 Some(format!("https://svelte.dev/e/{code}"))
             }
             _ => None,
@@ -217,6 +260,34 @@ impl Diagnostic {
 
     pub fn void_element_invalid_content(span: Span) -> Self {
         Self::error(DiagnosticKind::VoidElementInvalidContent, span)
+    }
+
+    pub fn svelte_options_unknown_attribute(span: Span, name: String) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsUnknownAttribute(name), span, severity: Severity::Error }
+    }
+
+    pub fn svelte_options_invalid_attribute_value(span: Span, expected: String) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsInvalidAttributeValue(expected), span, severity: Severity::Error }
+    }
+
+    pub fn svelte_options_invalid_custom_element_tag(span: Span) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsInvalidCustomElementTag, span, severity: Severity::Error }
+    }
+
+    pub fn svelte_options_reserved_tag_name(span: Span) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsReservedTagName, span, severity: Severity::Error }
+    }
+
+    pub fn svelte_options_no_children(span: Span) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsNoChildren, span, severity: Severity::Error }
+    }
+
+    pub fn svelte_options_invalid_attribute(span: Span) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsInvalidAttribute, span, severity: Severity::Error }
+    }
+
+    pub fn svelte_options_duplicate(span: Span) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsDuplicate, span, severity: Severity::Error }
     }
 
     pub fn internal_error(message: String) -> Self {

--- a/crates/svelte_diagnostics/src/lib.rs
+++ b/crates/svelte_diagnostics/src/lib.rs
@@ -36,6 +36,8 @@ pub enum DiagnosticKind {
     SvelteOptionsNoChildren,
     SvelteOptionsInvalidAttribute,
     SvelteOptionsDuplicate,
+    /// LEGACY(svelte4): `tag` attribute renamed to `customElement`.
+    SvelteOptionsDeprecatedTag,
     // Internal compiler errors
     InternalError(String),
 }
@@ -69,6 +71,7 @@ impl DiagnosticKind {
             Self::SvelteOptionsNoChildren => "svelte_options_children_forbidden",
             Self::SvelteOptionsInvalidAttribute => "svelte_options_invalid_attribute",
             Self::SvelteOptionsDuplicate => "svelte_options_duplicate",
+            Self::SvelteOptionsDeprecatedTag => "svelte_options_deprecated_tag",
             Self::InternalError(_) => "internal_error",
         }
     }
@@ -132,6 +135,9 @@ impl DiagnosticKind {
             Self::SvelteOptionsDuplicate => {
                 "A component can have a single <svelte:options> element".into()
             }
+            Self::SvelteOptionsDeprecatedTag => {
+                "\"tag\" option is deprecated \u{2014} use \"customElement\" instead".into()
+            }
             Self::InternalError(msg) => format!("Internal compiler error: {msg}"),
         }
     }
@@ -160,7 +166,8 @@ impl DiagnosticKind {
             | Self::SvelteOptionsReservedTagName
             | Self::SvelteOptionsNoChildren
             | Self::SvelteOptionsInvalidAttribute
-            | Self::SvelteOptionsDuplicate => {
+            | Self::SvelteOptionsDuplicate
+            | Self::SvelteOptionsDeprecatedTag => {
                 Some(format!("https://svelte.dev/e/{code}"))
             }
             _ => None,
@@ -288,6 +295,11 @@ impl Diagnostic {
 
     pub fn svelte_options_duplicate(span: Span) -> Self {
         Diagnostic { kind: DiagnosticKind::SvelteOptionsDuplicate, span, severity: Severity::Error }
+    }
+
+    /// LEGACY(svelte4): `tag` attribute renamed to `customElement`.
+    pub fn svelte_options_deprecated_tag(span: Span) -> Self {
+        Diagnostic { kind: DiagnosticKind::SvelteOptionsDeprecatedTag, span, severity: Severity::Warning }
     }
 
     pub fn internal_error(message: String) -> Self {

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -6,10 +6,11 @@ use svelte_span::Span;
 
 use svelte_ast::{
     AnimateDirective, Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment,
-    ComponentNode, ConstTag, ConcatPart, ConcatenationAttribute, Component, EachBlock, Element,
-    OnDirectiveLegacy, StyleDirective, StyleDirectiveValue, ExpressionAttribute, Fragment, HtmlTag,
-    IfBlock, KeyBlock, Node, NodeIdAllocator, RawBlock, RenderTag, Script, ScriptContext,
-    ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute, Text, TransitionDirective,
+    ComponentNode, ConstTag, ConcatPart, ConcatenationAttribute, Component, CssMode,
+    CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
+    KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
+    ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute,
+    StyleDirective, StyleDirectiveValue, SvelteOptions, Text, TransitionDirective,
     TransitionDirection, UseDirective,
 };
 
@@ -342,6 +343,9 @@ impl<'a> Parser<'a> {
             css,
         );
         component.set_next_node_id(self.ids.current());
+
+        // Extract <svelte:options> from fragment (must be top-level)
+        self.extract_svelte_options(&mut component);
 
         (component, self.diagnostics)
     }
@@ -953,6 +957,249 @@ impl<'a> Parser<'a> {
 
         attributes
     }
+
+    // -----------------------------------------------------------------------
+    // <svelte:options> extraction
+    // -----------------------------------------------------------------------
+
+    fn extract_svelte_options(&mut self, component: &mut Component) {
+        let options_idx = component
+            .fragment
+            .nodes
+            .iter()
+            .position(|n| n.as_element().is_some_and(|el| el.name == "svelte:options"));
+
+        let Some(idx) = options_idx else {
+            return;
+        };
+
+        let node = component.fragment.nodes.remove(idx);
+        let Node::Element(el) = node else {
+            unreachable!();
+        };
+
+        // Check for duplicate <svelte:options>
+        let has_another = component
+            .fragment
+            .nodes
+            .iter()
+            .any(|n| n.as_element().is_some_and(|e| e.name == "svelte:options"));
+        if has_another {
+            self.recover(Diagnostic::svelte_options_duplicate(el.span));
+        }
+
+        // Validate no children
+        if !el.fragment.is_empty() {
+            self.recover(Diagnostic::svelte_options_no_children(el.span));
+        }
+
+        component.options = Some(self.read_svelte_options(&el));
+    }
+
+    fn read_svelte_options(&mut self, el: &Element) -> SvelteOptions {
+        let mut options = SvelteOptions {
+            span: el.span,
+            runes: None,
+            namespace: None,
+            css: None,
+            custom_element: None,
+            immutable: None,
+            accessors: None,
+            preserve_whitespace: None,
+        };
+
+        for attr in &el.attributes {
+            match attr {
+                Attribute::BooleanAttribute(ba) => {
+                    self.process_svelte_option_bool(&ba.name, true, el.span, &mut options);
+                }
+                Attribute::StringAttribute(sa) => {
+                    let value = sa.value_span.source_text(self.source).to_string();
+                    self.process_svelte_option_string(&sa.name, &value, el.span, &mut options);
+                }
+                Attribute::ExpressionAttribute(ea) => {
+                    let expr_text = ea.expression_span.source_text(self.source).trim();
+                    match expr_text {
+                        "true" => {
+                            self.process_svelte_option_bool(&ea.name, true, el.span, &mut options);
+                        }
+                        "false" => {
+                            self.process_svelte_option_bool(&ea.name, false, el.span, &mut options);
+                        }
+                        _ => {
+                            // Could be an object expression for customElement
+                            if ea.name == "customElement" {
+                                self.process_custom_element_expression(
+                                    ea.expression_span,
+                                    el.span,
+                                    &mut options,
+                                );
+                            } else {
+                                self.recover(Diagnostic::svelte_options_invalid_attribute(el.span));
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    // Directives and other non-standard attributes are not allowed
+                    self.recover(Diagnostic::svelte_options_invalid_attribute(el.span));
+                }
+            }
+        }
+
+        options
+    }
+
+    fn process_svelte_option_bool(
+        &mut self,
+        name: &str,
+        value: bool,
+        span: Span,
+        options: &mut SvelteOptions,
+    ) {
+        match name {
+            "runes" => options.runes = Some(value),
+            "immutable" => options.immutable = Some(value),
+            "accessors" => options.accessors = Some(value),
+            "preserveWhitespace" => options.preserve_whitespace = Some(value),
+            "namespace" | "css" | "customElement" => {
+                self.recover(Diagnostic::svelte_options_invalid_attribute_value(
+                    span,
+                    "a string value".into(),
+                ));
+            }
+            _ => {
+                self.recover(Diagnostic::svelte_options_unknown_attribute(
+                    span,
+                    name.to_string(),
+                ));
+            }
+        }
+    }
+
+    fn process_svelte_option_string(
+        &mut self,
+        name: &str,
+        value: &str,
+        span: Span,
+        options: &mut SvelteOptions,
+    ) {
+        match name {
+            "namespace" => match value {
+                "html" => options.namespace = Some(Namespace::Html),
+                "svg" | "http://www.w3.org/2000/svg" => options.namespace = Some(Namespace::Svg),
+                "mathml" | "http://www.w3.org/1998/Math/MathML" => {
+                    options.namespace = Some(Namespace::Mathml)
+                }
+                _ => {
+                    self.recover(Diagnostic::svelte_options_invalid_attribute_value(
+                        span,
+                        r#""html", "mathml" or "svg""#.into(),
+                    ));
+                }
+            },
+            "css" => {
+                if value == "injected" {
+                    options.css = Some(CssMode::Injected);
+                } else {
+                    self.recover(Diagnostic::svelte_options_invalid_attribute_value(
+                        span,
+                        r#""injected""#.into(),
+                    ));
+                }
+            }
+            "customElement" => {
+                if let Some(tag_err) = validate_custom_element_tag(value) {
+                    match tag_err {
+                        TagError::Invalid => {
+                            self.recover(
+                                Diagnostic::svelte_options_invalid_custom_element_tag(span),
+                            );
+                        }
+                        TagError::Reserved => {
+                            self.recover(Diagnostic::svelte_options_reserved_tag_name(span));
+                        }
+                    }
+                }
+                options.custom_element = Some(CustomElementConfig::Tag(value.to_string()));
+            }
+            "runes" | "immutable" | "accessors" | "preserveWhitespace" => {
+                self.recover(Diagnostic::svelte_options_invalid_attribute_value(
+                    span,
+                    "true or false".into(),
+                ));
+            }
+            _ => {
+                self.recover(Diagnostic::svelte_options_unknown_attribute(
+                    span,
+                    name.to_string(),
+                ));
+            }
+        }
+    }
+
+    fn process_custom_element_expression(
+        &mut self,
+        expression_span: Span,
+        el_span: Span,
+        options: &mut SvelteOptions,
+    ) {
+        let expr_text = expression_span.source_text(self.source).trim();
+
+        // `null` is backwards compat from Svelte 4 — just ignore
+        if expr_text == "null" {
+            return;
+        }
+
+        // Must be an object expression
+        if !expr_text.starts_with('{') {
+            self.recover(Diagnostic::svelte_options_invalid_attribute(el_span));
+            return;
+        }
+
+        // Store the expression span; full object parsing deferred to analysis
+        options.custom_element = Some(CustomElementConfig::Expression(expression_span));
+    }
+}
+
+// Custom element tag name validation
+enum TagError {
+    Invalid,
+    Reserved,
+}
+
+fn validate_custom_element_tag(tag: &str) -> Option<TagError> {
+    if tag.is_empty() {
+        return None; // Empty tag is allowed (means "no tag")
+    }
+
+    // Must start with lowercase letter, contain a hyphen, and only valid chars
+    let is_valid = tag.starts_with(|c: char| c.is_ascii_lowercase())
+        && tag.contains('-')
+        && tag
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.' || c == '_');
+
+    if !is_valid {
+        return Some(TagError::Invalid);
+    }
+
+    const RESERVED: &[&str] = &[
+        "annotation-xml",
+        "color-profile",
+        "font-face",
+        "font-face-src",
+        "font-face-uri",
+        "font-face-format",
+        "font-face-name",
+        "missing-glyph",
+    ];
+
+    if RESERVED.contains(&tag) {
+        return Some(TagError::Reserved);
+    }
+
+    None
 }
 
 fn is_component_name(name: &str) -> bool {
@@ -1504,5 +1751,208 @@ mod tests {
         assert_element(&c, 0, "input", true);
         assert_element(&c, 1, "br", true);
         assert_element(&c, 2, "hr", true);
+    }
+
+    // --- <svelte:options> tests ---
+
+    fn assert_options_runes(c: &Component, expected: bool) {
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.runes, Some(expected), "expected runes={expected}");
+    }
+
+    fn assert_options_namespace(c: &Component, expected: svelte_ast::Namespace) {
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.namespace, Some(expected), "expected namespace={expected:?}");
+    }
+
+    fn assert_options_css(c: &Component, expected: svelte_ast::CssMode) {
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.css, Some(expected), "expected css={expected:?}");
+    }
+
+    fn assert_options_custom_element_tag(c: &Component, expected_tag: &str) {
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        match &opts.custom_element {
+            Some(svelte_ast::CustomElementConfig::Tag(tag)) => {
+                assert_eq!(tag, expected_tag, "expected customElement tag");
+            }
+            _ => panic!("expected CustomElementConfig::Tag"),
+        }
+    }
+
+    fn assert_options_custom_element_expression(c: &Component) {
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert!(
+            matches!(&opts.custom_element, Some(svelte_ast::CustomElementConfig::Expression(_))),
+            "expected CustomElementConfig::Expression"
+        );
+    }
+
+    fn assert_no_options(c: &Component) {
+        assert!(c.options.is_none(), "expected no svelte:options");
+    }
+
+    #[test]
+    fn svelte_options_runes_true() {
+        let c = parse("<svelte:options runes={true} />");
+        assert_options_runes(&c, true);
+        assert!(c.fragment.is_empty(), "svelte:options should be removed from fragment");
+    }
+
+    #[test]
+    fn svelte_options_runes_false() {
+        let c = parse("<svelte:options runes={false} />");
+        assert_options_runes(&c, false);
+    }
+
+    #[test]
+    fn svelte_options_namespace_svg() {
+        let c = parse(r#"<svelte:options namespace="svg" />"#);
+        assert_options_namespace(&c, svelte_ast::Namespace::Svg);
+    }
+
+    #[test]
+    fn svelte_options_namespace_mathml() {
+        let c = parse(r#"<svelte:options namespace="mathml" />"#);
+        assert_options_namespace(&c, svelte_ast::Namespace::Mathml);
+    }
+
+    #[test]
+    fn svelte_options_namespace_html() {
+        let c = parse(r#"<svelte:options namespace="html" />"#);
+        assert_options_namespace(&c, svelte_ast::Namespace::Html);
+    }
+
+    #[test]
+    fn svelte_options_css_injected() {
+        let c = parse(r#"<svelte:options css="injected" />"#);
+        assert_options_css(&c, svelte_ast::CssMode::Injected);
+    }
+
+    #[test]
+    fn svelte_options_custom_element_string() {
+        let c = parse(r#"<svelte:options customElement="my-element" />"#);
+        assert_options_custom_element_tag(&c, "my-element");
+    }
+
+    #[test]
+    fn svelte_options_custom_element_object() {
+        let c = parse(r#"<svelte:options customElement={{ tag: "my-element", shadow: "open" }} />"#);
+        assert_options_custom_element_expression(&c);
+    }
+
+    #[test]
+    fn svelte_options_preserve_whitespace() {
+        let c = parse("<svelte:options preserveWhitespace />");
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.preserve_whitespace, Some(true));
+    }
+
+    #[test]
+    fn svelte_options_immutable() {
+        let c = parse("<svelte:options immutable={true} />");
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.immutable, Some(true));
+    }
+
+    #[test]
+    fn svelte_options_accessors() {
+        let c = parse("<svelte:options accessors={true} />");
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.accessors, Some(true));
+    }
+
+    #[test]
+    fn svelte_options_multiple_attributes() {
+        let c = parse(r#"<svelte:options runes={true} namespace="svg" />"#);
+        assert_options_runes(&c, true);
+        assert_options_namespace(&c, svelte_ast::Namespace::Svg);
+    }
+
+    #[test]
+    fn svelte_options_with_content() {
+        let c = parse("<svelte:options runes={true} />\n<p>Hello</p>");
+        assert_options_runes(&c, true);
+        // <p> should be in the fragment, svelte:options should not
+        assert_eq!(c.fragment.nodes.len(), 2); // newline text + <p>
+    }
+
+    #[test]
+    fn svelte_options_removed_from_fragment() {
+        let c = parse("<svelte:options runes={true} />");
+        assert!(c.options.is_some());
+        assert!(c.fragment.is_empty(), "svelte:options must be removed from fragment");
+    }
+
+    #[test]
+    fn no_svelte_options() {
+        let c = parse("<p>Hello</p>");
+        assert_no_options(&c);
+    }
+
+    #[test]
+    fn svelte_options_unknown_attribute_diagnostic() {
+        let (_, diags) = parse_with_diagnostics(r#"<svelte:options foo="bar" />"#);
+        assert!(!diags.is_empty());
+        assert!(diags.iter().any(|d| matches!(
+            &d.kind,
+            svelte_diagnostics::DiagnosticKind::SvelteOptionsUnknownAttribute(name) if name == "foo"
+        )));
+    }
+
+    #[test]
+    fn svelte_options_invalid_namespace_diagnostic() {
+        let (_, diags) = parse_with_diagnostics(r#"<svelte:options namespace="invalid" />"#);
+        assert!(!diags.is_empty());
+        assert!(diags.iter().any(|d| matches!(
+            &d.kind,
+            svelte_diagnostics::DiagnosticKind::SvelteOptionsInvalidAttributeValue(_)
+        )));
+    }
+
+    #[test]
+    fn svelte_options_invalid_css_diagnostic() {
+        let (_, diags) = parse_with_diagnostics(r#"<svelte:options css="external" />"#);
+        assert!(!diags.is_empty());
+    }
+
+    #[test]
+    fn svelte_options_no_children_diagnostic() {
+        let (_, diags) = parse_with_diagnostics("<svelte:options runes={true}><p>child</p></svelte:options>");
+        assert!(!diags.is_empty());
+        assert!(diags.iter().any(|d| matches!(
+            &d.kind,
+            svelte_diagnostics::DiagnosticKind::SvelteOptionsNoChildren
+        )));
+    }
+
+    #[test]
+    fn svelte_options_invalid_custom_element_tag_diagnostic() {
+        let (_, diags) = parse_with_diagnostics(r#"<svelte:options customElement="NoHyphen" />"#);
+        assert!(!diags.is_empty());
+    }
+
+    #[test]
+    fn svelte_options_reserved_tag_name_diagnostic() {
+        let (_, diags) = parse_with_diagnostics(r#"<svelte:options customElement="font-face" />"#);
+        assert!(!diags.is_empty());
+        assert!(diags.iter().any(|d| matches!(
+            &d.kind,
+            svelte_diagnostics::DiagnosticKind::SvelteOptionsReservedTagName
+        )));
+    }
+
+    #[test]
+    fn svelte_options_custom_element_null_compat() {
+        // null is backwards compat from Svelte 4 — should not error
+        let c = parse("<svelte:options customElement={null} />");
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert!(opts.custom_element.is_none());
+    }
+
+    #[test]
+    fn svelte_options_namespace_svg_uri() {
+        let c = parse(r#"<svelte:options namespace="http://www.w3.org/2000/svg" />"#);
+        assert_options_namespace(&c, svelte_ast::Namespace::Svg);
     }
 }

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -1006,6 +1006,7 @@ impl<'a> Parser<'a> {
             immutable: None,
             accessors: None,
             preserve_whitespace: None,
+            attributes: el.attributes.clone(),
         };
 
         for attr in &el.attributes {
@@ -1068,6 +1069,10 @@ impl<'a> Parser<'a> {
                     "a string value".into(),
                 ));
             }
+            // LEGACY(svelte4): `tag` renamed to `customElement`
+            "tag" => {
+                self.recover(Diagnostic::svelte_options_deprecated_tag(span));
+            }
             _ => {
                 self.recover(Diagnostic::svelte_options_unknown_attribute(
                     span,
@@ -1120,14 +1125,19 @@ impl<'a> Parser<'a> {
                             self.recover(Diagnostic::svelte_options_reserved_tag_name(span));
                         }
                     }
+                } else {
+                    options.custom_element = Some(CustomElementConfig::Tag(value.to_string()));
                 }
-                options.custom_element = Some(CustomElementConfig::Tag(value.to_string()));
             }
             "runes" | "immutable" | "accessors" | "preserveWhitespace" => {
                 self.recover(Diagnostic::svelte_options_invalid_attribute_value(
                     span,
                     "true or false".into(),
                 ));
+            }
+            // LEGACY(svelte4): `tag` renamed to `customElement`
+            "tag" => {
+                self.recover(Diagnostic::svelte_options_deprecated_tag(span));
             }
             _ => {
                 self.recover(Diagnostic::svelte_options_unknown_attribute(
@@ -1954,5 +1964,32 @@ mod tests {
     fn svelte_options_namespace_svg_uri() {
         let c = parse(r#"<svelte:options namespace="http://www.w3.org/2000/svg" />"#);
         assert_options_namespace(&c, svelte_ast::Namespace::Svg);
+    }
+
+    #[test]
+    fn svelte_options_deprecated_tag_diagnostic() {
+        let (_, diags) = parse_with_diagnostics(r#"<svelte:options tag="my-element" />"#);
+        assert!(!diags.is_empty());
+        assert!(diags.iter().any(|d| matches!(
+            &d.kind,
+            svelte_diagnostics::DiagnosticKind::SvelteOptionsDeprecatedTag
+        )));
+        // Should be a warning, not an error
+        assert!(diags.iter().any(|d| d.severity == svelte_diagnostics::Severity::Warning));
+    }
+
+    #[test]
+    fn svelte_options_invalid_tag_not_stored() {
+        let (c, diags) = parse_with_diagnostics(r#"<svelte:options customElement="NoHyphen" />"#);
+        assert!(!diags.is_empty());
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert!(opts.custom_element.is_none(), "invalid tag should not be stored");
+    }
+
+    #[test]
+    fn svelte_options_preserves_attributes() {
+        let c = parse(r#"<svelte:options runes={true} namespace="svg" />"#);
+        let opts = c.options.as_ref().expect("expected svelte:options");
+        assert_eq!(opts.attributes.len(), 2);
     }
 }

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -256,6 +256,12 @@ impl<'a> Scanner<'a> {
             return Err(Diagnostic::invalid_tag_name(self.span(name_start, self.current)));
         }
 
+        // Handle `svelte:*` special element names (e.g., svelte:options, svelte:head)
+        if name == "svelte" && self.peek() == Some(':') {
+            self.advance(); // consume ':'
+            self.identifier(); // consume the rest (options, head, window, etc.)
+        }
+
         let name_span = self.span(name_start, self.current);
 
         let attributes = self.attributes()?;
@@ -698,6 +704,12 @@ impl<'a> Scanner<'a> {
 
         if name.is_empty() {
             return Err(Diagnostic::invalid_tag_name(self.span(name_start, self.current)));
+        }
+
+        // Handle `svelte:*` special element names
+        if name == "svelte" && self.peek() == Some(':') {
+            self.advance(); // consume ':'
+            self.identifier(); // consume the rest
         }
 
         let name_span = self.span(name_start, self.current);

--- a/tasks/compiler_tests/cases2/svelte_options_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_options_basic/case-rust.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p>Hello world</p>`);
+export default function App($$anchor) {
+	var p = root();
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/svelte_options_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_options_basic/case-svelte.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p>Hello world</p>`);
+export default function App($$anchor) {
+	var p = root();
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/svelte_options_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_options_basic/case.svelte
@@ -1,0 +1,3 @@
+<svelte:options runes={true} />
+
+<p>Hello world</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -654,3 +654,8 @@ fn assert_compiler_module(case: &str) {
 fn module_compilation() {
     assert_compiler_module("module_compilation");
 }
+
+#[rstest]
+fn svelte_options_basic() {
+    assert_compiler("svelte_options_basic");
+}


### PR DESCRIPTION
Add SvelteOptions AST type with support for all attributes:
- runes={true|false}, namespace, css, customElement (string/object),
  preserveWhitespace, immutable, accessors

Scanner extended to handle svelte:* tag names (colon in identifiers).
Parser extracts <svelte:options> from fragment and stores on Component.options.

Validation: unknown attributes, invalid values, no children,
custom element tag name format and reserved names.

22 new parser tests, 1 compiler integration test.
customElement object parsing and namespace codegen deferred.

https://claude.ai/code/session_01YHHAzKYj6dUu1QWoWisWVk