### PR TITLE
Port <svelte:element this={tag}> — full pipeline from parser to codegen

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,12 +180,15 @@ Ref: `reference/compiler/phases/3-transform/client/visitors/shared/utils.js` (Me
 
 Theme: `<svelte:*>` elements for global bindings, dynamic elements, error boundaries.
 
-### `<svelte:element this={tag}>` — Dynamic element
+### ~~`<svelte:element this={tag}>` — Dynamic element~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Node::SvelteElement { id, span, tag_span, attributes, fragment }`
 - **Codegen**: `$.element(anchor, () => tag, ($$anchor, element) => { ... })`
 - **Notes**: Namespace inference with explicit `xmlns` control, void element validation
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteElement.js` (~161 lines)
+- [ ] `svelte:element` inside `{#if}` block *(deferred)*
+- [ ] `svelte:element` with `class:` directives *(deferred)*
+- [ ] `svelte:element` with `style:` directives *(deferred)*
 
 ### `<svelte:window>` — Window events & bindings
 - **Phases**: P, A, T

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -37,7 +37,8 @@ fn item_is_dynamic(
         | FragmentItem::EachBlock(id)
         | FragmentItem::RenderTag(id)
         | FragmentItem::HtmlTag(id)
-        | FragmentItem::KeyBlock(id) => dynamic_nodes.contains(id),
+        | FragmentItem::KeyBlock(id)
+        | FragmentItem::SvelteElement(id) => dynamic_nodes.contains(id),
     }
 }
 
@@ -54,7 +55,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentType {
             | FragmentItem::EachBlock(_)
             | FragmentItem::RenderTag(_)
             | FragmentItem::HtmlTag(_)
-            | FragmentItem::KeyBlock(_) => return ContentType::SingleBlock,
+            | FragmentItem::KeyBlock(_)
+            | FragmentItem::SvelteElement(_) => return ContentType::SingleBlock,
             FragmentItem::TextConcat { .. } => {}
         }
     }
@@ -72,7 +74,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentType {
             | FragmentItem::EachBlock(_)
             | FragmentItem::RenderTag(_)
             | FragmentItem::HtmlTag(_)
-            | FragmentItem::KeyBlock(_) => has_block = true,
+            | FragmentItem::KeyBlock(_)
+            | FragmentItem::SvelteElement(_) => has_block = true,
             FragmentItem::TextConcat { has_expr, .. } => {
                 if *has_expr {
                     has_dynamic_text = true;

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -54,6 +54,7 @@ pub enum FragmentKey {
     SnippetBody(NodeId),
     KeyBlockBody(NodeId),
     SvelteHeadBody(NodeId),
+    SvelteElementBody(NodeId),
 }
 
 // ---------------------------------------------------------------------------
@@ -287,6 +288,8 @@ pub enum FragmentItem {
     HtmlTag(NodeId),
     /// A KeyBlock ({#key expr}...{/key}).
     KeyBlock(NodeId),
+    /// A SvelteElement (<svelte:element this={tag}>).
+    SvelteElement(NodeId),
     /// Adjacent text nodes and expression tags grouped together.
     TextConcat { parts: Vec<ConcatPart>, has_expr: bool },
 }
@@ -309,7 +312,8 @@ impl FragmentItem {
             | FragmentItem::EachBlock(id)
             | FragmentItem::RenderTag(id)
             | FragmentItem::HtmlTag(id)
-            | FragmentItem::KeyBlock(id) => *id,
+            | FragmentItem::KeyBlock(id)
+            | FragmentItem::SvelteElement(id) => *id,
             FragmentItem::TextConcat { .. } => panic!("TextConcat has no single NodeId"),
         }
     }

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -183,6 +183,9 @@ fn register_snippet_params(
                     register_snippet_params(fb, component, data);
                 }
             }
+            svelte_ast::Node::SvelteElement(el) => {
+                register_snippet_params(&el.fragment, component, data);
+            }
             _ => {}
         }
     }

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -54,6 +54,9 @@ fn lower_fragment(
             Node::SvelteHead(head) => {
                 lower_fragment(&head.fragment, FragmentKey::SvelteHeadBody(head.id), component, data);
             }
+            Node::SvelteElement(el) => {
+                lower_fragment(&el.fragment, FragmentKey::SvelteElementBody(el.id), component, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
     }
@@ -153,6 +156,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
                     Node::RenderTag(tag) => items.push(FragmentItem::RenderTag(tag.id)),
                     Node::HtmlTag(tag) => items.push(FragmentItem::HtmlTag(tag.id)),
                     Node::KeyBlock(block) => items.push(FragmentItem::KeyBlock(block.id)),
+                    Node::SvelteElement(el) => items.push(FragmentItem::SvelteElement(el.id)),
                     _ => {}
                 }
             }

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -62,6 +62,6 @@ fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
             // Already computed: leave_element processes children before parents
             data.element_flags.needs_var.contains(id)
         }
-        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) => true,
+        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) => true,
     }
 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -208,6 +208,15 @@ fn walk_node<'a>(
         Node::SvelteHead(head) => {
             walk_fragment(alloc, &head.fragment, component, data, parsed, diags);
         }
+        Node::SvelteElement(el) => {
+            // Parse the tag expression (skip for static string tags like this="div")
+            if !el.static_tag {
+                let tag_source = component.source_text(el.tag_span);
+                parse_expr(alloc, tag_source, el.tag_span.start, el.id, data, parsed, diags);
+            }
+            walk_attrs(alloc, el.id, &el.attributes, component, data, parsed, diags);
+            walk_fragment(alloc, &el.fragment, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::{ReferenceFlags as OxcReferenceFlags, ScopeId};
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
-    KeyBlock, NodeId, RenderTag,
+    KeyBlock, NodeId, RenderTag, SvelteElement,
 };
 
 use crate::data::AnalysisData;
@@ -130,6 +130,31 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
         scope: ScopeId,
         data: &mut AnalysisData,
     ) {
+        self.resolve_bind(dir, scope, data);
+    }
+
+    fn visit_svelte_element(
+        &mut self,
+        el: &SvelteElement,
+        scope: ScopeId,
+        data: &mut AnalysisData,
+    ) {
+        // Resolve tag expression references (skip for static string tags)
+        if !el.static_tag {
+            resolve_expr_refs(el.id, scope, data);
+        }
+        // Walk attributes — resolve expression refs and bind directives
+        for (idx, attr) in el.attributes.iter().enumerate() {
+            resolve_attr_refs(el.id, idx, scope, data);
+            if let Attribute::BindDirective(dir) = attr {
+                self.resolve_bind(dir, scope, data);
+            }
+        }
+    }
+}
+
+impl ResolveReferencesVisitor<'_> {
+    fn resolve_bind(&self, dir: &BindDirective, scope: ScopeId, data: &mut AnalysisData) {
         let name = if dir.shorthand {
             dir.name.as_str()
         } else if let Some(span) = dir.expression_span {

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -251,6 +251,9 @@ fn walk_template_scopes(
             Node::SvelteHead(head) => {
                 walk_template_scopes(&head.fragment, component, scoping, current_scope, const_tag_names);
             }
+            Node::SvelteElement(el) => {
+                walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names);
+            }
             Node::ConstTag(tag) => {
                 if let Some(names) = const_tag_names.get(&tag.id) {
                     for name in names {

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -2,7 +2,7 @@ use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
-    TransitionDirective, UseDirective,
+    SvelteElement, TransitionDirective, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -28,6 +28,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_each_block(&mut self, block: &EachBlock, parent_scope: ScopeId, body_scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -122,6 +123,10 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
             Node::SvelteHead(head) => {
                 walk_template(&head.fragment, data, scope, visitor);
             }
+            Node::SvelteElement(el) => {
+                visitor.visit_svelte_element(el, scope, data);
+                walk_template(&el.fragment, data, scope, visitor);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -160,6 +165,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_key_block(block, scope, data);)+
+        }
+        fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_svelte_element(el, scope, data);)+
         }
         fn visit_attribute(&mut self, attr: &Attribute, idx: usize, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_attribute(attr, idx, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -124,6 +124,7 @@ impl_node_enum! {
     ConstTag(ConstTag)           => is_const_tag / as_const_tag,
     KeyBlock(KeyBlock)           => is_key_block / as_key_block,
     SvelteHead(SvelteHead)       => is_svelte_head / as_svelte_head,
+    SvelteElement(SvelteElement) => is_svelte_element / as_svelte_element,
     Error(ErrorNode)             => is_error / as_error,
 }
 
@@ -315,6 +316,21 @@ pub struct KeyBlock {
 pub struct SvelteHead {
     pub id: NodeId,
     pub span: Span,
+    pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteElement — <svelte:element this={tag}>...</svelte:element>
+// ---------------------------------------------------------------------------
+
+pub struct SvelteElement {
+    pub id: NodeId,
+    pub span: Span,
+    /// Span of the `this` expression (the dynamic tag).
+    pub tag_span: Span,
+    /// True when `this="literal"` (StringAttribute) — tag is a static string, not a JS expression.
+    pub static_tag: bool,
+    pub attributes: Vec<Attribute>,
     pub fragment: Fragment,
 }
 

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, ContentType, FragmentKey, IdentGen, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock};
+use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, HtmlTag, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteElement};
 use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 
@@ -18,6 +18,7 @@ struct NodeIndex<'a> {
     render_tags: FxHashMap<NodeId, &'a RenderTag>,
     html_tags: FxHashMap<NodeId, &'a HtmlTag>,
     const_tags: FxHashMap<NodeId, &'a ConstTag>,
+    svelte_elements: FxHashMap<NodeId, &'a SvelteElement>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -32,6 +33,7 @@ impl<'a> NodeIndex<'a> {
             render_tags: FxHashMap::default(),
             html_tags: FxHashMap::default(),
             const_tags: FxHashMap::default(),
+            svelte_elements: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -81,6 +83,10 @@ impl<'a> NodeIndex<'a> {
                 }
                 Node::SvelteHead(h) => {
                     self.walk(&h.fragment);
+                }
+                Node::SvelteElement(el) => {
+                    self.svelte_elements.insert(el.id, el);
+                    self.walk(&el.fragment);
                 }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
@@ -171,6 +177,7 @@ impl<'a> Ctx<'a> {
     pub fn each_block(&self, id: NodeId) -> &'a EachBlock { self.get_node(&self.index.each_blocks, id, "each block") }
     pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock { self.get_node(&self.index.snippet_blocks, id, "snippet block") }
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag { self.get_node(&self.index.render_tags, id, "render tag") }
+    pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.get_node(&self.index.svelte_elements, id, "svelte element") }
     fn get_node<T>(&self, map: &FxHashMap<NodeId, &'a T>, id: NodeId, label: &str) -> &'a T {
         map.get(&id).copied()
             .unwrap_or_else(|| panic!("{} {:?} not found in index", label, id))

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -639,7 +639,15 @@ fn gen_bind_directive<'a>(
 
         // --- bind:this ---
         "this" => {
-            let setter = build_setter(ctx, var_name.clone());
+            // svelte:element uses proxy flag because the element type is unknown at compile time
+            let setter = if tag_name.is_empty() && ctx.is_mutable_rune(&var_name) {
+                let body = ctx.b.call_expr("$.set", [
+                    Arg::Ident(&var_name), Arg::Ident("$$value"), Arg::Expr(ctx.b.bool_expr(true)),
+                ]);
+                ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+            } else {
+                build_setter(ctx, var_name.clone())
+            };
             let getter = build_getter(ctx, &var_name);
             let stmt = ctx.b.call_stmt("$.bind_this", [
                 Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
@@ -691,8 +699,21 @@ pub(crate) fn process_attrs_spread<'a>(
                     props.push(ObjProp::Shorthand(name_alloc));
                 } else {
                     let expr = get_attr_expr(ctx, el.id, attr_idx);
-                    let name_alloc = ctx.b.alloc_str(&a.name);
-                    props.push(ObjProp::KeyValue(name_alloc, expr));
+                    // Hoist event handlers (on*) with function values for stable identity
+                    let is_event = a.name.starts_with("on");
+                    let is_fn = matches!(
+                        &expr,
+                        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_)
+                    );
+                    if is_event && is_fn {
+                        let handler_name = ctx.gen_ident("event_handler");
+                        init.push(ctx.b.var_stmt(&handler_name, expr));
+                        let name_alloc = ctx.b.alloc_str(&a.name);
+                        props.push(ObjProp::KeyValue(name_alloc, ctx.b.rid_expr(&handler_name)));
+                    } else {
+                        let name_alloc = ctx.b.alloc_str(&a.name);
+                        props.push(ObjProp::KeyValue(name_alloc, expr));
+                    }
                 }
             }
             Attribute::ConcatenationAttribute(a) => {
@@ -728,10 +749,12 @@ pub(crate) fn process_attrs_spread<'a>(
         }
     }
 
-    // $.attribute_effect(el, () => ({...}))
-    let obj = ctx.b.object_expr(props);
-    let arrow = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(obj)]);
-    init.push(ctx.b.call_stmt("$.attribute_effect", [Arg::Ident(el_name), Arg::Expr(arrow)]));
+    // $.attribute_effect(el, () => ({...})) — skip if no renderable properties
+    if !props.is_empty() {
+        let obj = ctx.b.object_expr(props);
+        let arrow = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(obj)]);
+        init.push(ctx.b.call_stmt("$.attribute_effect", [Arg::Ident(el_name), Arg::Expr(arrow)]));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -166,7 +166,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
         svelte_analyze::FragmentItem::Element(id) => ctx.needs_var(*id),
-        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) => {
+        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) => {
             true
         }
     }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -233,7 +233,7 @@ pub(crate) fn emit_trailing_next<'a>(
 pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
-        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) => {
+        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) => {
             ctx.is_dynamic(*id)
         }
     }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -33,7 +33,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
                 let el = ctx.element(*id);
                 html.push_str(&element_html(ctx, el));
             }
-            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) => html.push_str("<!>"),
+            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) => html.push_str("<!>"),
         }
     }
     html

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod html_tag;
 pub(crate) mod key_block;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
+pub(crate) mod svelte_element;
 pub(crate) mod svelte_head;
 pub(crate) mod traverse;
 
@@ -31,6 +32,7 @@ enum SingleBlockKind {
     KeyBlock(NodeId),
     RenderTag(NodeId),
     ComponentNode(NodeId),
+    SvelteElement(NodeId),
 }
 
 use element::process_element;
@@ -43,6 +45,7 @@ use html_tag::gen_html_tag;
 use key_block::gen_key_block;
 use render_tag::gen_render_tag;
 use const_tag::emit_const_tags;
+use svelte_element::gen_svelte_element;
 use traverse::traverse_items;
 
 /// Check if template HTML needs `importNode` (flag bit 2).
@@ -243,7 +246,10 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, body: &mut Vec<Statement<'a>>) {
         SingleBlockKind::KeyBlock(id) => {
             gen_key_block(ctx, id, ctx.b.rid_expr(&node), body);
         }
-        _ => unreachable!("SingleBlock should be if/each/html/key at this point"),
+        SingleBlockKind::SvelteElement(id) => {
+            gen_svelte_element(ctx, id, ctx.b.rid_expr(&node), body);
+        }
+        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element at this point"),
     }
 
     body.push(ctx.b.call_stmt(
@@ -423,7 +429,10 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                         SingleBlockKind::KeyBlock(id) => {
                             gen_key_block(ctx, id, ctx.b.rid_expr(&node), &mut body);
                         }
-                        _ => unreachable!("SingleBlock should be if/each/html/key at this point"),
+                        SingleBlockKind::SvelteElement(id) => {
+                            gen_svelte_element(ctx, id, ctx.b.rid_expr(&node), &mut body);
+                        }
+                        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element at this point"),
                     }
                     body.push(ctx.b.call_stmt(
                         "$.append",
@@ -494,6 +503,7 @@ fn single_block_kind(item: &FragmentItem) -> SingleBlockKind {
         FragmentItem::KeyBlock(id) => SingleBlockKind::KeyBlock(id),
         FragmentItem::RenderTag(id) => SingleBlockKind::RenderTag(id),
         FragmentItem::ComponentNode(id) => SingleBlockKind::ComponentNode(id),
+        FragmentItem::SvelteElement(id) => SingleBlockKind::SvelteElement(id),
         _ => unreachable!("SingleBlock should contain a block-level item"),
     }
 }

--- a/crates/svelte_codegen_client/src/template/svelte_element.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_element.rs
@@ -1,0 +1,94 @@
+//! SvelteElement code generation — `<svelte:element this={tag}>`.
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_analyze::FragmentKey;
+use svelte_ast::NodeId;
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::attributes::process_attrs_spread;
+use super::expression::get_node_expr;
+use super::gen_fragment;
+
+/// Generate `$.element(anchor, () => tag, is_svg, ($$element, $$anchor) => { ... })`.
+pub(crate) fn gen_svelte_element<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    anchor: Expression<'a>,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let el = ctx.svelte_element(id);
+    let static_tag = el.static_tag;
+    let tag_value = if static_tag {
+        Some(ctx.component.source_text(el.tag_span).to_string())
+    } else {
+        None
+    };
+    let el_clone = svelte_ast::Element {
+        id: el.id,
+        span: el.span,
+        name: String::new(),
+        self_closing: true,
+        attributes: el.attributes.clone(),
+        fragment: svelte_ast::Fragment::empty(),
+    };
+    let has_attrs = !el_clone.attributes.is_empty();
+
+    // Detect SVG namespace from static xmlns attribute
+    let is_svg_ns = el.attributes.iter().any(|attr| {
+        if let svelte_ast::Attribute::StringAttribute(sa) = attr {
+            sa.name == "xmlns"
+                && ctx.component.source_text(sa.value_span) == "http://www.w3.org/2000/svg"
+        } else {
+            false
+        }
+    });
+
+    // Generate $$element ident for the inner callback
+    let el_name = ctx.gen_ident("$$element");
+
+    let mut inner_init: Vec<Statement<'a>> = Vec::new();
+    let mut inner_after_update: Vec<Statement<'a>> = Vec::new();
+
+    // Process attributes — always use spread-like handling for svelte:element
+    // because the element tag is unknown at compile time.
+    if has_attrs {
+        process_attrs_spread(ctx, &el_clone, &el_name, &mut inner_init, &mut inner_after_update);
+    }
+
+    // Generate children
+    let child_body = gen_fragment(ctx, FragmentKey::SvelteElementBody(id));
+
+    // Build tag thunk: () => tag_expression (or () => "literal" for static tags)
+    let tag_expr = if let Some(ref value) = tag_value {
+        ctx.b.str_expr(value)
+    } else {
+        get_node_expr(ctx, id)
+    };
+    let get_tag = ctx.b.thunk(tag_expr);
+
+    let is_svg = ctx.b.bool_expr(is_svg_ns);
+
+    // Assemble inner body: init + update + after_update + children
+    let mut inner = inner_init;
+    inner.extend(inner_after_update);
+    inner.extend(child_body);
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Expr(anchor),
+        Arg::Expr(get_tag),
+        Arg::Expr(is_svg),
+    ];
+
+    if !inner.is_empty() {
+        let callback = ctx.b.arrow_block_expr(
+            ctx.b.params(["$$element", "$$anchor"]),
+            inner,
+        );
+        args.push(Arg::Expr(callback));
+    }
+
+    stmts.push(ctx.b.call_stmt("$.element", args));
+}

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -92,7 +92,8 @@ pub(crate) fn traverse_items<'a>(
                 | FragmentItem::EachBlock(_)
                 | FragmentItem::RenderTag(_)
                 | FragmentItem::HtmlTag(_)
-                | FragmentItem::KeyBlock(_) => {
+                | FragmentItem::KeyBlock(_)
+                | FragmentItem::SvelteElement(_) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
                     sibling_offset = 1;
@@ -107,6 +108,7 @@ pub(crate) fn traverse_items<'a>(
                         FragmentItem::RenderTag(id) => gen_render_tag(ctx, *id, anchor, init),
                         FragmentItem::HtmlTag(id) => gen_html_tag(ctx, *id, anchor, init),
                         FragmentItem::KeyBlock(id) => gen_key_block(ctx, *id, anchor, init),
+                        FragmentItem::SvelteElement(id) => super::svelte_element::gen_svelte_element(ctx, *id, anchor, init),
                         _ => unreachable!(),
                     }
                     prev_ident = Some(node_name);

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -784,6 +784,48 @@ fn collect_references(expr: &Expression<'_>, offset: u32, refs: &mut Vec<Referen
                 }
             }
         }
+        Expression::ArrowFunctionExpression(arrow) => {
+            for stmt in &arrow.body.statements {
+                collect_statement_references(stmt, offset, refs);
+            }
+        }
+        Expression::SequenceExpression(seq) => {
+            for expr in &seq.expressions {
+                collect_references(expr, offset, refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_statement_references(stmt: &oxc_ast::ast::Statement<'_>, offset: u32, refs: &mut Vec<Reference>) {
+    use oxc_ast::ast::Statement;
+    match stmt {
+        Statement::ExpressionStatement(es) => collect_references(&es.expression, offset, refs),
+        Statement::ReturnStatement(ret) => {
+            if let Some(arg) = &ret.argument {
+                collect_references(arg, offset, refs);
+            }
+        }
+        Statement::BlockStatement(block) => {
+            for s in &block.body {
+                collect_statement_references(s, offset, refs);
+            }
+        }
+        Statement::IfStatement(if_stmt) => {
+            collect_references(&if_stmt.test, offset, refs);
+            collect_statement_references(&if_stmt.consequent, offset, refs);
+            if let Some(alt) = &if_stmt.alternate {
+                collect_statement_references(alt, offset, refs);
+            }
+        }
+        Statement::VariableDeclaration(decl) => {
+            for d in &decl.declarations {
+                if let Some(init) = &d.init {
+                    collect_references(init, offset, refs);
+                }
+            }
+        }
         _ => {}
     }
 }

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -350,6 +350,9 @@ impl<'a> Parser<'a> {
         // Convert <svelte:head> elements to SvelteHead nodes
         Self::convert_svelte_head(&mut component);
 
+        // Convert <svelte:element> elements to SvelteElement nodes
+        Self::convert_svelte_element(&mut component.fragment);
+
         (component, self.diagnostics)
     }
 
@@ -1191,6 +1194,74 @@ impl<'a> Parser<'a> {
                     *node = Node::SvelteHead(head);
                 }
             }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // <svelte:element> conversion
+    // -----------------------------------------------------------------------
+
+    /// Convert `<svelte:element this={expr}>` Element nodes to SvelteElement nodes.
+    /// Unlike svelte:head, these can appear anywhere in the tree, so we walk recursively.
+    fn convert_svelte_element(fragment: &mut Fragment) {
+        for node in &mut fragment.nodes {
+            match node {
+                Node::Element(el) if el.name == "svelte:element" => {
+                    let (tag_span, static_tag) = Self::extract_this_attribute(&mut el.attributes);
+                    let mut svelte_el = svelte_ast::SvelteElement {
+                        id: el.id,
+                        span: el.span,
+                        tag_span,
+                        static_tag,
+                        attributes: std::mem::take(&mut el.attributes),
+                        fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
+                    };
+                    Self::convert_svelte_element(&mut svelte_el.fragment);
+                    *node = Node::SvelteElement(svelte_el);
+                }
+                Node::Element(el) => Self::convert_svelte_element(&mut el.fragment),
+                Node::ComponentNode(cn) => Self::convert_svelte_element(&mut cn.fragment),
+                Node::IfBlock(block) => {
+                    Self::convert_svelte_element(&mut block.consequent);
+                    if let Some(alt) = &mut block.alternate {
+                        Self::convert_svelte_element(alt);
+                    }
+                }
+                Node::EachBlock(block) => {
+                    Self::convert_svelte_element(&mut block.body);
+                    if let Some(fallback) = &mut block.fallback {
+                        Self::convert_svelte_element(fallback);
+                    }
+                }
+                Node::SnippetBlock(block) => Self::convert_svelte_element(&mut block.body),
+                Node::KeyBlock(block) => Self::convert_svelte_element(&mut block.fragment),
+                Node::SvelteHead(head) => Self::convert_svelte_element(&mut head.fragment),
+                Node::SvelteElement(el) => Self::convert_svelte_element(&mut el.fragment),
+                _ => {}
+            }
+        }
+    }
+
+    /// Extract the `this` attribute from an attribute list, returning its expression span.
+    /// Removes the `this` attribute from the vec.
+    /// Returns (tag_span, is_static) — is_static is true for `this="literal"`.
+    fn extract_this_attribute(attributes: &mut Vec<svelte_ast::Attribute>) -> (Span, bool) {
+        let pos = attributes.iter().position(|attr| match attr {
+            svelte_ast::Attribute::ExpressionAttribute(a) => a.name == "this",
+            svelte_ast::Attribute::StringAttribute(a) => a.name == "this",
+            _ => false,
+        });
+
+        if let Some(idx) = pos {
+            let attr = attributes.remove(idx);
+            match attr {
+                svelte_ast::Attribute::ExpressionAttribute(a) => (a.expression_span, false),
+                svelte_ast::Attribute::StringAttribute(a) => (a.value_span, true),
+                _ => unreachable!(),
+            }
+        } else {
+            // Missing `this` attribute — use empty span as fallback
+            (Span::new(0, 0), false)
         }
     }
 }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -184,6 +184,16 @@ fn walk_node<'a>(
             walk_fragment(ctx, &head.fragment, component, parsed, scope, snippet_params);
             ctx.const_aliases.pop();
         }
+        Node::SvelteElement(el) => {
+            // Transform the tag expression (skip for static string tags)
+            if !el.static_tag {
+                transform_node_expr(ctx, el.id, parsed, scope, snippet_params);
+            }
+            transform_attrs(ctx, el.id, &el.attributes, parsed, scope, snippet_params);
+            ctx.const_aliases.push(FxHashMap::default());
+            walk_fragment(ctx, &el.fragment, component, parsed, scope, snippet_params);
+            ctx.const_aliases.pop();
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/benchmark/benches/compiler/big_v5.svelte
+++ b/tasks/benchmark/benches/compiler/big_v5.svelte
@@ -1,0 +1,2904 @@
+<script>
+    import { onMount } from "svelte";
+    import { fade, fly } from "svelte/transition";
+
+    let {
+        title = "Default Title",
+        count = 0,
+        items = [],
+        config = $bindable({}),
+        multiplier = 2,
+        ...rest
+    } = $props();
+
+    let state = $state("");
+    let counter = $state(0);
+
+    counter = 10;
+
+    let doubled = $derived(count * multiplier);
+
+    $effect(() => {
+        console.log("Title:", title, "Count:", count);
+    });
+
+    export const APP_VERSION = "1.0.0";
+
+    export function formatTitle(prefix) {
+        return prefix + ": " + title;
+    }
+
+    function action(node, arg) {
+        return { destroy() {} };
+    }
+</script>
+
+<svelte:head>
+    <meta name="description" content="Benchmark component">
+    <link rel="canonical" href="/benchmark">
+</svelte:head>
+
+{#snippet badge(text, variant)}
+    <span class="badge" class:primary={variant === "primary"} class:secondary={variant === "secondary"}>
+        {text}
+    </span>
+{/snippet}
+
+{#snippet card(heading, body)}
+    <div class="card">
+        <h3>{heading}</h3>
+        <p>{body}</p>
+        {@render badge("new", "primary")}
+    </div>
+{/snippet}
+
+<div>
+    Chunk 0: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 0.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 0.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 0.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-0">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-0">
+        Dynamic element chunk 0: {title}
+    </svelte:element>
+
+    {@render badge("chunk-0", "secondary")}
+    {@render card(title, "Content for chunk 0")}
+</div>
+
+<div>
+    Chunk 1: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 1.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 1.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 1.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-1">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-1">
+        Dynamic element chunk 1: {title}
+    </svelte:element>
+
+    {@render badge("chunk-1", "secondary")}
+    {@render card(title, "Content for chunk 1")}
+</div>
+
+<div>
+    Chunk 2: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 2.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 2.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 2.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-2">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-2">
+        Dynamic element chunk 2: {title}
+    </svelte:element>
+
+    {@render badge("chunk-2", "secondary")}
+    {@render card(title, "Content for chunk 2")}
+</div>
+
+<div>
+    Chunk 3: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 3.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 3.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 3.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-3">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-3">
+        Dynamic element chunk 3: {title}
+    </svelte:element>
+
+    {@render badge("chunk-3", "secondary")}
+    {@render card(title, "Content for chunk 3")}
+</div>
+
+<div>
+    Chunk 4: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 4.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 4.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 4.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-4">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-4">
+        Dynamic element chunk 4: {title}
+    </svelte:element>
+
+    {@render badge("chunk-4", "secondary")}
+    {@render card(title, "Content for chunk 4")}
+</div>
+
+<div>
+    Chunk 5: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 5.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 5.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 5.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-5">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-5">
+        Dynamic element chunk 5: {title}
+    </svelte:element>
+
+    {@render badge("chunk-5", "secondary")}
+    {@render card(title, "Content for chunk 5")}
+</div>
+
+<div>
+    Chunk 6: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 6.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 6.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 6.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-6">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-6">
+        Dynamic element chunk 6: {title}
+    </svelte:element>
+
+    {@render badge("chunk-6", "secondary")}
+    {@render card(title, "Content for chunk 6")}
+</div>
+
+<div>
+    Chunk 7: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 7.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 7.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 7.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-7">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-7">
+        Dynamic element chunk 7: {title}
+    </svelte:element>
+
+    {@render badge("chunk-7", "secondary")}
+    {@render card(title, "Content for chunk 7")}
+</div>
+
+<div>
+    Chunk 8: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 8.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 8.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 8.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-8">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-8">
+        Dynamic element chunk 8: {title}
+    </svelte:element>
+
+    {@render badge("chunk-8", "secondary")}
+    {@render card(title, "Content for chunk 8")}
+</div>
+
+<div>
+    Chunk 9: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 9.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 9.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 9.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-9">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-9">
+        Dynamic element chunk 9: {title}
+    </svelte:element>
+
+    {@render badge("chunk-9", "secondary")}
+    {@render card(title, "Content for chunk 9")}
+</div>
+
+<div>
+    Chunk 10: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 10.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 10.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 10.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-10">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-10">
+        Dynamic element chunk 10: {title}
+    </svelte:element>
+
+    {@render badge("chunk-10", "secondary")}
+    {@render card(title, "Content for chunk 10")}
+</div>
+
+<div>
+    Chunk 11: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 11.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 11.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 11.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-11">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-11">
+        Dynamic element chunk 11: {title}
+    </svelte:element>
+
+    {@render badge("chunk-11", "secondary")}
+    {@render card(title, "Content for chunk 11")}
+</div>
+
+<div>
+    Chunk 12: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 12.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 12.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 12.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-12">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-12">
+        Dynamic element chunk 12: {title}
+    </svelte:element>
+
+    {@render badge("chunk-12", "secondary")}
+    {@render card(title, "Content for chunk 12")}
+</div>
+
+<div>
+    Chunk 13: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 13.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 13.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 13.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-13">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-13">
+        Dynamic element chunk 13: {title}
+    </svelte:element>
+
+    {@render badge("chunk-13", "secondary")}
+    {@render card(title, "Content for chunk 13")}
+</div>
+
+<div>
+    Chunk 14: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 14.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 14.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 14.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-14">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-14">
+        Dynamic element chunk 14: {title}
+    </svelte:element>
+
+    {@render badge("chunk-14", "secondary")}
+    {@render card(title, "Content for chunk 14")}
+</div>
+
+<div>
+    Chunk 15: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 15.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 15.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 15.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-15">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-15">
+        Dynamic element chunk 15: {title}
+    </svelte:element>
+
+    {@render badge("chunk-15", "secondary")}
+    {@render card(title, "Content for chunk 15")}
+</div>
+
+<div>
+    Chunk 16: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 16.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 16.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 16.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-16">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-16">
+        Dynamic element chunk 16: {title}
+    </svelte:element>
+
+    {@render badge("chunk-16", "secondary")}
+    {@render card(title, "Content for chunk 16")}
+</div>
+
+<div>
+    Chunk 17: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 17.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 17.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 17.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-17">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-17">
+        Dynamic element chunk 17: {title}
+    </svelte:element>
+
+    {@render badge("chunk-17", "secondary")}
+    {@render card(title, "Content for chunk 17")}
+</div>
+
+<div>
+    Chunk 18: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 18.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 18.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 18.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-18">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-18">
+        Dynamic element chunk 18: {title}
+    </svelte:element>
+
+    {@render badge("chunk-18", "secondary")}
+    {@render card(title, "Content for chunk 18")}
+</div>
+
+<div>
+    Chunk 19: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 19.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 19.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 19.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-19">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-19">
+        Dynamic element chunk 19: {title}
+    </svelte:element>
+
+    {@render badge("chunk-19", "secondary")}
+    {@render card(title, "Content for chunk 19")}
+</div>
+
+<div>
+    Chunk 20: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 20.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 20.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 20.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-20">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-20">
+        Dynamic element chunk 20: {title}
+    </svelte:element>
+
+    {@render badge("chunk-20", "secondary")}
+    {@render card(title, "Content for chunk 20")}
+</div>
+
+<div>
+    Chunk 21: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 21.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 21.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 21.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-21">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-21">
+        Dynamic element chunk 21: {title}
+    </svelte:element>
+
+    {@render badge("chunk-21", "secondary")}
+    {@render card(title, "Content for chunk 21")}
+</div>
+
+<div>
+    Chunk 22: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 22.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 22.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 22.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-22">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-22">
+        Dynamic element chunk 22: {title}
+    </svelte:element>
+
+    {@render badge("chunk-22", "secondary")}
+    {@render card(title, "Content for chunk 22")}
+</div>
+
+<div>
+    Chunk 23: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 23.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 23.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 23.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-23">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-23">
+        Dynamic element chunk 23: {title}
+    </svelte:element>
+
+    {@render badge("chunk-23", "secondary")}
+    {@render card(title, "Content for chunk 23")}
+</div>
+
+<div>
+    Chunk 24: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 24.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 24.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 24.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-24">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-24">
+        Dynamic element chunk 24: {title}
+    </svelte:element>
+
+    {@render badge("chunk-24", "secondary")}
+    {@render card(title, "Content for chunk 24")}
+</div>
+
+<div>
+    Chunk 25: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 25.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 25.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 25.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-25">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-25">
+        Dynamic element chunk 25: {title}
+    </svelte:element>
+
+    {@render badge("chunk-25", "secondary")}
+    {@render card(title, "Content for chunk 25")}
+</div>
+
+<div>
+    Chunk 26: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 26.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 26.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 26.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-26">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-26">
+        Dynamic element chunk 26: {title}
+    </svelte:element>
+
+    {@render badge("chunk-26", "secondary")}
+    {@render card(title, "Content for chunk 26")}
+</div>
+
+<div>
+    Chunk 27: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 27.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 27.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 27.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-27">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-27">
+        Dynamic element chunk 27: {title}
+    </svelte:element>
+
+    {@render badge("chunk-27", "secondary")}
+    {@render card(title, "Content for chunk 27")}
+</div>
+
+<div>
+    Chunk 28: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 28.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 28.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 28.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-28">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-28">
+        Dynamic element chunk 28: {title}
+    </svelte:element>
+
+    {@render badge("chunk-28", "secondary")}
+    {@render card(title, "Content for chunk 28")}
+</div>
+
+<div>
+    Chunk 29: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 29.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 29.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 29.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-29">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-29">
+        Dynamic element chunk 29: {title}
+    </svelte:element>
+
+    {@render badge("chunk-29", "secondary")}
+    {@render card(title, "Content for chunk 29")}
+</div>
+
+<div>
+    Chunk 30: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 30.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 30.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 30.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-30">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-30">
+        Dynamic element chunk 30: {title}
+    </svelte:element>
+
+    {@render badge("chunk-30", "secondary")}
+    {@render card(title, "Content for chunk 30")}
+</div>
+
+<div>
+    Chunk 31: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 31.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 31.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 31.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-31">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-31">
+        Dynamic element chunk 31: {title}
+    </svelte:element>
+
+    {@render badge("chunk-31", "secondary")}
+    {@render card(title, "Content for chunk 31")}
+</div>
+
+<div>
+    Chunk 32: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 32.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 32.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 32.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-32">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-32">
+        Dynamic element chunk 32: {title}
+    </svelte:element>
+
+    {@render badge("chunk-32", "secondary")}
+    {@render card(title, "Content for chunk 32")}
+</div>
+
+<div>
+    Chunk 33: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 33.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 33.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 33.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-33">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-33">
+        Dynamic element chunk 33: {title}
+    </svelte:element>
+
+    {@render badge("chunk-33", "secondary")}
+    {@render card(title, "Content for chunk 33")}
+</div>
+
+<div>
+    Chunk 34: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 34.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 34.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 34.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-34">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-34">
+        Dynamic element chunk 34: {title}
+    </svelte:element>
+
+    {@render badge("chunk-34", "secondary")}
+    {@render card(title, "Content for chunk 34")}
+</div>
+
+<div>
+    Chunk 35: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 35.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 35.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 35.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-35">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-35">
+        Dynamic element chunk 35: {title}
+    </svelte:element>
+
+    {@render badge("chunk-35", "secondary")}
+    {@render card(title, "Content for chunk 35")}
+</div>
+
+<div>
+    Chunk 36: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 36.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 36.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 36.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-36">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-36">
+        Dynamic element chunk 36: {title}
+    </svelte:element>
+
+    {@render badge("chunk-36", "secondary")}
+    {@render card(title, "Content for chunk 36")}
+</div>
+
+<div>
+    Chunk 37: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 37.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 37.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 37.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-37">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-37">
+        Dynamic element chunk 37: {title}
+    </svelte:element>
+
+    {@render badge("chunk-37", "secondary")}
+    {@render card(title, "Content for chunk 37")}
+</div>
+
+<div>
+    Chunk 38: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 38.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 38.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 38.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-38">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-38">
+        Dynamic element chunk 38: {title}
+    </svelte:element>
+
+    {@render badge("chunk-38", "secondary")}
+    {@render card(title, "Content for chunk 38")}
+</div>
+
+<div>
+    Chunk 39: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 39.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 39.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 39.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-39">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-39">
+        Dynamic element chunk 39: {title}
+    </svelte:element>
+
+    {@render badge("chunk-39", "secondary")}
+    {@render card(title, "Content for chunk 39")}
+</div>
+
+<div>
+    Chunk 40: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 40.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 40.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 40.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-40">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-40">
+        Dynamic element chunk 40: {title}
+    </svelte:element>
+
+    {@render badge("chunk-40", "secondary")}
+    {@render card(title, "Content for chunk 40")}
+</div>
+
+<div>
+    Chunk 41: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 41.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 41.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 41.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-41">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-41">
+        Dynamic element chunk 41: {title}
+    </svelte:element>
+
+    {@render badge("chunk-41", "secondary")}
+    {@render card(title, "Content for chunk 41")}
+</div>
+
+<div>
+    Chunk 42: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 42.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 42.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 42.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-42">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-42">
+        Dynamic element chunk 42: {title}
+    </svelte:element>
+
+    {@render badge("chunk-42", "secondary")}
+    {@render card(title, "Content for chunk 42")}
+</div>
+
+<div>
+    Chunk 43: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 43.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 43.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 43.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-43">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-43">
+        Dynamic element chunk 43: {title}
+    </svelte:element>
+
+    {@render badge("chunk-43", "secondary")}
+    {@render card(title, "Content for chunk 43")}
+</div>
+
+<div>
+    Chunk 44: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 44.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 44.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 44.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-44">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-44">
+        Dynamic element chunk 44: {title}
+    </svelte:element>
+
+    {@render badge("chunk-44", "secondary")}
+    {@render card(title, "Content for chunk 44")}
+</div>
+
+<div>
+    Chunk 45: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 45.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 45.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 45.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-45">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-45">
+        Dynamic element chunk 45: {title}
+    </svelte:element>
+
+    {@render badge("chunk-45", "secondary")}
+    {@render card(title, "Content for chunk 45")}
+</div>
+
+<div>
+    Chunk 46: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 46.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 46.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 46.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-46">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-46">
+        Dynamic element chunk 46: {title}
+    </svelte:element>
+
+    {@render badge("chunk-46", "secondary")}
+    {@render card(title, "Content for chunk 46")}
+</div>
+
+<div>
+    Chunk 47: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 47.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 47.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 47.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-47">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-47">
+        Dynamic element chunk 47: {title}
+    </svelte:element>
+
+    {@render badge("chunk-47", "secondary")}
+    {@render card(title, "Content for chunk 47")}
+</div>
+
+<div>
+    Chunk 48: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 48.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 48.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 48.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-48">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-48">
+        Dynamic element chunk 48: {title}
+    </svelte:element>
+
+    {@render badge("chunk-48", "secondary")}
+    {@render card(title, "Content for chunk 48")}
+</div>
+
+<div>
+    Chunk 49: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}</p>
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+
+        {#if state}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum. Chunk 49.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Chunk 49.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 49.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#each items as item}
+        <p {...rest} data-index="chunk-49">{item}</p>
+    {/each}
+
+    <input bind:value={state} />
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+
+    <svelte:element this={state ? "div" : "span"} class="dynamic-49">
+        Dynamic element chunk 49: {title}
+    </svelte:element>
+
+    {@render badge("chunk-49", "secondary")}
+    {@render card(title, "Content for chunk 49")}
+</div>
+

--- a/tasks/compiler_tests/cases2/svelte_element_attributes/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_attributes/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	let myId = "foo";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		$.attribute_effect($$element, () => ({
+			class: "bar",
+			id: myId
+		}));
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_attributes/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_attributes/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	let myId = "foo";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		$.attribute_effect($$element, () => ({
+			class: "bar",
+			id: myId
+		}));
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_attributes/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_attributes/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let tag = $state("div");
+	let myId = $state("foo");
+</script>
+
+<svelte:element this={tag} class="bar" id={myId}>content</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_basic/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var text = $.text("Hello");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_basic/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var text = $.text("Hello");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_basic/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let tag = $state("div");
+</script>
+
+<svelte:element this={tag}>Hello</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_bind/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_bind/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	let el = $.state(void 0);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		$.bind_this($$element, ($$value) => $.set(el, $$value, true), () => $.get(el));
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_bind/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_bind/case-svelte.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	let el = $.state(void 0);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		$.bind_this($$element, ($$value) => $.set(el, $$value, true), () => $.get(el));
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_bind/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_bind/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let tag = $state("div");
+	let el = $state();
+</script>
+
+<svelte:element this={tag} bind:this={el}>content</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_children_expr/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_children_expr/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "p";
+	let name = "world";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var text = $.text();
+		text.nodeValue = "Hello world!";
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_children_expr/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_children_expr/case-svelte.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "p";
+	let name = "world";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var text = $.text();
+		text.nodeValue = "Hello world!";
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_children_expr/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_children_expr/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let tag = $state("p");
+	let name = $state("world");
+</script>
+
+<svelte:element this={tag}>Hello {name}!</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_null_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_null_tag/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = null;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_null_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_null_tag/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = null;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_null_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_null_tag/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let tag = $state(null);
+</script>
+
+<svelte:element this={tag}>content</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_onclick/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_onclick/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "button";
+	let count = $.state(0);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var event_handler = () => $.update(count);
+		$.attribute_effect($$element, () => ({ onclick: event_handler }));
+		var text = $.text("Click");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_onclick/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_onclick/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "button";
+	let count = $.state(0);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		var event_handler = () => $.update(count);
+		$.attribute_effect($$element, () => ({ onclick: event_handler }));
+		var text = $.text("Click");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_onclick/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_onclick/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let tag = $state("button");
+	let count = $state(0);
+</script>
+
+<svelte:element this={tag} onclick={() => count++}>Click</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_self_closing/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_self_closing/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "hr";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_self_closing/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_self_closing/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "hr";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_self_closing/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_self_closing/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let tag = $state("hr");
+</script>
+
+<svelte:element this={tag} />

--- a/tasks/compiler_tests/cases2/svelte_element_spread/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_spread/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	let props = $.proxy({
+		class: "foo",
+		id: "bar"
+	});
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		$.attribute_effect($$element, () => ({ ...props }));
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_spread/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_spread/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "div";
+	let props = $.proxy({
+		class: "foo",
+		id: "bar"
+	});
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, false, ($$element, $$anchor) => {
+		$.attribute_effect($$element, () => ({ ...props }));
+		var text = $.text("content");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_spread/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_spread/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let tag = $state("div");
+	let props = $state({ class: "foo", id: "bar" });
+</script>
+
+<svelte:element this={tag} {...props}>content</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_static_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_static_tag/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => "div", false, ($$element, $$anchor) => {
+		var text = $.text("Hello");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_static_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_static_tag/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => "div", false, ($$element, $$anchor) => {
+		var text = $.text("Hello");
+		$.append($$anchor, text);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_static_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_static_tag/case.svelte
@@ -1,0 +1,1 @@
+<svelte:element this="div">Hello</svelte:element>

--- a/tasks/compiler_tests/cases2/svelte_element_xmlns/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_element_xmlns/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "rect";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, true, ($$element, $$anchor) => {
+		$.attribute_effect($$element, () => ({
+			xmlns: "http://www.w3.org/2000/svg",
+			width: "100",
+			height: "100"
+		}));
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_xmlns/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_element_xmlns/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let tag = "rect";
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.element(node, () => tag, true, ($$element, $$anchor) => {
+		$.attribute_effect($$element, () => ({
+			xmlns: "http://www.w3.org/2000/svg",
+			width: "100",
+			height: "100"
+		}));
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/svelte_element_xmlns/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_element_xmlns/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let tag = $state("rect");
+</script>
+
+<svelte:element this={tag} xmlns="http://www.w3.org/2000/svg" width="100" height="100" />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -688,3 +688,53 @@ fn svelte_head_empty() {
 fn svelte_head_with_content() {
     assert_compiler("svelte_head_with_content");
 }
+
+#[rstest]
+fn svelte_element_basic() {
+    assert_compiler("svelte_element_basic");
+}
+
+#[rstest]
+fn svelte_element_self_closing() {
+    assert_compiler("svelte_element_self_closing");
+}
+
+#[rstest]
+fn svelte_element_static_tag() {
+    assert_compiler("svelte_element_static_tag");
+}
+
+#[rstest]
+fn svelte_element_attributes() {
+    assert_compiler("svelte_element_attributes");
+}
+
+#[rstest]
+fn svelte_element_spread() {
+    assert_compiler("svelte_element_spread");
+}
+
+#[rstest]
+fn svelte_element_onclick() {
+    assert_compiler("svelte_element_onclick");
+}
+
+#[rstest]
+fn svelte_element_bind() {
+    assert_compiler("svelte_element_bind");
+}
+
+#[rstest]
+fn svelte_element_null_tag() {
+    assert_compiler("svelte_element_null_tag");
+}
+
+#[rstest]
+fn svelte_element_xmlns() {
+    assert_compiler("svelte_element_xmlns");
+}
+
+#[rstest]
+fn svelte_element_children_expr() {
+    assert_compiler("svelte_element_children_expr");
+}

--- a/tasks/generate_benchmark/src/main.rs
+++ b/tasks/generate_benchmark/src/main.rs
@@ -154,6 +154,10 @@ fn write_chunk(out: &mut String, i: usize) {
     <div transition:fade>transition target</div>
     <div in:fly={{{{ y: 200 }}}} out:fade>in/out target</div>
 
+    <svelte:element this={{state ? "div" : "span"}} class="dynamic-{i}">
+        Dynamic element chunk {i}: {{title}}
+    </svelte:element>
+
     {{@render badge("chunk-{i}", "secondary")}}
     {{@render card(title, "Content for chunk {i}")}}
 </div>


### PR DESCRIPTION
Adds support for dynamic element tags via `<svelte:element this={expr}>`.
Generates `$.element(anchor, () => tag, is_svg, callback)` at runtime.

Key changes across all crates:
- AST: SvelteElement struct with tag_span, static_tag flag, attributes, fragment
- Parser: convert_svelte_element() recursively walks fragments, extracts `this` attr
- Analysis: FragmentKey::SvelteElementBody, FragmentItem::SvelteElement, reference
  resolution for bind directives on svelte:element, scope walking
- Transform: tag expression + attribute transforms with static_tag guard
- Codegen: gen_svelte_element() with spread attribute handling, SVG xmlns detection,
  event handler hoisting, bind:this with proxy flag for dynamic elements

Also fixes:
- collect_references now recurses into arrow function bodies (detects mutations
  like `count++` in `onclick={() => count++}`)
- process_attrs_spread skips empty attribute_effect when only bind directives remain
- Event handlers in spread attributes get stable identity via hoisted variables

10 test cases covering: basic, self-closing, static tag, attributes, spread,
onclick, bind:this, null tag, xmlns, children with expressions.

https://claude.ai/code/session_01XHLP33JyTa8uJdi9kgNgsq