### PR TITLE
Port <svelte:head> — parser, analysis, and codegen

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -357,12 +357,15 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, head managem
 - [ ] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties *(deferred — expression span stored, analysis-phase parsing needed)*
 - [ ] `namespace` affecting codegen: `$.from_svg()` / `$.from_mathml()` instead of `$.from_html()` *(deferred — requires codegen changes)*
 
-### `<svelte:head>` — Document head
+### ~~`<svelte:head>` — Document head~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Node::SvelteHead { id, span, fragment }`
-- **Codegen**: `$.head(($$anchor) => { ... })`
+- **Codegen**: `$.head(hash, ($$anchor) => { ... })`
 - **Constraint**: Top-level only
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteHead.js`
+- [ ] Validation: `<svelte:head>` only allowed at root level *(discovered during port, deferred)*
+- [ ] Validation: no attributes allowed (diagnostic) *(discovered during port, deferred)*
+- [ ] `filename` parameter for `compile()` to produce correct hash *(discovered during port, deferred — currently uses "(unknown)" default)*
 
 ### `<svelte:element this={tag}>` — Dynamic element
 - **Phases**: P, A, T

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -53,6 +53,7 @@ pub enum FragmentKey {
     EachFallback(NodeId),
     SnippetBody(NodeId),
     KeyBlockBody(NodeId),
+    SvelteHeadBody(NodeId),
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -51,6 +51,9 @@ fn lower_fragment(
             Node::KeyBlock(block) => {
                 lower_fragment(&block.fragment, FragmentKey::KeyBlockBody(block.id), component, data);
             }
+            Node::SvelteHead(head) => {
+                lower_fragment(&head.fragment, FragmentKey::SvelteHeadBody(head.id), component, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
     }
@@ -70,7 +73,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
     let mut regular: Vec<&Node> = Vec::new();
     for node in &fragment.nodes {
         match node {
-            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::Error(_) => continue,
+            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::SvelteHead(_) | Node::Error(_) => continue,
             _ => regular.push(node),
         }
     }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -205,6 +205,9 @@ fn walk_node<'a>(
                 Err(diag) => diags.push(diag),
             }
         }
+        Node::SvelteHead(head) => {
+            walk_fragment(alloc, &head.fragment, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -248,6 +248,9 @@ fn walk_template_scopes(
             Node::KeyBlock(block) => {
                 walk_template_scopes(&block.fragment, component, scoping, current_scope, const_tag_names);
             }
+            Node::SvelteHead(head) => {
+                walk_template_scopes(&head.fragment, component, scoping, current_scope, const_tag_names);
+            }
             Node::ConstTag(tag) => {
                 if let Some(names) = const_tag_names.get(&tag.id) {
                     for name in names {

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -119,6 +119,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
                 visitor.visit_key_block(block, scope, data);
                 walk_template(&block.fragment, data, scope, visitor);
             }
+            Node::SvelteHead(head) => {
+                walk_template(&head.fragment, data, scope, visitor);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -123,6 +123,7 @@ impl_node_enum! {
     HtmlTag(HtmlTag)             => is_html_tag / as_html_tag,
     ConstTag(ConstTag)           => is_const_tag / as_const_tag,
     KeyBlock(KeyBlock)           => is_key_block / as_key_block,
+    SvelteHead(SvelteHead)       => is_svelte_head / as_svelte_head,
     Error(ErrorNode)             => is_error / as_error,
 }
 
@@ -304,6 +305,16 @@ pub struct KeyBlock {
     pub span: Span,
     /// Span of the JS expression: "count" in `{#key count}`.
     pub expression_span: Span,
+    pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteHead — <svelte:head>...</svelte:head>
+// ---------------------------------------------------------------------------
+
+pub struct SvelteHead {
+    pub id: NodeId,
+    pub span: Span,
     pub fragment: Fragment,
 }
 

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -79,6 +79,9 @@ impl<'a> NodeIndex<'a> {
                 Node::KeyBlock(b) => {
                     self.walk(&b.fragment);
                 }
+                Node::SvelteHead(h) => {
+                    self.walk(&h.fragment);
+                }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
                 }

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod html_tag;
 pub(crate) mod key_block;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
+pub(crate) mod svelte_head;
 pub(crate) mod traverse;
 
 use oxc_ast::ast::Statement;
@@ -98,6 +99,11 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
 
     emit_const_tags(ctx, key, &mut body);
 
+    // Collect SvelteHead IDs — $.head() calls are generated after main template init
+    let svelte_head_ids: Vec<_> = ctx.component.fragment.nodes.iter()
+        .filter_map(|n| n.as_svelte_head().map(|h| h.id))
+        .collect();
+
     match ct {
         ContentType::Empty => {}
         ContentType::StaticText => gen_root_static_text(ctx, &mut body),
@@ -105,6 +111,25 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
         ContentType::SingleElement => gen_root_single_element(ctx, &tpl_name, &mut hoisted, &mut body),
         ContentType::SingleBlock => gen_root_single_block(ctx, &mut body),
         ContentType::Mixed => gen_root_mixed(ctx, &tpl_name, &mut hoisted, &mut body),
+    }
+
+    // Generate $.head() calls for <svelte:head> nodes.
+    // In the Svelte reference, hoisted nodes are visited first and push to init[],
+    // while the template var decl is unshifted to init[0]. So $.head() ends up
+    // after the template init but before $.append().
+    if !svelte_head_ids.is_empty() {
+        // Find the $.append() call at the end and insert before it
+        let insert_pos = body.len().saturating_sub(
+            if matches!(ct, ContentType::SingleElement | ContentType::Mixed | ContentType::DynamicText) { 1 } else { 0 }
+        );
+        let mut head_stmts = Vec::new();
+        for id in svelte_head_ids {
+            svelte_head::gen_svelte_head(ctx, id, &mut head_stmts);
+        }
+        // Insert head stmts before the append
+        let tail: Vec<_> = body.drain(insert_pos..).collect();
+        body.extend(head_stmts);
+        body.extend(tail);
     }
 
     (hoisted, body, snippet_stmts, hoistable_snippets)

--- a/crates/svelte_codegen_client/src/template/svelte_head.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_head.rs
@@ -1,0 +1,56 @@
+//! SvelteHead code generation — `<svelte:head>...</svelte:head>`.
+
+use oxc_ast::ast::Statement;
+
+use svelte_analyze::FragmentKey;
+use svelte_ast::NodeId;
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::gen_fragment;
+
+/// Generate `$.head(hash, ($$anchor) => { ... })`.
+pub(crate) fn gen_svelte_head<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let body = gen_fragment(ctx, FragmentKey::SvelteHeadBody(id));
+    let body_fn = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), body);
+
+    // hash(filename) — Svelte uses djb2 hash of the filename for scope isolation.
+    // Our compile() doesn't accept filename yet, so we use "(unknown)" to match
+    // the Svelte compiler's default.
+    let hash_str = hash("(unknown)");
+
+    stmts.push(ctx.b.call_stmt(
+        "$.head",
+        [Arg::Str(hash_str), Arg::Expr(body_fn)],
+    ));
+}
+
+/// Svelte's hash — iterates string bytes in reverse, returns base-36 string.
+/// Matches: `((hash << 5) - hash) ^ charCode`, strips `\r`.
+fn hash(s: &str) -> String {
+    let mut h: u32 = 5381;
+    for &b in s.as_bytes().iter().rev() {
+        if b == b'\r' { continue; }
+        h = (h.wrapping_shl(5).wrapping_sub(h)) ^ (b as u32);
+    }
+    to_base36(h)
+}
+
+fn to_base36(mut n: u32) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut result = Vec::new();
+    while n > 0 {
+        result.push(CHARS[(n % 36) as usize]);
+        n /= 36;
+    }
+    result.reverse();
+    String::from_utf8(result).unwrap()
+}

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -10,7 +10,7 @@ use svelte_ast::{
     CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
     KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute,
-    StyleDirective, StyleDirectiveValue, SvelteOptions, Text, TransitionDirective,
+    StyleDirective, StyleDirectiveValue, SvelteHead, SvelteOptions, Text, TransitionDirective,
     TransitionDirection, UseDirective,
 };
 
@@ -346,6 +346,9 @@ impl<'a> Parser<'a> {
 
         // Extract <svelte:options> from fragment (must be top-level)
         self.extract_svelte_options(&mut component);
+
+        // Convert <svelte:head> elements to SvelteHead nodes
+        Self::convert_svelte_head(&mut component);
 
         (component, self.diagnostics)
     }
@@ -1169,6 +1172,26 @@ impl<'a> Parser<'a> {
 
         // Store the expression span; full object parsing deferred to analysis
         options.custom_element = Some(CustomElementConfig::Expression(expression_span));
+    }
+
+    // -----------------------------------------------------------------------
+    // <svelte:head> conversion
+    // -----------------------------------------------------------------------
+
+    /// Convert `<svelte:head>` Element nodes in the root fragment to SvelteHead nodes.
+    fn convert_svelte_head(component: &mut Component) {
+        for node in &mut component.fragment.nodes {
+            if let Node::Element(el) = node {
+                if el.name == "svelte:head" {
+                    let head = SvelteHead {
+                        id: el.id,
+                        span: el.span,
+                        fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
+                    };
+                    *node = Node::SvelteHead(head);
+                }
+            }
+        }
     }
 }
 

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -179,6 +179,11 @@ fn walk_node<'a>(
             walk_fragment(ctx, &block.fragment, component, parsed, scope, snippet_params);
             ctx.const_aliases.pop();
         }
+        Node::SvelteHead(head) => {
+            ctx.const_aliases.push(FxHashMap::default());
+            walk_fragment(ctx, &head.fragment, component, parsed, scope, snippet_params);
+            ctx.const_aliases.pop();
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/benchmark/benches/compiler/big_v4.svelte
+++ b/tasks/benchmark/benches/compiler/big_v4.svelte
@@ -1,0 +1,2704 @@
+<script>
+    import { onMount } from "svelte";
+    import { fade, fly } from "svelte/transition";
+
+    let {
+        title = "Default Title",
+        count = 0,
+        items = [],
+        config = $bindable({}),
+        multiplier = 2,
+        ...rest
+    } = $props();
+
+    let state = $state("");
+    let counter = $state(0);
+
+    counter = 10;
+
+    let doubled = $derived(count * multiplier);
+
+    $effect(() => {
+        console.log("Title:", title, "Count:", count);
+    });
+
+    export const APP_VERSION = "1.0.0";
+
+    export function formatTitle(prefix) {
+        return prefix + ": " + title;
+    }
+
+    function action(node, arg) {
+        return { destroy() {} };
+    }
+</script>
+
+<svelte:head>
+    <meta name="description" content="Benchmark component">
+    <link rel="canonical" href="/benchmark">
+</svelte:head>
+
+{#snippet badge(text, variant)}
+    <span class="badge" class:primary={variant === "primary"} class:secondary={variant === "secondary"}>
+        {text}
+    </span>
+{/snippet}
+
+{#snippet card(heading, body)}
+    <div class="card">
+        <h3>{heading}</h3>
+        <p>{body}</p>
+        {@render badge("new", "primary")}
+    </div>
+{/snippet}
+
+<div>
+    Chunk 0: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 0.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 0.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 0.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-0">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-0", "secondary")}
+    {@render card(title, "Content for chunk 0")}
+</div>
+
+<div>
+    Chunk 1: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 1.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 1.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 1.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-1">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-1", "secondary")}
+    {@render card(title, "Content for chunk 1")}
+</div>
+
+<div>
+    Chunk 2: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 2.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 2.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 2.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-2">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-2", "secondary")}
+    {@render card(title, "Content for chunk 2")}
+</div>
+
+<div>
+    Chunk 3: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 3.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 3.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 3.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-3">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-3", "secondary")}
+    {@render card(title, "Content for chunk 3")}
+</div>
+
+<div>
+    Chunk 4: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 4.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 4.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 4.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-4">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-4", "secondary")}
+    {@render card(title, "Content for chunk 4")}
+</div>
+
+<div>
+    Chunk 5: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 5.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 5.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 5.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-5">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-5", "secondary")}
+    {@render card(title, "Content for chunk 5")}
+</div>
+
+<div>
+    Chunk 6: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 6.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 6.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 6.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-6">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-6", "secondary")}
+    {@render card(title, "Content for chunk 6")}
+</div>
+
+<div>
+    Chunk 7: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 7.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 7.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 7.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-7">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-7", "secondary")}
+    {@render card(title, "Content for chunk 7")}
+</div>
+
+<div>
+    Chunk 8: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 8.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 8.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 8.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-8">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-8", "secondary")}
+    {@render card(title, "Content for chunk 8")}
+</div>
+
+<div>
+    Chunk 9: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 9.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 9.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 9.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-9">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-9", "secondary")}
+    {@render card(title, "Content for chunk 9")}
+</div>
+
+<div>
+    Chunk 10: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 10.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 10.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 10.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-10">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-10", "secondary")}
+    {@render card(title, "Content for chunk 10")}
+</div>
+
+<div>
+    Chunk 11: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 11.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 11.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 11.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-11">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-11", "secondary")}
+    {@render card(title, "Content for chunk 11")}
+</div>
+
+<div>
+    Chunk 12: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 12.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 12.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 12.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-12">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-12", "secondary")}
+    {@render card(title, "Content for chunk 12")}
+</div>
+
+<div>
+    Chunk 13: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 13.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 13.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 13.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-13">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-13", "secondary")}
+    {@render card(title, "Content for chunk 13")}
+</div>
+
+<div>
+    Chunk 14: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 14.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 14.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 14.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-14">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-14", "secondary")}
+    {@render card(title, "Content for chunk 14")}
+</div>
+
+<div>
+    Chunk 15: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 15.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 15.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 15.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-15">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-15", "secondary")}
+    {@render card(title, "Content for chunk 15")}
+</div>
+
+<div>
+    Chunk 16: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 16.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 16.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 16.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-16">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-16", "secondary")}
+    {@render card(title, "Content for chunk 16")}
+</div>
+
+<div>
+    Chunk 17: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 17.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 17.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 17.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-17">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-17", "secondary")}
+    {@render card(title, "Content for chunk 17")}
+</div>
+
+<div>
+    Chunk 18: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 18.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 18.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 18.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-18">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-18", "secondary")}
+    {@render card(title, "Content for chunk 18")}
+</div>
+
+<div>
+    Chunk 19: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 19.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 19.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 19.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-19">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-19", "secondary")}
+    {@render card(title, "Content for chunk 19")}
+</div>
+
+<div>
+    Chunk 20: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 20.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 20.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 20.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-20">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-20", "secondary")}
+    {@render card(title, "Content for chunk 20")}
+</div>
+
+<div>
+    Chunk 21: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 21.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 21.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 21.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-21">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-21", "secondary")}
+    {@render card(title, "Content for chunk 21")}
+</div>
+
+<div>
+    Chunk 22: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 22.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 22.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 22.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-22">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-22", "secondary")}
+    {@render card(title, "Content for chunk 22")}
+</div>
+
+<div>
+    Chunk 23: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 23.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 23.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 23.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-23">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-23", "secondary")}
+    {@render card(title, "Content for chunk 23")}
+</div>
+
+<div>
+    Chunk 24: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 24.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 24.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 24.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-24">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-24", "secondary")}
+    {@render card(title, "Content for chunk 24")}
+</div>
+
+<div>
+    Chunk 25: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 25.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 25.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 25.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-25">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-25", "secondary")}
+    {@render card(title, "Content for chunk 25")}
+</div>
+
+<div>
+    Chunk 26: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 26.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 26.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 26.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-26">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-26", "secondary")}
+    {@render card(title, "Content for chunk 26")}
+</div>
+
+<div>
+    Chunk 27: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 27.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 27.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 27.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-27">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-27", "secondary")}
+    {@render card(title, "Content for chunk 27")}
+</div>
+
+<div>
+    Chunk 28: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 28.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 28.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 28.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-28">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-28", "secondary")}
+    {@render card(title, "Content for chunk 28")}
+</div>
+
+<div>
+    Chunk 29: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 29.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 29.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 29.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-29">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-29", "secondary")}
+    {@render card(title, "Content for chunk 29")}
+</div>
+
+<div>
+    Chunk 30: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 30.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 30.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 30.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-30">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-30", "secondary")}
+    {@render card(title, "Content for chunk 30")}
+</div>
+
+<div>
+    Chunk 31: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 31.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 31.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 31.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-31">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-31", "secondary")}
+    {@render card(title, "Content for chunk 31")}
+</div>
+
+<div>
+    Chunk 32: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 32.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 32.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 32.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-32">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-32", "secondary")}
+    {@render card(title, "Content for chunk 32")}
+</div>
+
+<div>
+    Chunk 33: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 33.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 33.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 33.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-33">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-33", "secondary")}
+    {@render card(title, "Content for chunk 33")}
+</div>
+
+<div>
+    Chunk 34: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 34.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 34.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 34.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-34">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-34", "secondary")}
+    {@render card(title, "Content for chunk 34")}
+</div>
+
+<div>
+    Chunk 35: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 35.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 35.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 35.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-35">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-35", "secondary")}
+    {@render card(title, "Content for chunk 35")}
+</div>
+
+<div>
+    Chunk 36: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 36.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 36.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 36.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-36">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-36", "secondary")}
+    {@render card(title, "Content for chunk 36")}
+</div>
+
+<div>
+    Chunk 37: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 37.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 37.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 37.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-37">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-37", "secondary")}
+    {@render card(title, "Content for chunk 37")}
+</div>
+
+<div>
+    Chunk 38: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 38.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 38.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 38.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-38">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-38", "secondary")}
+    {@render card(title, "Content for chunk 38")}
+</div>
+
+<div>
+    Chunk 39: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 39.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 39.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 39.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-39">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-39", "secondary")}
+    {@render card(title, "Content for chunk 39")}
+</div>
+
+<div>
+    Chunk 40: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 40.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 40.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 40.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-40">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-40", "secondary")}
+    {@render card(title, "Content for chunk 40")}
+</div>
+
+<div>
+    Chunk 41: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 41.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 41.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 41.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-41">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-41", "secondary")}
+    {@render card(title, "Content for chunk 41")}
+</div>
+
+<div>
+    Chunk 42: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 42.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 42.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 42.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-42">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-42", "secondary")}
+    {@render card(title, "Content for chunk 42")}
+</div>
+
+<div>
+    Chunk 43: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 43.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 43.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 43.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-43">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-43", "secondary")}
+    {@render card(title, "Content for chunk 43")}
+</div>
+
+<div>
+    Chunk 44: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 44.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 44.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 44.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-44">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-44", "secondary")}
+    {@render card(title, "Content for chunk 44")}
+</div>
+
+<div>
+    Chunk 45: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 45.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 45.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 45.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-45">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-45", "secondary")}
+    {@render card(title, "Content for chunk 45")}
+</div>
+
+<div>
+    Chunk 46: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 46.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 46.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 46.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-46">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-46", "secondary")}
+    {@render card(title, "Content for chunk 46")}
+</div>
+
+<div>
+    Chunk 47: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 47.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 47.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 47.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-47">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-47", "secondary")}
+    {@render card(title, "Content for chunk 47")}
+</div>
+
+<div>
+    Chunk 48: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 48.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 48.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 48.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-48">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-48", "secondary")}
+    {@render card(title, "Content for chunk 48")}
+</div>
+
+<div>
+    Chunk 49: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 49.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 49.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 49.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-49">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    {@render badge("chunk-49", "secondary")}
+    {@render card(title, "Content for chunk 49")}
+</div>
+

--- a/tasks/compiler_tests/cases2/svelte_head_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_head_basic/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description" content="A great app"/>`);
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		var meta = root_1();
+		$.append($$anchor, meta);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_head_basic/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description" content="A great app"/>`);
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		var meta = root_1();
+		$.append($$anchor, meta);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_head_basic/case.svelte
@@ -1,0 +1,3 @@
+<svelte:head>
+	<meta name="description" content="A great app">
+</svelte:head>

--- a/tasks/compiler_tests/cases2/svelte_head_empty/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_head_empty/case-rust.js
@@ -1,0 +1,4 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_empty/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_head_empty/case-svelte.js
@@ -1,0 +1,4 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_empty/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_head_empty/case.svelte
@@ -1,0 +1,1 @@
+<svelte:head></svelte:head>

--- a/tasks/compiler_tests/cases2/svelte_head_multiple/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_head_multiple/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description" content="A great app"/> <link rel="icon" href="/favicon.ico"/>`, 1);
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		var fragment = root_1();
+		$.next(2);
+		$.append($$anchor, fragment);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_multiple/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_head_multiple/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description" content="A great app"/> <link rel="icon" href="/favicon.ico"/>`, 1);
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		var fragment = root_1();
+		$.next(2);
+		$.append($$anchor, fragment);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_multiple/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_head_multiple/case.svelte
@@ -1,0 +1,4 @@
+<svelte:head>
+	<meta name="description" content="A great app">
+	<link rel="icon" href="/favicon.ico">
+</svelte:head>

--- a/tasks/compiler_tests/cases2/svelte_head_reactive/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_head_reactive/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description"/>`);
+export default function App($$anchor) {
+	let count = 0;
+	$.head("q2w0q4", ($$anchor) => {
+		var meta = root_1();
+		$.set_attribute(meta, "content", count);
+		$.append($$anchor, meta);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_reactive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_head_reactive/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description"/>`);
+export default function App($$anchor) {
+	let count = 0;
+	$.head("q2w0q4", ($$anchor) => {
+		var meta = root_1();
+		$.set_attribute(meta, "content", count);
+		$.append($$anchor, meta);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_head_reactive/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_head_reactive/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = $state(0);
+</script>
+
+<svelte:head>
+	<meta name="description" content={count}>
+</svelte:head>

--- a/tasks/compiler_tests/cases2/svelte_head_with_content/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_head_with_content/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description" content="A great app"/>`);
+var root = $.from_html(`<h1>Hello</h1>`);
+export default function App($$anchor) {
+	var h1 = root();
+	$.head("q2w0q4", ($$anchor) => {
+		var meta = root_1();
+		$.append($$anchor, meta);
+	});
+	$.append($$anchor, h1);
+}

--- a/tasks/compiler_tests/cases2/svelte_head_with_content/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_head_with_content/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<meta name="description" content="A great app"/>`);
+var root = $.from_html(`<h1>Hello</h1>`);
+export default function App($$anchor) {
+	var h1 = root();
+	$.head("q2w0q4", ($$anchor) => {
+		var meta = root_1();
+		$.append($$anchor, meta);
+	});
+	$.append($$anchor, h1);
+}

--- a/tasks/compiler_tests/cases2/svelte_head_with_content/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_head_with_content/case.svelte
@@ -1,0 +1,5 @@
+<svelte:head>
+	<meta name="description" content="A great app">
+</svelte:head>
+
+<h1>Hello</h1>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -659,3 +659,32 @@ fn module_compilation() {
 fn svelte_options_basic() {
     assert_compiler("svelte_options_basic");
 }
+
+// ---------------------------------------------------------------------------
+// svelte:head tests
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn svelte_head_basic() {
+    assert_compiler("svelte_head_basic");
+}
+
+#[rstest]
+fn svelte_head_reactive() {
+    assert_compiler("svelte_head_reactive");
+}
+
+#[rstest]
+fn svelte_head_multiple() {
+    assert_compiler("svelte_head_multiple");
+}
+
+#[rstest]
+fn svelte_head_empty() {
+    assert_compiler("svelte_head_empty");
+}
+
+#[rstest]
+fn svelte_head_with_content() {
+    assert_compiler("svelte_head_with_content");
+}

--- a/tasks/generate_benchmark/src/main.rs
+++ b/tasks/generate_benchmark/src/main.rs
@@ -12,6 +12,7 @@ fn main() {
     let mut out = String::with_capacity(n * 3000);
 
     write_script(&mut out);
+    write_svelte_head(&mut out);
     write_snippets(&mut out);
 
     for i in 0..n {
@@ -65,6 +66,17 @@ fn write_script(out: &mut String) {
         return { destroy() {} };
     }
 </script>
+
+"#,
+    );
+}
+
+fn write_svelte_head(out: &mut String) {
+    out.push_str(
+        r#"<svelte:head>
+    <meta name="description" content="Benchmark component">
+    <link rel="canonical" href="/benchmark">
+</svelte:head>
 
 "#,
     );


### PR DESCRIPTION
Add full support for the <svelte:head> element:

- AST: new SvelteHead struct and Node variant
- Parser: convert <svelte:head> elements to SvelteHead nodes at root level
- Analysis: lower, parse_js, walker, scope all handle SvelteHead fragments
- Codegen: generate $.head(hash, ($$anchor) => { ... }) calls with inner
  template generation, placed after main template init but before $.append()
- Hash: implement Svelte's djb2 hash for filename scope isolation
  (uses "(unknown)" default matching Svelte's behavior when no filename)
- Tests: 5 test cases (basic, reactive, multiple, empty, with_content)
- Benchmark: add svelte:head to generator, create big_v4.svelte

https://claude.ai/code/session_01XfohUTq6KMrqqj1py9mnhc