### PR TITLE
docs: sync ROADMAP.md and CODEBASE_MAP.md with recent feature ports

### DIFF
--- a/.claude/commands/port-svelte.md
+++ b/.claude/commands/port-svelte.md
@@ -102,10 +102,10 @@ Deferred to ROADMAP (M cases): ...
 
 ### 2d: Record deferred items in ROADMAP
 
-For cases NOT selected by the user:
-- Find or create the feature's section in `ROADMAP.md`
-- Add each deferred case as `- [ ] <description> *(discovered during port, deferred)*`
-- Do NOT remove or modify existing ROADMAP entries
+For cases NOT selected by the user, add them to the **Deferred** section at the bottom of `ROADMAP.md`:
+- Find or create a sub-heading `### <feature name> (Tier N)` under the **Deferred** section
+- Add each deferred case as `- [ ] <description>`
+- Do NOT scatter deferred items inside completed feature sections — they all go in **Deferred**
 
 ### 2e: Check what already exists
 
@@ -179,8 +179,8 @@ If the test still fails after 3 attempts, stop and report what you've tried.
 ## Step 8: Update tracking
 
 Update `ROADMAP.md`:
-- Mark `[x]` for completed checkboxes (deferred items from Step 2d stay as `[ ]`)
-- If new subtasks were discovered during implementation — add them as `- [ ]`
+- Move the completed feature to the **Done ✅** section
+- If new deferred items were discovered during implementation — add them to the **Deferred** section at the bottom
 
 
 ## Step 9: Benchmark

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ To port a new feature, use `/port-svelte <feature description>`.
 
 Read `ROADMAP.md` for the full feature catalog and current priorities.
 
+When `/port-svelte` discovers deferred items (edge cases, validations, blocked work), add them to the **Deferred** section at the bottom of `ROADMAP.md`, grouped under the parent feature name with its tier reference (e.g., `### feature-name (Tier N)`).
+
 ### Legacy features (Svelte 4 → removed in Svelte 6)
 
 Legacy Svelte 4 syntax (deprecated in Svelte 5, scheduled for removal in Svelte 6) is ported with isolation in mind so it can be cleanly deleted later.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -73,6 +73,8 @@ enum Node {
     HtmlTag(HtmlTag),             // id, span, expression_span
     ConstTag(ConstTag),           // id, span, declaration_span
     KeyBlock(KeyBlock),           // id, span, expression_span, fragment
+    SvelteHead(SvelteHead),       // id, span, fragment
+    Error(ErrorNode),             // id, span
 }
 
 enum Attribute {
@@ -84,12 +86,17 @@ enum Attribute {
     ClassDirective(ClassDirective),               // name, expression_span?, shorthand
     StyleDirective(StyleDirective),               // name, value: StyleDirectiveValue, important
     BindDirective(BindDirective),                 // name, expression_span?, shorthand
+    UseDirective(UseDirective),                   // name, expression_span?
     OnDirectiveLegacy(OnDirectiveLegacy),         // name, expression_span?, modifiers (Svelte 4)
+    TransitionDirective(TransitionDirective),     // name, expression_span?, modifiers, direction: TransitionDirection
+    AnimateDirective(AnimateDirective),           // name, expression_span?
+    AttachTag(AttachTag),                         // expression_span (Svelte 5.29+)
 }
 
 enum ConcatPart { Static(String), Dynamic(Span) }
 enum StyleDirectiveValue { Shorthand, Expression(Span), String(String), Concatenation(Vec<ConcatPart>) }
 enum ElementKind { Unknown, Input }
+enum TransitionDirection { Both, In, Out }
 enum ScriptContext { Default, Module }
 enum ScriptLanguage { JavaScript, TypeScript }
 
@@ -205,6 +212,7 @@ enum FragmentKey {
     IfConsequent(NodeId), IfAlternate(NodeId),
     EachBody(NodeId), EachFallback(NodeId),
     SnippetBody(NodeId), KeyBlockBody(NodeId),
+    SvelteHeadBody(NodeId),
 }
 
 enum FragmentItem {
@@ -338,6 +346,7 @@ fn generate(component: &Component, analysis: &AnalysisData) -> String
 `template/expression.rs` — генерация JS-выражений из span'ов
 `template/html.rs` — построение HTML template strings
 `template/traverse.rs` — обход DOM-дерева (`.first_child`, `.sibling`)
+`template/svelte_head.rs` — `<svelte:head>` codegen (`$.head()`)
 
 ---
 
@@ -373,7 +382,9 @@ fn transform_component<'a>(
 ```rust
 struct CompileResult { pub js: String }
 fn compile(source: &str) -> Result<CompileResult, Diagnostic>
-// = parse → analyze → (fatal diag check) → generate
+// = parse → analyze → (fatal diag check) → transform → generate
+fn compile_module(source: &str) -> Result<CompileResult, Diagnostic>
+// = OXC parse → analyze_module → rune transforms → JS output (no template/CSS)
 ```
 
 ---

--- a/PARITY.md
+++ b/PARITY.md
@@ -1,0 +1,260 @@
+# Svelte Compiler Feature Parity Report
+
+Last updated: 2026-03-17
+
+This document tracks feature parity between our Rust compiler and the Svelte reference compiler.
+For implementation priorities, see [ROADMAP.md](ROADMAP.md).
+
+## Summary
+
+- **123** compiler integration test cases
+- **13** of ~25 AST node types implemented
+- **12** of 13 attribute/directive types implemented
+- **11** analysis passes operational
+- **15** codegen modules
+
+## Legend
+
+| Status | Meaning |
+|--------|---------|
+| Done | Fully implemented and tested |
+| Partial | Core path works, edge cases or sub-features missing |
+| Missing | Not implemented |
+| N/A | Not applicable or intentionally deferred |
+
+---
+
+## AST Node Types
+
+| Node Type | Reference | Ours | Status | Notes |
+|-----------|-----------|------|--------|-------|
+| Text | `Text` | `Node::Text` | Done | |
+| RegularElement | `RegularElement` | `Node::Element` | Done | |
+| Component | `Component` | `Node::ComponentNode` | Done | |
+| Comment | `Comment` | `Node::Comment` | Partial | Parsed, no `preserveComments` codegen |
+| ExpressionTag | `ExpressionTag` | `Node::ExpressionTag` | Done | |
+| IfBlock | `IfBlock` | `Node::IfBlock` | Done | |
+| EachBlock | `EachBlock` | `Node::EachBlock` | Done | |
+| SnippetBlock | `SnippetBlock` | `Node::SnippetBlock` | Done | |
+| RenderTag | `RenderTag` | `Node::RenderTag` | Partial | Missing optional chaining `fn?.()` |
+| HtmlTag | `HtmlTag` | `Node::HtmlTag` | Done | |
+| ConstTag | `ConstTag` | `Node::ConstTag` | Done | |
+| KeyBlock | `KeyBlock` | `Node::KeyBlock` | Done | |
+| SvelteHead | `SvelteHead` | `Node::SvelteHead` | Done | |
+| AwaitBlock | `AwaitBlock` | — | Missing | `{#await}` not in AST or codegen |
+| DebugTag | `DebugTag` | — | Missing | `{@debug}` not in AST or codegen |
+| TitleElement | `TitleElement` | — | Missing | `<title>` special handling |
+| SlotElement | `SlotElement` | — | Missing | Legacy `<slot>` element |
+| SvelteWindow | `SvelteWindow` | — | Missing | `<svelte:window>` bindings/events |
+| SvelteDocument | `SvelteDocument` | — | Missing | `<svelte:document>` bindings/events |
+| SvelteBody | `SvelteBody` | — | Missing | `<svelte:body>` events |
+| SvelteBoundary | `SvelteBoundary` | — | Missing | `<svelte:boundary>` error boundaries |
+| SvelteComponent | `SvelteComponent` | — | Missing | Legacy `<svelte:component this={X}>` |
+| SvelteElement | `SvelteElement` | — | Missing | `<svelte:element this={tag}>` |
+| SvelteSelf | `SvelteSelf` | — | Missing | Legacy `<svelte:self>` |
+| SvelteFragment | `SvelteFragment` | — | Missing | Legacy `<svelte:fragment>` |
+| Error | — | `Node::Error` | N/A | Error recovery (ours only) |
+
+---
+
+## Attributes & Directives
+
+| Type | Reference | Ours | Status | Notes |
+|------|-----------|------|--------|-------|
+| StringAttribute | `Attribute` | `StringAttribute` | Done | |
+| ExpressionAttribute | `Attribute` | `ExpressionAttribute` | Done | |
+| BooleanAttribute | `Attribute` | `BooleanAttribute` | Done | |
+| ConcatenationAttribute | `Attribute` | `ConcatenationAttribute` | Done | |
+| SpreadAttribute | `SpreadAttribute` | `ShorthandOrSpread` | Done | |
+| ClassDirective | `ClassDirective` | `ClassDirective` | Done | |
+| StyleDirective | `StyleDirective` | `StyleDirective` | Done | |
+| BindDirective | `BindDirective` | `BindDirective` | Done | 15+ bind types |
+| UseDirective | `UseDirective` | `UseDirective` | Done | |
+| TransitionDirective | `TransitionDirective` | `TransitionDirective` | Done | in/out/both, local/global |
+| AnimateDirective | `AnimateDirective` | `AnimateDirective` | Done | |
+| AttachTag | `AttachTag` | `AttachTag` | Done | Svelte 5.29+ |
+| OnDirective (legacy) | `OnDirective` | `OnDirectiveLegacy` | Done | Svelte 4, with modifiers |
+| LetDirective | `LetDirective` | — | Missing | `let:` for slot context |
+
+---
+
+## Event Handling
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Delegatable event attributes (`onclick`) | Done | `$.delegated()` codegen |
+| Event delegation setup (`$.delegate([...])`) | Done | Component-level |
+| Non-delegatable event attributes (`onscroll`) | **Bug** | Uses `$.set_attribute()` instead of `$.event()` |
+| Event capture suffix (`onclickcapture`) | Missing | |
+| Passive event auto-detection | Missing | `touchstart`, `wheel`, etc. |
+| Handler wrapping (non-inline) | Missing | `(...$$args) => handler.apply(this, $$args)` |
+| Handler memoization (`has_call`) | Missing | Depends on Memoizer infrastructure |
+| Legacy `on:` directive | Done | With all modifiers |
+
+---
+
+## Runes & Reactivity
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| `$state()` | Done | Mutation tracking, $.get/$.set |
+| `$state.raw()` | Done | |
+| `$derived` | Done | |
+| `$derived.by` | Done | |
+| `$props()` | Done | Destructuring, defaults, bindability |
+| `$effect` | Done | |
+| `$effect.pre` | Done | |
+| `$effect.tracking` | Done | |
+| `$effect.root` | Done | |
+| `$snapshot` | Done | |
+| Store subscriptions (`$store`) | Done | |
+| Legacy `$:` reactive declarations | Missing | Svelte 4 |
+
+---
+
+## Analysis Passes
+
+| Pass | Status | Notes |
+|------|--------|-------|
+| JS expression parsing | Done | OXC-based |
+| Scope building | Done | Unified scope tree |
+| Reference resolution | Done | Template → symbol linking |
+| Store subscription detection | Done | |
+| Known values (const eval) | Done | |
+| Props analysis | Done | |
+| Fragment lowering (whitespace) | Done | |
+| Reactivity marking | Done | Dynamic node detection |
+| Elseif detection | Done | |
+| Element flags | Done | Spread, class, style, etc. |
+| Hoistable snippets | Done | |
+| Content type classification | Done | |
+| Needs-var computation | Done | |
+| Expression memoization (`has_call`) | Missing | No `Memoizer` infrastructure |
+| A11y validation | Missing | 0 of 39 rules |
+| Full semantic validation | Missing | Placeholder only |
+
+---
+
+## Codegen — Client
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Root fragment generation | Done | |
+| Element creation & hydration | Done | |
+| Component instantiation | Done | Props, children |
+| If/else/elseif blocks | Done | |
+| Each blocks (item, index, key) | Done | |
+| Snippet blocks (instance + hoistable) | Done | |
+| Render tags | Partial | Missing optional chaining |
+| HTML tags (`{@html}`) | Done | |
+| Const tags | Done | Single + destructured |
+| Key blocks | Done | |
+| Svelte:head | Done | |
+| Expression/text interpolation | Done | |
+| Template HTML generation | Done | |
+| Bind directives (15+ types) | Done | |
+| Class directives | Done | |
+| Style directives | Done | |
+| Spread attributes | Done | |
+| Use (action) directives | Done | |
+| Transition directives | Done | |
+| Animate directives | Done | |
+| Attach tags | Done | |
+| Legacy on: directives | Done | |
+| Script rune transforms | Done | $.get/$.set/$.update |
+| Module compilation (.svelte.js) | Done | |
+
+---
+
+## Codegen — Missing Visitors
+
+These reference compiler visitors have no counterpart in our codegen:
+
+| Visitor | Feature | Priority |
+|---------|---------|----------|
+| `AwaitBlock` | `{#await}` rendering | High |
+| `DebugTag` | `{@debug}` dev output | Low |
+| `TitleElement` | `<title>` text updates | Medium |
+| `SlotElement` | Legacy `<slot>` | Low (legacy) |
+| `SvelteWindow` | Window bindings/events | Medium |
+| `SvelteDocument` | Document bindings/events | Medium |
+| `SvelteBody` | Body events | Medium |
+| `SvelteBoundary` | Error boundaries | Medium |
+| `SvelteComponent` | Dynamic `this={X}` | Low (legacy) |
+| `SvelteElement` | Dynamic `this={tag}` | Medium |
+| `SvelteSelf` | Recursive components | Low (legacy) |
+| `SvelteFragment` | Named fragments | Low (legacy) |
+| `LetDirective` | Slot context vars | Low (legacy) |
+| `Comment` | `preserveComments` | Low |
+
+---
+
+## Compiler Options
+
+| Option | Reference | Ours | Status |
+|--------|-----------|------|--------|
+| `generate: 'client'` | Yes | Implicit | Done (client only) |
+| `generate: 'server'` | Yes | — | Missing |
+| `dev` mode | Yes | — | Missing |
+| `css: 'injected' \| 'external'` | Yes | — | Missing |
+| `cssHash` | Yes | — | Missing |
+| `runes` | Yes | Always true | Partial |
+| `namespace` | Yes | — | Missing |
+| `preserveComments` | Yes | — | Missing |
+| `preserveWhitespace` | Yes | Partial | Partial (lowering handles some) |
+| `customElement` | Yes | Parsed | Missing (no codegen) |
+| `hmr` | Yes | — | Missing |
+| `filename` | Yes | — | Missing |
+| `sourcemap` | Yes | — | Missing |
+| `fragments: 'html' \| 'tree'` | Yes | html only | Partial |
+| `discloseVersion` | Yes | — | Missing |
+| `warningFilter` | Yes | — | Missing |
+
+---
+
+## CSS Processing
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| CSS parsing | Partial | Stored as raw span, not AST |
+| Scoped CSS (hash class) | Missing | |
+| `:global()` selector | Missing | |
+| CSS pruning (unused selectors) | Missing | |
+| Keyframe name scoping | Missing | |
+| CSS source maps | Missing | |
+
+---
+
+## Infrastructure
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| WASM compilation target | Done | `wasm_compiler` crate |
+| Diagnostics (errors) | Done | Parse errors |
+| Diagnostics (warnings) | Missing | 0 of 82 warning codes |
+| Source maps (JS) | Missing | |
+| Source maps (CSS) | Missing | |
+| SSR codegen | Missing | |
+| HMR support | Missing | |
+| Custom element codegen | Missing | |
+| Preprocessor support | Missing | |
+
+---
+
+## Test Coverage by Feature Area
+
+| Area | Cases | Notes |
+|------|-------|-------|
+| Core syntax | 7 | empty, text, element, interpolation, if, if-else |
+| Components | 7 | basic, children, props, mixed |
+| Bind directives | 11+ | All major bind types |
+| Class & style | 9 | Directives, variables, objects |
+| State & runes | 13 | $state, $derived, $effect variants |
+| Props | 6 | Basic, bindable, lazy, rest, mutated |
+| Each blocks | 7 | With conditions, nested |
+| Snippets | 1 | Basic only |
+| Transitions & animations | 14 | All direction/modifier combos |
+| Directives (use/on) | 9 | Actions, legacy events |
+| Special tags | 11 | const, html, attach, render, key |
+| Head & metadata | 7 | svelte:head, store, options |
+| **Total** | **~123** | |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap: Svelte 5 Client Compiler in Rust
 
 Scope: client-side compilation only (no SSR, no legacy mode).
+For a full feature parity audit, see [PARITY.md](PARITY.md).
 
 **Phase notation**: **P** = Parser/AST, **A** = Analyze, **S** = Script codegen, **T** = Template codegen, **V** = Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,11 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] `style:prop` directive (shorthand, expression, string, concat, `|important`)
 - [x] `class` object/array syntax (Svelte 5)
 
+### Event handling
+- [x] Svelte 5 event attributes — `onclick={handler}` → `$.event()` / `$.delegated()`
+- [x] Event delegation — `$.delegate([...events])` at component level
+- [x] `on:event` — legacy event directive (Svelte 4)
+
 ### Bind directives
 - [x] `bind:value` (input, textarea, select), `bind:checked`, `bind:group`, `bind:files`
 - [x] `bind:indeterminate`, `bind:open` (generic `$.bind_property`)
@@ -67,7 +72,6 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] `transition:` / `in:` / `out:` — transitions (local/global, params)
 - [x] `animate:name={params}` — FLIP animations
 - [x] `{@attach fn}` — element attachment (Svelte 5.29+)
-- [x] `on:event` — legacy event directive (Svelte 4)
 
 ### Special elements
 - [x] `<svelte:options>` — compiler options tag (parser + validation)
@@ -102,9 +106,7 @@ Key file: `crates/svelte_codegen_client/src/script.rs`
 | 1 | `$inspect(vals)` | `$.inspect(...)` | S | Dev-mode only — strip in prod. Needs `dev` compiler option |
 | 2 | `$inspect.trace()` | dev-only trace | S | Same `dev` flag dependency |
 | 3 | `$host()` | `$$props.$$host` | S | Expression replacement, for custom elements |
-| 4 | `$state.eager(val)` | `$.state($.eager(val))` | S | Experimental async — forces immediate UI updates during `await`. Requires `experimental.async` flag |
-| 5 | `$effect.pending()` | `$.effect_pending()` | S | Returns number of pending promises in current boundary. Used with `<svelte:boundary pending>` |
-| 6 | `$props.id()` | `$$props.$$id` or inline | S | Generates unique, hydration-safe ID per component instance (v5.20+) |
+| 4 | `$props.id()` | `$$props.$$id` or inline | S | Generates unique, hydration-safe ID per component instance (v5.20+) |
 
 ---
 
@@ -118,6 +120,14 @@ Key file: `crates/svelte_codegen_client/src/script.rs`
 ---
 
 ## Tier 2 — Remaining Template Blocks
+
+### `{#await promise}` — Async blocks
+- **Phases**: P, A, T
+- **AST**: `Node::AwaitBlock { id, span, expression_span, pending, then_binding, then, catch_binding, catch }`
+- **Parser**: `{#await expr}...{:then val}...{:catch err}...{/await}`, short form `{#await expr then val}...{/await}`
+- **Codegen**: `$.await(anchor, () => promise, pending_fn, then_fn, catch_fn)`
+- **Notes**: Needs child scopes for `then`/`catch` bindings. Common in real apps (data fetching).
+- **Ref**: `reference/compiler/phases/3-transform/client/visitors/AwaitBlock.js` (~124 lines)
 
 ### `{@debug vars}` — Dev-mode debugger
 - **Phases**: P, T
@@ -207,16 +217,9 @@ Theme: scoped CSS compilation — largest standalone workstream, new `svelte_css
 
 ---
 
-## Tier 7 — Async, Validation & Optimization
+## Tier 7 — Validation & Diagnostics
 
-Theme: less-used features, developer experience, performance improvements.
-
-### Template features
-
-| Feature | Phases | Description |
-|---------|--------|-------------|
-| `{#await promise}` | P, A, T | `$.await(anchor, () => promise, pending_fn, then_fn, catch_fn)`. AST: `Node::AwaitBlock`. Needs child scopes for `then`/`catch` bindings. Ref: `AwaitBlock.js` (~124 lines) |
-| Await expressions (experimental) | P, A, T | `{await expr}` in templates. Svelte 5.36+, requires `experimental.async: true`. Ref: `AwaitExpression.js` |
+Theme: developer experience — errors, warnings, and diagnostic infrastructure.
 
 ### Validation (**V**)
 
@@ -226,19 +229,88 @@ Theme: less-used features, developer experience, performance improvements.
 | Assignment validation | Error on assignments to `const`, imports, `$derived` runes | `2-analyze/visitors/AssignmentExpression.js` |
 | Rune argument validation | Validate rune call signatures (e.g., `$state()` takes 0-1 args) | `2-analyze/visitors/CallExpression.js` |
 | Directive placement validation | `transition:` not on components, `animate:` only in keyed each | `2-analyze/visitors/Component.js` |
-| A11y warnings | Missing `alt`, ARIA errors, form label association, etc. | `2-analyze/a11y.js` |
-| `<!-- svelte-ignore -->` comments | Suppress specific compiler warnings for the next sibling node | `1-parse/` + `2-analyze/` |
 
-### Optimization
+### A11y warnings (~40 checks)
+- Missing `alt` on `<img>`, `<area>`, `<input type="image">`
+- ARIA attribute validation (`role`, `aria-*` correctness)
+- Form label association (`<label>` + `for`/`id`)
+- Keyboard event pairing (`onclick` → needs `onkeydown`)
+- Heading hierarchy (`<h1>`–`<h6>` order)
+- Interactive role focus management
+- Media caption requirements
+- Redundant/conflicting attributes
+- **Ref**: `reference/compiler/phases/2-analyze/visitors/shared/a11y/` (~954 lines)
 
-| Feature | Phases | Description |
-|---------|--------|-------------|
-| Event delegation refinement | A, T | Refine `is_delegatable_event` analysis, track `$.delegate()` calls at component level |
-| CSS hash injection | T | Add scoped class to elements (requires Tier 6) |
+### `<!-- svelte-ignore -->` comments
+- **Phases**: P, A
+- Parse `<!-- svelte-ignore warning_name -->` from HTML comments
+- Suppress specific warnings for the next sibling node
+- `extract_svelte_ignore()` + `is_ignored(node, 'rule')` check
+- **Ref**: `reference/compiler/phases/2-analyze/index.js`
+
+### Ownership validation (dev mode)
+- `$.create_ownership_validator($$props)` — detect invalid mutations of bound props
+- `svelte-ignore ownership_invalid_binding` suppression
+- **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/component.js`
 
 ---
 
-## Tier 8 — Legacy Svelte 4 (Lowest Priority)
+## Tier 8 — Compiler Infrastructure
+
+Theme: compiler options, source maps, dev mode support.
+
+### `CompileOptions` structure
+
+The reference compiler accepts these options (we currently accept only `source`):
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `dev` | `boolean` | Enable runtime checks, `$inspect`, `{@debug}`, ownership validation, `$.apply()` wrapping |
+| `css` | `'injected' \| 'external'` | CSS handling mode |
+| `generate` | `'client' \| 'server' \| false` | Output target |
+| `filename` | `string` | Source filename for diagnostics and CSS hash |
+| `rootDir` | `string` | Root directory for relative paths |
+| `name` | `string` | Component class name |
+| `namespace` | `'html' \| 'svg' \| 'mathml'` | Element namespace |
+| `runes` | `boolean \| undefined` | Force runes mode on/off |
+| `preserveComments` | `boolean` | Keep HTML comments in output |
+| `preserveWhitespace` | `boolean` | Keep whitespace as typed |
+| `discloseVersion` | `boolean` | Expose Svelte version in `window.__svelte.v` |
+| `hmr` | `boolean` | Hot module replacement support |
+| `sourcemap` | `object` | Initial source map for preprocessing |
+| `warningFilter` | `function` | Custom warning filter |
+
+### Source maps
+- JS source map generation (via magic-string in reference, needs equivalent in Rust)
+- CSS source map generation
+- Merged preprocessor source maps
+
+### Dev mode (`dev: true`)
+Gates these features:
+- `$inspect()` / `$inspect.trace()` rune transforms
+- `{@debug}` tag codegen
+- `$.apply()` wrapping for better stack traces
+- Ownership validation (`$.create_ownership_validator`)
+- Snippet wrapping (`$.wrap_snippet`)
+- Component naming for devtools
+
+---
+
+## Tier 9 — Custom Elements
+
+Theme: Web Component compilation — alternative output format.
+
+- **`customElement` option** — compile component as custom element with shadow DOM
+- **`$.create_custom_element()`** — wrapper for component function
+- **Shadow DOM config** — `{ mode: 'open' }`, `'none'`, or custom
+- **Props metadata** — `attribute`, `reflect`, `type` for each prop
+- **`extend` option** — class inheritance for custom element
+- **`customElements.define(tag, element)`** call generation
+- **Ref**: `reference/compiler/phases/3-transform/client/transform-client.js` lines 598–677
+
+---
+
+## Tier 10 — Legacy Svelte 4 (Lowest Priority)
 
 Theme: deprecated syntax superseded by Svelte 5 features. Only needed for migrating codebases.
 
@@ -299,6 +371,9 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] `$state` / `$state.raw` destructuring support in script codegen
 - [ ] `$state` / `$state.raw` class field support
 - [ ] `$state.frozen` → `$state.raw` rename validation
+- [ ] `$state.eager(val)` — experimental async, requires `experimental.async` flag
+- [ ] `$effect.pending()` — requires `<svelte:boundary>` (Tier 5)
+- [ ] `$inspect().with(callback)` — custom inspection callback
 
 ### Module compilation (Tier 1b)
 - [ ] `ModuleCompileOptions` type — subset of `CompileOptions`
@@ -341,7 +416,15 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: no attributes allowed (diagnostic)
 - [ ] `filename` parameter for `compile()` to produce correct hash (currently uses `"(unknown)"` default)
 
-### `on:directive` legacy (Tier 8)
+### CSS (Tier 6)
+- [ ] Component CSS custom properties on `<Component>` — `$.css_props()` wrapper element injection
+
+### Compiler infrastructure (Tier 8)
+- [ ] HMR support — `$.hmr()` wrapper, `import.meta.hot.accept()`
+- [ ] `fragments: 'tree'` option — alternative DOM fragment strategy
+- [ ] `{await expr}` experimental template syntax (Svelte 5.36+, requires `experimental.async`)
+
+### `on:directive` legacy (Tier 10)
 - [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis
 - [ ] SvelteDocument/SvelteWindow/SvelteBody routing: events on special elements should go to `init` not `after_update`. Blocked on Tier 5
 - [ ] Dev-mode `$.apply()` wrapping for imported identifier handlers. Blocked on `dev` compiler option

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,58 +14,44 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] `IfBlock`, `EachBlock`, `SnippetBlock`, `RenderTag`
 - [x] Attributes: string, expression, boolean, concatenation, shorthand/spread, `class:`, `bind:`
 - [x] Script/Style blocks, TypeScript support
+- [x] Void (self-closing) HTML elements — `VOID_ELEMENTS`, auto `self_closing`, closing tag validation
 
-### Analyze (9 passes, composite visitor)
+### Analyze (11 passes, composite visitor)
 - [x] `parse_js` — JS expression parsing, rune detection
-- [x] `scope` — OXC scoping (script + template)
-- [x] `mutations` — rune mutation tracking
+- [x] `build_scoping` — unified scope tree (script + template)
+- [x] `resolve_references` — template refs → SymbolId, mutation tracking
+- [x] `store_subscriptions` — `$store` subscription detection
 - [x] `known_values` — static const evaluation
 - [x] `props` — `$props()` destructuring ($bindable, defaults, rest)
 - [x] `lower` — whitespace trim, adjacent text+expr merge
-- [x] `reactivity` + `elseif` — dynamic node/attribute marking
-- [x] `content_types` — fragment classification (single-element, text-only, etc.)
+- [x] `reactivity` + `elseif` + `element_flags` + `hoistable_snippets` — composite walk (4 visitors)
+- [x] `classify_and_mark_dynamic` — fragment classification (single-element, text-only, etc.)
 - [x] `needs_var` — elements needing JS variables
+- [x] `validate` — semantic checks
 
 ### Script codegen
 - [x] `$state` rune (read, assign, update, `$.proxy()`)
-- [x] `$derived` / `$derived.by` — `$.derived(() => expr)` / `$.derived(fn)`
-- [x] `$props` rune (destructure, defaults, `$bindable`, rest, mutated)
-- [x] Import hoisting
-- [x] Strip TypeScript
-- [x] Exports (`$$.exports`)
-- [x] `$effect(fn)` → `$.user_effect(fn)`, `$effect.pre(fn)` → `$.user_pre_effect(fn)`
-
-### Template codegen
-- [x] Element (with all attribute types)
-- [x] Component (props + children-as-snippet)
-- [x] IfBlock, EachBlock
-- [x] SnippetBlock, RenderTag
-- [x] Text node, ExpressionTag
-- [x] `{@html expr}`, `{#key expr}`, `{@const}`
-- [x] `style:prop` directive, `class` object/array syntax
-
-### Directives (Tier 4)
-- [x] `use:action={params}` — action directive
-- [x] `transition:` / `in:` / `out:` — transitions (local/global, params)
-- [x] `animate:name={params}` — FLIP animations
-- [x] `{@attach fn}` — element attachment (Svelte 5.29+)
-- [x] `on:event` — legacy event directive (Svelte 4)
-
-### Special elements (Tier 5)
-- [x] `<svelte:options>` — compiler options tag (parser + validation)
-- [x] `<svelte:head>` — document head insertion
-
-### Runes (Tier 1)
 - [x] `$state.raw(val)` → `$.state(val)` (no proxy)
 - [x] `$state.snapshot(val)` → `$.snapshot(val)`
+- [x] `$derived` / `$derived.by` — `$.derived(() => expr)` / `$.derived(fn)`
+- [x] `$props` rune (destructure, defaults, `$bindable`, rest, mutated)
+- [x] `$effect(fn)` → `$.user_effect(fn)`, `$effect.pre(fn)` → `$.user_pre_effect(fn)`
 - [x] `$effect.tracking()` → `$.effect_tracking()`
 - [x] `$effect.root(fn)` → `$.effect_root(fn)`
 - [x] `$store` auto-subscription → `$.store_get` / `$.store_set`
+- [x] Import hoisting, strip TypeScript, exports (`$$.exports`)
 
-### Module compilation (Tier 1b)
-- [x] `compile_module()` entry point + `analyze_module()` + WASM export
+### Template codegen
+- [x] Element (with all attribute types), Component (props + children-as-snippet)
+- [x] IfBlock, EachBlock, SnippetBlock, RenderTag
+- [x] Text node, ExpressionTag
+- [x] `{@html expr}` — raw HTML insertion
+- [x] `{#key expr}` — keyed re-render block
+- [x] `{@const x = expr}` — block-scoped constant (incl. destructuring)
+- [x] `style:prop` directive (shorthand, expression, string, concat, `|important`)
+- [x] `class` object/array syntax (Svelte 5)
 
-### Bind directives (Tier 3)
+### Bind directives
 - [x] `bind:value` (input, textarea, select), `bind:checked`, `bind:group`, `bind:files`
 - [x] `bind:indeterminate`, `bind:open` (generic `$.bind_property`)
 - [x] `bind:innerHTML`, `bind:innerText`, `bind:textContent` (contenteditable)
@@ -74,11 +60,21 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] `bind:currentTime`, `bind:paused`, `bind:volume`, `bind:muted`, `bind:playbackRate` (media R/W)
 - [x] `bind:buffered`, `bind:seekable`, `bind:seeking`, `bind:ended`, `bind:readyState`, `bind:played` (media RO)
 - [x] `bind:duration`, `bind:videoWidth`, `bind:videoHeight`, `bind:naturalWidth`, `bind:naturalHeight` (event-based RO)
-- [x] `bind:this` (element reference)
-- [x] `bind:focused`
-- [ ] `bind:property={get, set}` — function bindings (Svelte 5) *(deferred)*
-- [ ] Window bindings: `scrollX`, `scrollY`, `innerWidth`, `innerHeight`, `outerWidth`, `outerHeight`, `online`, `devicePixelRatio` *(requires `<svelte:window>` parser)*
-- [ ] Document bindings: `activeElement`, `fullscreenElement`, `pointerLockElement`, `visibilityState` *(requires `<svelte:document>` parser)*
+- [x] `bind:this` (element reference), `bind:focused`
+
+### Directives
+- [x] `use:action={params}` — action directive
+- [x] `transition:` / `in:` / `out:` — transitions (local/global, params)
+- [x] `animate:name={params}` — FLIP animations
+- [x] `{@attach fn}` — element attachment (Svelte 5.29+)
+- [x] `on:event` — legacy event directive (Svelte 4)
+
+### Special elements
+- [x] `<svelte:options>` — compiler options tag (parser + validation)
+- [x] `<svelte:head>` — document head insertion
+
+### Module compilation
+- [x] `compile_module()` entry point + `analyze_module()` + WASM export
 
 ### Optimizations
 - [x] Whitespace trimming
@@ -94,132 +90,34 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 
 ---
 
-## Tier 0 — Parser Fundamentals ✅
+## Tier 1 — Remaining Runes
 
-Theme: critical parser capabilities needed for correct HTML handling. Without these, common valid HTML fails to parse.
-
-### ~~Void (self-closing) HTML elements~~ ✅
-- **Phases**: P, V
-- **Work items**:
-  1. [x] Add `VOID_ELEMENTS` constant and `is_void(name)` helper
-  2. [x] In scanner/parser: auto-set `self_closing: true` when tag name is void (even without `/>`)
-  3. [x] Validation: emit error on `</input>` and similar (closing tag for void element) — `void_element_invalid_content`
-  4. [ ] Validation: emit error if void element has children (deferred — requires parser-level check for content between void open tags)
-
----
-
-## Tier 1 — Complete Rune Coverage
-
-Theme: finish all rune transformations. Purely script codegen (**S**), patterns already exist in `script.rs`.
+Theme: finish rune transformations. Purely script codegen (**S**), patterns already exist in `script.rs`.
 
 Ref: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`, `ExpressionStatement.js`, `VariableDeclaration.js`
 Key file: `crates/svelte_codegen_client/src/script.rs`
 
 | # | Feature | Transform | Phases | Notes |
 |---|---------|-----------|--------|-------|
-| 1 | ~~`$effect(fn)`~~ | `$.user_effect(fn)` | S | ✅ Done |
-| 2 | ~~`$effect.pre(fn)`~~ | `$.user_pre_effect(fn)` | S | ✅ Done |
-| 3 | ~~`$state.raw(val)`~~ | `$.state(val)` (no `$.proxy()`) | S | ✅ Done. Deferred: destructuring (shared gap with `$state`), class fields, `$state.frozen` rename validation |
-| 4 | ~~`$state.snapshot(val)`~~ | `$.snapshot(val)` | S | ✅ Done |
-| 5 | ~~`$effect.tracking()`~~ | `$.effect_tracking()` | S | ✅ Done. Trivial call rewrite, no args |
-| 6 | ~~`$effect.root(fn)`~~ | `$.effect_root(fn)` | S | ✅ Done. Simple callee rewrite |
-| 7 | `$inspect(vals)` | `$.inspect(...)` | S | Dev-mode only — strip in prod. Needs `dev` compiler option |
-| 8 | `$inspect.trace()` | dev-only trace | S | Same `dev` flag dependency |
-| 9 | `$host()` | `$$props.$$host` | S | Expression replacement, for custom elements |
-| 10 | `$state.eager(val)` | `$.state($.eager(val))` | S | Experimental async — forces immediate UI updates during `await`. Requires `experimental.async` flag |
-| 11 | `$effect.pending()` | `$.effect_pending()` | S | Returns number of pending promises in current boundary. Used with `<svelte:boundary pending>` |
-| 12 | `$props.id()` | `$$props.$$id` or inline | S | Generates unique, hydration-safe ID per component instance (v5.20+) |
-| 13 | ~~`$store` auto-subscription~~ | ~~`$.store_get`/`$.store_set` with scope analysis~~ | ~~S, A~~ | ✅ Done — read, assign, compound assign, update (++/--) in both template and script |
+| 1 | `$inspect(vals)` | `$.inspect(...)` | S | Dev-mode only — strip in prod. Needs `dev` compiler option |
+| 2 | `$inspect.trace()` | dev-only trace | S | Same `dev` flag dependency |
+| 3 | `$host()` | `$$props.$$host` | S | Expression replacement, for custom elements |
+| 4 | `$state.eager(val)` | `$.state($.eager(val))` | S | Experimental async — forces immediate UI updates during `await`. Requires `experimental.async` flag |
+| 5 | `$effect.pending()` | `$.effect_pending()` | S | Returns number of pending promises in current boundary. Used with `<svelte:boundary pending>` |
+| 6 | `$props.id()` | `$$props.$$id` or inline | S | Generates unique, hydration-safe ID per component instance (v5.20+) |
 
 ---
 
-## Tier 1b — Module Compilation (`.svelte.js` / `.svelte.ts`)
-
-Theme: separate entry point for compiling rune-enabled JS/TS modules (no template, no CSS).
-
-In Svelte, the bundler plugin detects `.svelte.js`/`.svelte.ts` extensions and calls `compileModule()` instead of `compile()`. The compiler itself does not inspect filenames — it exposes two distinct functions.
-
-Ref: `reference/compiler/index.js` (`compileModule`), `reference/compiler/phases/2-analyze/index.js` (`analyze_module`), `reference/compiler/phases/3-transform/client/transform-client.js` (`client_module`)
-
-### Pipeline
-
-```
-source (JS/TS) → analyze_module() → client_module() → JS output
-```
-
-### Comparison with `compile()`
-
-| Aspect | `compile()` | `compileModule()` |
-|--------|-------------|-------------------|
-| Input | `.svelte` (HTML + Script + Style) | JS/TS only |
-| Runes mode | Inferred or forced | Always `runes: true` |
-| CSS output | Yes | `null` |
-| Template codegen | Yes | No |
-| Output shape | Component class (default export) | Plain JS module |
-
-### Work items
+## Tier 1b — Module Compilation (remaining)
 
 | # | Item | Description |
 |---|------|-------------|
-| 1 | ~~`compile_module()` entry point~~ | ~~New public function: takes JS/TS source + `ModuleCompileOptions`, returns `CompileResult`~~ ✅ Done |
-| 2 | ~~`analyze_module()`~~ | ~~Simplified analysis: OXC parse → scopes → rune detection. No template, no props, no content_types. Hardcode `runes: true`~~ ✅ Done |
-| 3 | ~~Script transforms reuse~~ | ~~Apply existing `script.rs` rune transformations ($state, $derived, $effect, etc.) to module AST~~ ✅ Done |
-| 4 | `ModuleCompileOptions` | Subset of `CompileOptions`: `dev`, `generate`, `filename`, `rootDir`. No `name`, `css`, `customElement`, `namespace` |
-| 5 | Validation | Disallow `$props()`, `$bindable()` in modules. Disallow `$store` auto-subscriptions |
-| 6 | ~~WASM export~~ | ~~Expose `compileModule()` alongside existing `compile()` in WASM build~~ ✅ Done |
-
-### Dependencies
-- Tier 1 rune transforms (reused, not duplicated)
+| 1 | `ModuleCompileOptions` | Subset of `CompileOptions`: `dev`, `generate`, `filename`, `rootDir`. No `name`, `css`, `customElement`, `namespace` |
+| 2 | Validation | Disallow `$props()`, `$bindable()` in modules. Disallow `$store` auto-subscriptions |
 
 ---
 
-## Tier 2 — Essential Template Blocks
-
-Theme: most commonly needed template features. Requires parser + AST + analyze + codegen.
-
-Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_client/src/template/`
-
-### ~~`{@html expr}`~~ — Raw HTML insertion ✅
-- **Phases**: P, A, T
-- **AST**: `Node::HtmlTag { id, span, expression_span }`
-- **Parser**: Handle `{@html ...}` in tag scanner (similar to `{@render}`)
-- **Analyze**: Register expression in `parse_js`. Mark dynamic in `reactivity`. Handle in `content_types`
-- **Codegen**: `$.html(anchor, () => expr)`
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/HtmlTag.js` (~60 lines)
-- **Not yet**: `is_controlled` optimization (single child → innerHTML), `is_svg`/`is_mathml` namespace flags
-
-### ~~`{#key expr}` — Keyed re-render block~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Node::KeyBlock { id, span, expression_span, fragment }`
-- **Parser**: Parse `{#key expr}...{/key}`
-- **Analyze**: Add `FragmentKey::KeyBody(NodeId)`. Process in `lower`, `reactivity`, `content_types`
-- **Codegen**: `$.key(anchor, () => expr, ($$anchor) => { ... })`
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/KeyBlock.js` (~45 lines)
-
-### ~~`{@const x = expr}` — Block-scoped constant~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Node::ConstTag { id, span, declaration_span }`
-- **Parser**: Parse `{@const ...}` extracting variable declaration
-- **Analyze**: Scope integration — const binding visible in subsequent template nodes within same block
-- **Transform**: Destructuring → generates tmp var (`$$const_0`), rewrites aliases to `$.get(tmp).prop`
-- **Codegen**: Simple: `const x = $.derived(() => expr)`. Destructured: `const $$const_0 = $.derived(() => expr)` + aliases
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/ConstTag.js`
-- **Deferred**: dev mode `$.tag()`, placement validation
-
-### ~~`style:prop={value}` — Style directive~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Attribute::StyleDirective { name, value: StyleDirectiveValue, important: bool }` with `StyleDirectiveValue` enum (Shorthand, Expression, String, Concatenation)
-- **Parser**: Parse `style:color={expr}`, `style:color` (shorthand), `style:color="red"` (string), `style:color="red-{x}"` (concat), `|important` modifier
-- **Codegen**: `$.set_style(el, staticStyle, prev, { directives })` — same pattern as `$.set_class()`. `|important` produces `[{ normal }, { important }]` array format.
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js`
-
-### ~~`class` attribute — Object/array syntax (Svelte 5)~~ ✅
-- **Phases**: P, A, T
-- **Syntax**: `class={{ active: isActive, bold }}`, `class={[base, isActive && "active", variant]}`
-- **Parser**: Detect object/array expression in `class` attribute value
-- **Codegen**: `$.set_class(el, ...)` — merges object keys where value is truthy, filters falsy array items
-- **Notes**: Preferred over `class:name` directive in Svelte 5. Coexists with static `class="..."` and `class:` directives
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/element.js`
+## Tier 2 — Remaining Template Blocks
 
 ### `{@debug vars}` — Dev-mode debugger
 - **Phases**: P, T
@@ -231,164 +129,9 @@ Key files: `svelte_ast/src/lib.rs`, `svelte_parser/src/lib.rs`, `svelte_codegen_
 
 ---
 
-## Tier 3 — Bind Directive Completeness ✅
+## Tier 5 — Special Elements (remaining)
 
-Theme: parser/AST already supports `bind:name={expr}`. Need element-aware codegen dispatch per binding type.
-
-**Status**: Codegen complete for all regular-element bindings. Window/document bindings deferred to Tier 4 (requires `<svelte:window>` / `<svelte:document>` parser support).
-
-Key file: `crates/svelte_codegen_client/src/template/attributes.rs`
-Ref: `reference/compiler/phases/3-transform/client/visitors/BindDirective.js`
-
-### Element reference
-
-| Binding | Elements | Runtime | Phases |
-|---------|----------|---------|--------|
-| `bind:this` | any element or component | `$.bind_this(el, ($$value) => ref = $$value, () => ref)` | T, A |
-
-Note: `bind:this` uses a different pattern — NOT getter/setter, uses `build_bind_this` utility.
-
-### Function bindings (Svelte 5)
-
-`bind:property={get, set}` — accepts a getter/setter pair for custom validation/transformation during binding updates.
-- **Syntax**: `bind:value={getValue, setValue}`
-- **Codegen**: Same runtime calls, but getter/setter are user-provided functions instead of generated ones
-- **Notes**: Works with any bindable property. Enables custom logic (clamping, formatting) on binding updates
-
-### Input/Form bindings
-
-| Binding | Elements | Runtime | Phases |
-|---------|----------|---------|--------|
-| `bind:value` | `<input>`, `<textarea>` | `$.bind_value(el, get, set)` | T |
-| `bind:value` | `<select>` | `$.bind_select_value(el, get, set)` | T |
-| `bind:value` | `<select multiple>` | `$.bind_select_value(el, get, set)` (array) | T |
-| `bind:checked` | `<input type="checkbox">` | `$.bind_checked(el, get, set)` | T |
-| `bind:checked` | `<input type="radio">` | `$.bind_checked(el, get, set)` | T |
-| `bind:indeterminate` | `<input type="checkbox">` | `$.bind_property(el, "indeterminate", "change", get, set)` | T |
-| `bind:group` | `<input type="checkbox">` | `$.bind_group(group_arr, el, get, set)` | T |
-| `bind:group` | `<input type="radio">` | `$.bind_group(group_arr, el, get, set)` | T |
-| `bind:files` | `<input type="file">` | `$.bind_files(el, get, set)` | T |
-
-### Details element
-
-| Binding | Elements | Runtime | Phases |
-|---------|----------|---------|--------|
-| `bind:open` | `<details>` | `$.bind_property(el, "open", "toggle", get, set)` | T |
-
-### Contenteditable bindings
-
-| Binding | Elements | Runtime | Phases |
-|---------|----------|---------|--------|
-| `bind:innerHTML` | `[contenteditable]` | `$.bind_content_editable(el, get, set, "innerHTML")` | T |
-| `bind:innerText` | `[contenteditable]` | `$.bind_content_editable(el, get, set, "innerText")` | T |
-| `bind:textContent` | `[contenteditable]` | `$.bind_content_editable(el, get, set, "textContent")` | T |
-
-### Dimension bindings (all readonly, all visible elements)
-
-| Binding | Runtime | Phases |
-|---------|---------|--------|
-| `bind:clientWidth` | `$.bind_resize_observer(el, "client", set)` | T |
-| `bind:clientHeight` | `$.bind_resize_observer(el, "client", set)` | T |
-| `bind:offsetWidth` | `$.bind_element_size(el, "offset", set)` | T |
-| `bind:offsetHeight` | `$.bind_element_size(el, "offset", set)` | T |
-| `bind:contentRect` | `$.bind_resize_observer(el, "contentRect", set)` | T |
-| `bind:contentBoxSize` | `$.bind_resize_observer(el, "contentBoxSize", set)` | T |
-| `bind:borderBoxSize` | `$.bind_resize_observer(el, "borderBoxSize", set)` | T |
-| `bind:devicePixelContentBoxSize` | `$.bind_resize_observer(el, "devicePixelContentBoxSize", set)` | T |
-
-### Media bindings (`<audio>`, `<video>`)
-
-| Binding | R/W | Runtime | Phases |
-|---------|-----|---------|--------|
-| `bind:currentTime` | R/W | `$.bind_current_time(el, get, set)` | T |
-| `bind:playbackRate` | R/W | `$.bind_playback_rate(el, get, set)` | T |
-| `bind:paused` | R/W | `$.bind_paused(el, get, set)` | T |
-| `bind:volume` | R/W | `$.bind_volume(el, get, set)` | T |
-| `bind:muted` | R/W | `$.bind_muted(el, get, set)` | T |
-| `bind:duration` | RO | `$.bind_property(el, "duration", "durationchange", set)` | T |
-| `bind:buffered` | RO | `$.bind_buffered(el, set)` | T |
-| `bind:seekable` | RO | `$.bind_seekable(el, set)` | T |
-| `bind:seeking` | RO | `$.bind_seeking(el, set)` | T |
-| `bind:ended` | RO | `$.bind_ended(el, set)` | T |
-| `bind:readyState` | RO | `$.bind_ready_state(el, set)` | T |
-| `bind:played` | RO | `$.bind_played(el, set)` | T |
-| `bind:videoWidth` | RO | `$.bind_property(el, "videoWidth", "resize", set)` | T |
-| `bind:videoHeight` | RO | `$.bind_property(el, "videoHeight", "resize", set)` | T |
-
-### Image bindings (readonly)
-
-| Binding | Elements | Runtime | Phases |
-|---------|----------|---------|--------|
-| `bind:naturalWidth` | `<img>` | `$.bind_property(el, "naturalWidth", "load", set)` | T |
-| `bind:naturalHeight` | `<img>` | `$.bind_property(el, "naturalHeight", "load", set)` | T |
-
----
-
-## Tier 4 — Directives & Interactivity
-
-Theme: action, transition, animation directives. New AST attribute variants + parser + codegen.
-
-### ~~`use:action={params}` — Action directive~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Attribute::UseDirective { name, expression_span: Option<Span> }`
-- **Codegen**: `$.action(el, () => actionFn, () => params)`
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/UseDirective.js` (~30 lines)
-- [ ] `use:action` with `await` expression (requires `run_after_blockers`) *(discovered during port, deferred)*
-
-### ~~`transition:name={params}` / `in:` / `out:` — Transitions~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Attribute::TransitionDirective { name, expression_span: Option<Span>, modifiers: Vec<String>, direction: TransitionDirection }`
-  - `TransitionDirection`: `Both` | `In` | `Out`
-- **Modifiers**: `|local` (scoped to block), `|global` (default)
-- **Codegen**:
-  - `transition:fade` → `$.transition(flags, el, () => fade, () => params)`
-  - `in:fly` → `$.transition(TRANSITION_IN, el, () => fly)`
-  - `out:slide` → `$.transition(TRANSITION_OUT, el, () => slide)`
-- **Events**: Elements get `introstart`, `introend`, `outrostart`, `outroend` events
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/TransitionDirective.js`
-- [ ] Validation: duplicate transition directives *(discovered during port, deferred)*
-- [ ] Validation: conflicting transition: + in:/out: on same element *(discovered during port, deferred)*
-
-### ~~`animate:name={params}` — FLIP animations~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Attribute::AnimateDirective { name, expression_span: Option<Span> }`
-- **Constraint**: Only valid inside keyed `{#each}` blocks (validation needed)
-- **Codegen**: `$.animation(el, animateFn, () => params)`
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/AnimateDirective.js`
-- [ ] Validation: `animate:` only valid inside keyed `{#each}` blocks *(discovered during port, deferred)*
-- [ ] Validation: duplicate `animate:` directives on same element *(discovered during port, deferred)*
-
-### ~~`{@attach fn}` — Element attachment (Svelte 5.29+)~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Attribute::AttachTag { expression_span }` (in element attributes array)
-- **Codegen**: `$.attach(el, () => fn)`
-- **Notes**: Modern alternative to `use:action`. Re-runs on reactive dependency changes. Conditional with falsy values.
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/AttachTag.js`
-- [ ] `{@attach}` on component nodes — generates `$.attachment()` property in props *(deferred)*
-- [ ] `{@attach}` with async/blockers — `$.run_after_blockers()` wrapping *(deferred)*
-
----
-
-## Tier 5 — Special Elements
-
-Theme: `<svelte:*>` elements for global bindings, dynamic elements, head management, error boundaries.
-
-### ~~`<svelte:options>` — Compiler options tag~~ ✅
-- **Phases**: P only (no codegen)
-- **Attributes**: `runes={true|false}`, `namespace="html"|"svg"|"mathml"`, `customElement="tag-name"`, `css="injected"`, `preserveWhitespace`, `immutable`, `accessors`
-- **Notes**: Parse early, store on component metadata. Scanner extended for `svelte:*` tag names. Validation for unknown attrs, invalid values, no children, tag names.
-- [ ] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties *(deferred — expression span stored, analysis-phase parsing needed)*
-- [ ] `namespace` affecting codegen: `$.from_svg()` / `$.from_mathml()` instead of `$.from_html()` *(deferred — requires codegen changes)*
-
-### ~~`<svelte:head>` — Document head~~ ✅
-- **Phases**: P, A, T
-- **AST**: `Node::SvelteHead { id, span, fragment }`
-- **Codegen**: `$.head(hash, ($$anchor) => { ... })`
-- **Constraint**: Top-level only
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteHead.js`
-- [ ] Validation: `<svelte:head>` only allowed at root level *(discovered during port, deferred)*
-- [ ] Validation: no attributes allowed (diagnostic) *(discovered during port, deferred)*
-- [ ] `filename` parameter for `compile()` to produce correct hash *(discovered during port, deferred — currently uses "(unknown)" default)*
+Theme: `<svelte:*>` elements for global bindings, dynamic elements, error boundaries.
 
 ### `<svelte:element this={tag}>` — Dynamic element
 - **Phases**: P, A, T
@@ -430,7 +173,7 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, head managem
 - **Phases**: P, A, T
 - **Codegen**: Events → `$.event($.body, ...)`. Supports `use:action`.
 - **Constraint**: Top-level only, no children
-- **Deps**: `use:action` (Tier 4)
+- **Deps**: `use:action` (done)
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteBody.js`
 
 ### `<svelte:boundary>` — Error boundary (Svelte 5.3+)
@@ -491,7 +234,6 @@ Theme: less-used features, developer experience, performance improvements.
 | Feature | Phases | Description |
 |---------|--------|-------------|
 | Event delegation refinement | A, T | Refine `is_delegatable_event` analysis, track `$.delegate()` calls at component level |
-| ~~Unmutated rune optimization~~ | ~~S~~ | ~~Done — moved to Done section~~ |
 | CSS hash injection | T | Add scoped class to elements (requires Tier 6) |
 
 ---
@@ -502,7 +244,6 @@ Theme: deprecated syntax superseded by Svelte 5 features. Only needed for migrat
 
 | Feature | Svelte 5 replacement | Transform | Phases |
 |---------|----------------------|-----------|--------|
-| ~~`on:event={handler}` + modifiers~~ | ~~`onclick={handler}` (already works)~~ | ~~`$.event(el, "click", handler, modifiers)`~~ | ~~P, A, T~~ | ✅ Done |
 | `<slot>` + `let:` | `{#snippet}` + `{@render}` | `$.slot(...)` | P, A, T |
 | `<svelte:component this={X}>` | `<X />` with capitalized variable | `$.component(...)` | P, A, T |
 | `<svelte:self>` | Import component directly | Recursive ref | P, T |
@@ -547,11 +288,60 @@ These are imported from `svelte` and used as regular function calls. The compile
 
 ---
 
-## Edge Cases / Tech Debt
+## Deferred
 
-Deferred items from completed features. Each links back to the originating tier.
+Items discovered during porting but not critical for the feature to work. Grouped by parent feature.
 
-### on:directive (Tier 8)
-- [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis. Rare in Svelte 4 code.
-- [ ] SvelteDocument/SvelteWindow/SvelteBody routing: events on these special elements should go to `init` not `after_update`. Blocked on Tier 5 (special elements).
-- [ ] Dev-mode `$.apply()` wrapping for imported identifier handlers. Blocked on `dev` compiler option.
+### Void elements (Tier 0)
+- [ ] Validation: emit error if void element has children (requires parser-level check for content between void open tags)
+
+### Runes (Tier 1)
+- [ ] `$state` / `$state.raw` destructuring support in script codegen
+- [ ] `$state` / `$state.raw` class field support
+- [ ] `$state.frozen` → `$state.raw` rename validation
+
+### Module compilation (Tier 1b)
+- [ ] `ModuleCompileOptions` type — subset of `CompileOptions`
+- [ ] Validation: disallow `$props()`, `$bindable()`, `$store` auto-subscriptions in modules
+
+### `{@html expr}` (Tier 2)
+- [ ] `is_controlled` optimization (single child → innerHTML)
+- [ ] `is_svg` / `is_mathml` namespace flags
+
+### `{@const}` (Tier 2)
+- [ ] Dev mode `$.tag()` wrapping
+- [ ] Placement validation
+
+### Bind directives (Tier 3)
+- [ ] `bind:property={get, set}` — function bindings (Svelte 5)
+- [ ] Window bindings (`scrollX`, `scrollY`, `innerWidth`, etc.) — blocked on `<svelte:window>` (Tier 5)
+- [ ] Document bindings (`activeElement`, `fullscreenElement`, etc.) — blocked on `<svelte:document>` (Tier 5)
+
+### `use:action` (Tier 4)
+- [ ] `use:action` with `await` expression (requires `run_after_blockers`)
+
+### Transitions (Tier 4)
+- [ ] Validation: duplicate transition directives on same element
+- [ ] Validation: conflicting `transition:` + `in:`/`out:` on same element
+
+### Animate (Tier 4)
+- [ ] Validation: `animate:` only valid inside keyed `{#each}` blocks
+- [ ] Validation: duplicate `animate:` directives on same element
+
+### `{@attach}` (Tier 4)
+- [ ] `{@attach}` on component nodes — generates `$.attachment()` property in props
+- [ ] `{@attach}` with async/blockers — `$.run_after_blockers()` wrapping
+
+### `<svelte:options>` (Tier 5)
+- [ ] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties (expression span stored, analysis-phase parsing needed)
+- [ ] `namespace` affecting codegen: `$.from_svg()` / `$.from_mathml()` instead of `$.from_html()`
+
+### `<svelte:head>` (Tier 5)
+- [ ] Validation: only allowed at root level
+- [ ] Validation: no attributes allowed (diagnostic)
+- [ ] `filename` parameter for `compile()` to produce correct hash (currently uses `"(unknown)"` default)
+
+### `on:directive` legacy (Tier 8)
+- [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis
+- [ ] SvelteDocument/SvelteWindow/SvelteBody routing: events on special elements should go to `init` not `after_update`. Blocked on Tier 5
+- [ ] Dev-mode `$.apply()` wrapping for imported identifier handlers. Blocked on `dev` compiler option

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,29 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] IfBlock, EachBlock
 - [x] SnippetBlock, RenderTag
 - [x] Text node, ExpressionTag
+- [x] `{@html expr}`, `{#key expr}`, `{@const}`
+- [x] `style:prop` directive, `class` object/array syntax
+
+### Directives (Tier 4)
+- [x] `use:action={params}` — action directive
+- [x] `transition:` / `in:` / `out:` — transitions (local/global, params)
+- [x] `animate:name={params}` — FLIP animations
+- [x] `{@attach fn}` — element attachment (Svelte 5.29+)
+- [x] `on:event` — legacy event directive (Svelte 4)
+
+### Special elements (Tier 5)
+- [x] `<svelte:options>` — compiler options tag (parser + validation)
+- [x] `<svelte:head>` — document head insertion
+
+### Runes (Tier 1)
+- [x] `$state.raw(val)` → `$.state(val)` (no proxy)
+- [x] `$state.snapshot(val)` → `$.snapshot(val)`
+- [x] `$effect.tracking()` → `$.effect_tracking()`
+- [x] `$effect.root(fn)` → `$.effect_root(fn)`
+- [x] `$store` auto-subscription → `$.store_get` / `$.store_set`
+
+### Module compilation (Tier 1b)
+- [x] `compile_module()` entry point + `analyze_module()` + WASM export
 
 ### Bind directives (Tier 3)
 - [x] `bind:value` (input, textarea, select), `bind:checked`, `bind:group`, `bind:files`
@@ -312,7 +335,7 @@ Theme: action, transition, animation directives. New AST attribute variants + pa
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/UseDirective.js` (~30 lines)
 - [ ] `use:action` with `await` expression (requires `run_after_blockers`) *(discovered during port, deferred)*
 
-### `transition:name={params}` / `in:` / `out:` — Transitions [x]
+### ~~`transition:name={params}` / `in:` / `out:` — Transitions~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Attribute::TransitionDirective { name, expression_span: Option<Span>, modifiers: Vec<String>, direction: TransitionDirection }`
   - `TransitionDirection`: `Both` | `In` | `Out`
@@ -326,7 +349,7 @@ Theme: action, transition, animation directives. New AST attribute variants + pa
 - [ ] Validation: duplicate transition directives *(discovered during port, deferred)*
 - [ ] Validation: conflicting transition: + in:/out: on same element *(discovered during port, deferred)*
 
-### `animate:name={params}` — FLIP animations [x]
+### ~~`animate:name={params}` — FLIP animations~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Attribute::AnimateDirective { name, expression_span: Option<Span> }`
 - **Constraint**: Only valid inside keyed `{#each}` blocks (validation needed)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Scope: client-side compilation only (no SSR, no legacy mode).
 - [x] `class` object/array syntax (Svelte 5)
 
 ### Event handling
-- [x] Svelte 5 event attributes — `onclick={handler}` → `$.event()` / `$.delegated()`
+- [x] Svelte 5 event attributes — `onclick={handler}` → `$.delegated()` for delegatable events
 - [x] Event delegation — `$.delegate([...events])` at component level
 - [x] `on:event` — legacy event directive (Svelte 4)
 
@@ -116,6 +116,42 @@ Key file: `crates/svelte_codegen_client/src/script.rs`
 |---|------|-------------|
 | 1 | `ModuleCompileOptions` | Subset of `CompileOptions`: `dev`, `generate`, `filename`, `rootDir`. No `name`, `css`, `customElement`, `namespace` |
 | 2 | Validation | Disallow `$props()`, `$bindable()` in modules. Disallow `$store` auto-subscriptions |
+
+---
+
+## Tier 1c — Event Attributes (fix + extend)
+
+Theme: complete the Svelte 5 event system. `onclick={handler}` is the standard way; `on:click` is legacy.
+
+**Current state**: delegatable events (click, input, change, etc.) correctly generate `$.delegated()`. Non-delegatable events (scroll, resize, etc.) incorrectly fall through to `$.set_attribute()`.
+
+Key file: `crates/svelte_codegen_client/src/template/attributes.rs`
+Ref: `reference/compiler/phases/3-transform/client/visitors/shared/events.js`, `Attribute.js`
+
+| # | Feature | Current | Correct | Phases |
+|---|---------|---------|---------|--------|
+| 1 | Non-delegatable event attrs | `$.set_attribute("onscroll", fn)` | `$.event("scroll", el, fn)` | T |
+| 2 | Event capture suffix | Not handled | `onclickcapture` → `capture: true` flag | A, T |
+| 3 | Passive event auto-detection | Not handled | Auto-passive for `touchstart`, `wheel`, etc. | T |
+| 4 | Handler wrapping (non-inline) | Not handled | `(...$$args) => handler.apply(this, $$args)` | T |
+
+---
+
+## Tier 1d — Expression Memoization
+
+Theme: prevent over-firing of reactive expressions containing function calls.
+
+The reference compiler's `Memoizer` class wraps expressions with `has_call` in `$.derived()` to memoize them. Without this, expressions like `onclick={getHandler()}` or `{@render fn(getArg())}` re-evaluate on every render cycle.
+
+Ref: `reference/compiler/phases/3-transform/client/visitors/shared/utils.js` (Memoizer class)
+
+| # | Feature | Phases | Description |
+|---|---------|--------|-------------|
+| 1 | `has_call` detection in analysis | A | Track whether expression contains `CallExpression` |
+| 2 | Memoizer codegen utility | T | Generate `$.derived(() => expr)` + `$.get(id)` pairs |
+| 3 | Integration: event handlers | T | Memoize `onclick={getHandler()}` |
+| 4 | Integration: component props | T | Memoize non-simple prop expressions with calls |
+| 5 | Integration: render tag args | T | Memoize `{@render fn(getArg())}` |
 
 ---
 
@@ -197,6 +233,11 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - **Phases**: T
 - **Codegen**: Special text update handling for `<title>` element content
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/TitleElement.js`
+
+### Component `bind:this`
+- **Phases**: T
+- **Codegen**: `$.bind_this(component, setter, getter)` — different from element `bind:this`, binds to component instance
+- **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/component.js`
 
 ---
 
@@ -415,6 +456,12 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: only allowed at root level
 - [ ] Validation: no attributes allowed (diagnostic)
 - [ ] `filename` parameter for `compile()` to produce correct hash (currently uses `"(unknown)"` default)
+
+### Render tag
+- [ ] Optional chaining: `{@render fn?.()}` → `$.noop` fallback when fn is nullish
+
+### Event attributes (Tier 1c)
+- [ ] Handler memoization for expressions with calls (`has_call`) — depends on Tier 1d memoization
 
 ### CSS (Tier 6)
 - [ ] Component CSS custom properties on `<Component>` — `$.css_props()` wrapper element injection


### PR DESCRIPTION
- ROADMAP: add Done entries for Tier 4 directives (use:action, transitions,
  animate, attach), Tier 5 special elements (svelte:options, svelte:head),
  Tier 1 runes ($state.raw/snapshot, $effect.tracking/root, $store),
  module compilation, and template codegen (html/key/const tags, style/class)
- ROADMAP: fix transition/animate headers to use consistent ✅ formatting
- CODEBASE_MAP: add new AST types (SvelteHead, UseDirective, TransitionDirective,
  AnimateDirective, AttachTag, ErrorNode, TransitionDirection enum)
- CODEBASE_MAP: add SvelteHeadBody FragmentKey variant
- CODEBASE_MAP: add svelte_head.rs codegen module
- CODEBASE_MAP: add compile_module() to svelte_compiler API

https://claude.ai/code/session_01RMTyHa44um7tWPkrgwxmqn