### PR TITLE
Port <svelte:window> special element (Tier 5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,6 +77,7 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 ### Special elements
 - [x] `<svelte:options>` — compiler options tag (parser + validation)
 - [x] `<svelte:head>` — document head insertion
+- [x] `<svelte:window>` — window events (`on:`, `onscroll`), bindings (`scrollX/Y`, `innerWidth/Height`, `outerWidth/Height`, `online`, `devicePixelRatio`)
 
 ### Module compilation
 - [x] `compile_module()` entry point + `analyze_module()` + WASM export
@@ -190,22 +191,11 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - [ ] `svelte:element` with `class:` directives *(deferred)*
 - [ ] `svelte:element` with `style:` directives *(deferred)*
 
-### `<svelte:window>` — Window events & bindings
+### ~~`<svelte:window>` — Window events & bindings~~ ✅
 - **Phases**: P, A, T
-- **Codegen**: Events → `$.event($.window, ...)`. Bindings → see table below
+- **Codegen**: Events → `$.event($.window, ...)`. Bindings → `$.bind_window_scroll`, `$.bind_window_size`, `$.bind_online`, `$.bind_property`
 - **Constraint**: Top-level only, no children
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteWindow.js`
-
-| Binding | Runtime |
-|---------|---------|
-| `bind:scrollX` | `$.bind_window_scroll("x", get, set)` |
-| `bind:scrollY` | `$.bind_window_scroll("y", get, set)` |
-| `bind:innerWidth` | `$.bind_window_size("innerWidth", set)` |
-| `bind:innerHeight` | `$.bind_window_size("innerHeight", set)` |
-| `bind:outerWidth` | `$.bind_window_size("outerWidth", set)` |
-| `bind:outerHeight` | `$.bind_window_size("outerHeight", set)` |
-| `bind:online` | `$.bind_online(set)` |
-| `bind:devicePixelRatio` | `$.bind_window_size("devicePixelRatio", set)` |
 
 ### `<svelte:document>` — Document events & bindings
 - **Phases**: P, A, T
@@ -434,7 +424,6 @@ Items discovered during porting but not critical for the feature to work. Groupe
 
 ### Bind directives (Tier 3)
 - [ ] `bind:property={get, set}` — function bindings (Svelte 5)
-- [ ] Window bindings (`scrollX`, `scrollY`, `innerWidth`, etc.) — blocked on `<svelte:window>` (Tier 5)
 - [ ] Document bindings (`activeElement`, `fullscreenElement`, etc.) — blocked on `<svelte:document>` (Tier 5)
 
 ### `use:action` (Tier 4)
@@ -455,6 +444,12 @@ Items discovered during porting but not critical for the feature to work. Groupe
 ### `<svelte:options>` (Tier 5)
 - [ ] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties (expression span stored, analysis-phase parsing needed)
 - [ ] `namespace` affecting codegen: `$.from_svg()` / `$.from_mathml()` instead of `$.from_html()`
+
+### `<svelte:window>` (Tier 5)
+- [ ] Validation: only allowed at root level (not nested)
+- [ ] Validation: no children allowed (diagnostic)
+- [ ] Validation: no spread attributes, only event/bind directives
+- [ ] Validation: only one `<svelte:window>` per component
 
 ### `<svelte:head>` (Tier 5)
 - [ ] Validation: only allowed at root level
@@ -477,5 +472,5 @@ Items discovered during porting but not critical for the feature to work. Groupe
 
 ### `on:directive` legacy (Tier 10)
 - [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis
-- [ ] SvelteDocument/SvelteWindow/SvelteBody routing: events on special elements should go to `init` not `after_update`. Blocked on Tier 5
+- [ ] SvelteDocument/SvelteBody routing: events on special elements should go to `init` not `after_update`. Blocked on Tier 5
 - [ ] Dev-mode `$.apply()` wrapping for imported identifier handlers. Blocked on `dev` compiler option

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -57,6 +57,7 @@ fn lower_fragment(
             Node::SvelteElement(el) => {
                 lower_fragment(&el.fragment, FragmentKey::SvelteElementBody(el.id), component, data);
             }
+            Node::SvelteWindow(_) => {}
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
     }
@@ -76,7 +77,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
     let mut regular: Vec<&Node> = Vec::new();
     for node in &fragment.nodes {
         match node {
-            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::SvelteHead(_) | Node::Error(_) => continue,
+            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::SvelteHead(_) | Node::SvelteWindow(_) | Node::Error(_) => continue,
             _ => regular.push(node),
         }
     }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -216,6 +216,9 @@ fn walk_node<'a>(
             walk_attrs(alloc, &el.attributes, component, data, parsed, diags);
             walk_fragment(alloc, &el.fragment, component, data, parsed, diags);
         }
+        Node::SvelteWindow(w) => {
+            walk_attrs(alloc, &w.attributes, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::{ReferenceFlags as OxcReferenceFlags, ScopeId};
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
-    KeyBlock, NodeId, RenderTag, SvelteElement,
+    KeyBlock, NodeId, RenderTag, SvelteElement, SvelteWindow,
 };
 
 use crate::data::AnalysisData;
@@ -146,6 +146,20 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
         }
         // Walk attributes — resolve expression refs and bind directives
         for attr in &el.attributes {
+            resolve_attr_refs(attr.id(), scope, data);
+            if let Attribute::BindDirective(dir) = attr {
+                self.resolve_bind(dir, scope, data);
+            }
+        }
+    }
+
+    fn visit_svelte_window(
+        &mut self,
+        w: &SvelteWindow,
+        scope: ScopeId,
+        data: &mut AnalysisData,
+    ) {
+        for attr in &w.attributes {
             resolve_attr_refs(attr.id(), scope, data);
             if let Attribute::BindDirective(dir) = attr {
                 self.resolve_bind(dir, scope, data);

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -326,6 +326,7 @@ fn walk_template_scopes(
                     }
                 }
             }
+            Node::SvelteWindow(_) => {}
             Node::ExpressionTag(_) | Node::Text(_) | Node::Comment(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -2,7 +2,7 @@ use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
-    SvelteElement, TransitionDirective, UseDirective,
+    SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -29,6 +29,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -128,6 +129,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
                 visitor.visit_svelte_element(el, scope, data);
                 walk_template(&el.fragment, data, scope, visitor);
             }
+            Node::SvelteWindow(w) => {
+                visitor.visit_svelte_window(w, scope, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -169,6 +173,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_svelte_element(el, scope, data);)+
+        }
+        fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_svelte_window(w, scope, data);)+
         }
         fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_attribute(attr, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -125,6 +125,7 @@ impl_node_enum! {
     KeyBlock(KeyBlock)           => is_key_block / as_key_block,
     SvelteHead(SvelteHead)       => is_svelte_head / as_svelte_head,
     SvelteElement(SvelteElement) => is_svelte_element / as_svelte_element,
+    SvelteWindow(SvelteWindow)   => is_svelte_window / as_svelte_window,
     Error(ErrorNode)             => is_error / as_error,
 }
 
@@ -330,6 +331,17 @@ pub struct SvelteElement {
     pub tag_span: Span,
     /// True when `this="literal"` (StringAttribute) — tag is a static string, not a JS expression.
     pub static_tag: bool,
+    pub attributes: Vec<Attribute>,
+    pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteWindow — <svelte:window on:event={handler} bind:scrollY />
+// ---------------------------------------------------------------------------
+
+pub struct SvelteWindow {
+    pub id: NodeId,
+    pub span: Span,
     pub attributes: Vec<Attribute>,
     pub fragment: Fragment,
 }

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, ContentStrategy, FragmentKey, IdentGen, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteElement};
+use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteElement, SvelteWindow};
 use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 use svelte_transform::TransformData;
@@ -19,6 +19,7 @@ struct NodeIndex<'a> {
     render_tags: FxHashMap<NodeId, &'a RenderTag>,
     const_tags: FxHashMap<NodeId, &'a ConstTag>,
     svelte_elements: FxHashMap<NodeId, &'a SvelteElement>,
+    svelte_windows: FxHashMap<NodeId, &'a SvelteWindow>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -33,6 +34,7 @@ impl<'a> NodeIndex<'a> {
             render_tags: FxHashMap::default(),
             const_tags: FxHashMap::default(),
             svelte_elements: FxHashMap::default(),
+            svelte_windows: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -84,6 +86,9 @@ impl<'a> NodeIndex<'a> {
                 Node::SvelteElement(el) => {
                     self.svelte_elements.insert(el.id, el);
                     self.walk(&el.fragment);
+                }
+                Node::SvelteWindow(w) => {
+                    self.svelte_windows.insert(w.id, w);
                 }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
@@ -156,6 +161,7 @@ impl<'a> Ctx<'a> {
     pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock { self.get_node(&self.index.snippet_blocks, id, "snippet block") }
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag { self.get_node(&self.index.render_tags, id, "render tag") }
     pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.get_node(&self.index.svelte_elements, id, "svelte element") }
+    pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow { self.get_node(&self.index.svelte_windows, id, "svelte window") }
     fn get_node<T>(&self, map: &FxHashMap<NodeId, &'a T>, id: NodeId, label: &str) -> &'a T {
         map.get(&id).copied()
             .unwrap_or_else(|| panic!("{} {:?} not found in index", label, id))

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod render_tag;
 pub(crate) mod snippet;
 pub(crate) mod svelte_element;
 pub(crate) mod svelte_head;
+pub(crate) mod svelte_window;
 pub(crate) mod traverse;
 
 use oxc_ast::ast::Statement;
@@ -90,6 +91,14 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
     let mut body = Vec::new();
 
     emit_const_tags(ctx, key, &mut body);
+
+    // Generate svelte:window events/bindings — go to init (before template)
+    let svelte_window_ids: Vec<_> = ctx.component.fragment.nodes.iter()
+        .filter_map(|n| n.as_svelte_window().map(|w| w.id))
+        .collect();
+    for id in svelte_window_ids {
+        svelte_window::gen_svelte_window(ctx, id, &mut body);
+    }
 
     // Collect SvelteHead IDs — $.head() calls are generated after main template init
     let svelte_head_ids: Vec<_> = ctx.component.fragment.nodes.iter()

--- a/crates/svelte_codegen_client/src/template/svelte_window.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_window.rs
@@ -1,0 +1,213 @@
+//! SvelteWindow code generation — `<svelte:window on:event bind:prop />`.
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_ast::{Attribute, NodeId};
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::expression::get_attr_expr;
+
+/// Generate event listeners and bindings for `<svelte:window>`.
+///
+/// Events → `$.event(name, $.window, handler)` pushed to init.
+/// Bindings → `$.bind_window_scroll` / `$.bind_window_size` / `$.bind_online` / `$.bind_property`.
+pub(crate) fn gen_svelte_window<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let window = ctx.svelte_window(id);
+    let attrs: Vec<_> = window.attributes.clone();
+
+    for attr in &attrs {
+        match attr {
+            Attribute::OnDirectiveLegacy(od) => {
+                let attr_id = attr.id();
+                gen_legacy_event(ctx, od, attr_id, stmts);
+            }
+            Attribute::ExpressionAttribute(ea) => {
+                if let Some(event_name) = ea.name.strip_prefix("on") {
+                    let attr_id = attr.id();
+                    gen_event_attr(ctx, attr_id, event_name, stmts);
+                }
+            }
+            Attribute::BindDirective(bind) => {
+                gen_window_binding(ctx, bind, stmts);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Legacy `on:event` → `$.event("name", $.window, handler)`.
+fn gen_legacy_event<'a>(
+    ctx: &mut Ctx<'a>,
+    od: &svelte_ast::OnDirectiveLegacy,
+    attr_id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = if od.expression_span.is_none() {
+        // Bubble event
+        let bubble_call = ctx.b.static_member_expr(
+            ctx.b.rid_expr("$.bubble_event"),
+            "call",
+        );
+        let call = ctx.b.call_expr_callee(bubble_call, [
+            Arg::Expr(ctx.b.this_expr()),
+            Arg::Ident("$$props"),
+            Arg::Ident("$$arg"),
+        ]);
+        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
+    } else {
+        let expr = get_attr_expr(ctx, attr_id);
+        build_event_handler(ctx, expr)
+    };
+
+    let mut wrapped = handler;
+    for modifier in &[
+        "stopPropagation",
+        "stopImmediatePropagation",
+        "preventDefault",
+        "self",
+        "trusted",
+        "once",
+    ] {
+        if od.modifiers.iter().any(|m| m == modifier) {
+            let fn_name = format!("$.{}", modifier);
+            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
+        }
+    }
+
+    let capture = od.modifiers.iter().any(|m| m == "capture");
+    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
+        "passive" => Some(true),
+        "nonpassive" => Some(false),
+        _ => None,
+    });
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Str(od.name.clone()),
+        Arg::Ident("$.window"),
+        Arg::Expr(wrapped),
+    ];
+    if capture || passive.is_some() {
+        args.push(Arg::Bool(capture));
+    }
+    if let Some(p) = passive {
+        args.push(Arg::Bool(p));
+    }
+
+    stmts.push(ctx.b.call_stmt("$.event", args));
+}
+
+/// Svelte 5 event attribute `onscroll={handler}` → `$.event("scroll", $.window, handler)`.
+fn gen_event_attr<'a>(
+    ctx: &mut Ctx<'a>,
+    attr_id: NodeId,
+    event_name: &str,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = get_attr_expr(ctx, attr_id);
+
+    stmts.push(ctx.b.call_stmt("$.event", [
+        Arg::Str(event_name.to_string()),
+        Arg::Ident("$.window"),
+        Arg::Expr(handler),
+    ]));
+}
+
+/// Build event handler for legacy on:directive (non-dev mode).
+fn build_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
+    match &handler {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
+        Expression::Identifier(_) => handler,
+        _ => {
+            let apply = ctx.b.static_member_expr(handler, "apply");
+            let call = ctx.b.call_expr_callee(apply, [
+                Arg::Expr(ctx.b.this_expr()),
+                Arg::Ident("$$args"),
+            ]);
+            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
+        }
+    }
+}
+
+/// Generate window-specific bind directives.
+fn gen_window_binding<'a>(
+    ctx: &mut Ctx<'a>,
+    bind: &svelte_ast::BindDirective,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let var_name = if bind.shorthand {
+        bind.name.clone()
+    } else if let Some(span) = bind.expression_span {
+        ctx.component.source_text(span).trim().to_string()
+    } else {
+        return;
+    };
+
+    let build_getter = |ctx: &mut Ctx<'a>, var: &str| -> Expression<'a> {
+        let body = if ctx.is_mutable_rune(var) {
+            ctx.b.call_expr("$.get", [Arg::Ident(var)])
+        } else {
+            ctx.b.rid_expr(var)
+        };
+        ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
+    };
+
+    // Window binding setters use `$.set(var, $$value, true)` — the `true` prevents
+    // re-triggering reactivity within the binding's own effect.
+    let build_setter = |ctx: &mut Ctx<'a>, var: String| -> Expression<'a> {
+        let body = if ctx.is_mutable_rune(&var) {
+            ctx.b.call_expr("$.set", [
+                Arg::Ident(&var),
+                Arg::Ident("$$value"),
+                Arg::Bool(true),
+            ])
+        } else {
+            ctx.b.assign_expr(
+                crate::builder::AssignLeft::Ident(var),
+                crate::builder::AssignRight::Expr(ctx.b.rid_expr("$$value")),
+            )
+        };
+        ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+    };
+
+    let stmt = match bind.name.as_str() {
+        "scrollX" | "scrollY" => {
+            let axis = if bind.name == "scrollX" { "x" } else { "y" };
+            let getter = build_getter(ctx, &var_name);
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_window_scroll", [
+                Arg::Str(axis.to_string()),
+                Arg::Expr(getter),
+                Arg::Expr(setter),
+            ])
+        }
+        "innerWidth" | "innerHeight" | "outerWidth" | "outerHeight" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_window_size", [
+                Arg::Str(bind.name.clone()),
+                Arg::Expr(setter),
+            ])
+        }
+        "online" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_online", [Arg::Expr(setter)])
+        }
+        "devicePixelRatio" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("devicePixelRatio".to_string()),
+                Arg::Str("resize".to_string()),
+                Arg::Ident("$.window"),
+                Arg::Expr(setter),
+            ])
+        }
+        _ => return,
+    };
+
+    stmts.push(stmt);
+}

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -10,7 +10,7 @@ use svelte_ast::{
     CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
     KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute,
-    StyleDirective, StyleDirectiveValue, SvelteHead, SvelteOptions, Text, TransitionDirective,
+    StyleDirective, StyleDirectiveValue, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
     TransitionDirection, UseDirective,
 };
 
@@ -349,6 +349,9 @@ impl<'a> Parser<'a> {
 
         // Convert <svelte:head> elements to SvelteHead nodes
         Self::convert_svelte_head(&mut component);
+
+        // Convert <svelte:window> elements to SvelteWindow nodes
+        Self::convert_svelte_window(&mut component);
 
         // Convert <svelte:element> elements to SvelteElement nodes
         Self::convert_svelte_element(&mut component.fragment);
@@ -1205,6 +1208,23 @@ impl<'a> Parser<'a> {
                         fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
                     };
                     *node = Node::SvelteHead(head);
+                }
+            }
+        }
+    }
+
+    /// Convert `<svelte:window>` Element nodes in the root fragment to SvelteWindow nodes.
+    fn convert_svelte_window(component: &mut Component) {
+        for node in &mut component.fragment.nodes {
+            if let Node::Element(el) = node {
+                if el.name == "svelte:window" {
+                    let window = SvelteWindow {
+                        id: el.id,
+                        span: el.span,
+                        attributes: std::mem::take(&mut el.attributes),
+                        fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
+                    };
+                    *node = Node::SvelteWindow(window);
                 }
             }
         }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -174,6 +174,9 @@ fn walk_node<'a>(
                 walk_fragment(ctx, &el.fragment, component, parsed, scope);
             });
         }
+        Node::SvelteWindow(w) => {
+            transform_attrs(ctx, &w.attributes, parsed, scope);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/compiler_tests/cases2/svelte_window_bind_online/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_online/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let isOnline = $.state(true);
+	$.bind_online(($$value) => $.set(isOnline, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_bind_online/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_online/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let isOnline = $.state(true);
+	$.bind_online(($$value) => $.set(isOnline, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_bind_online/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_online/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let isOnline = $state(true);
+</script>
+
+<svelte:window bind:online={isOnline} />

--- a/tasks/compiler_tests/cases2/svelte_window_bind_scroll/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_scroll/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let scrollX = $.state(0);
+	let scrollY = $.state(0);
+	$.bind_window_scroll("x", () => $.get(scrollX), ($$value) => $.set(scrollX, $$value, true));
+	$.bind_window_scroll("y", () => $.get(scrollY), ($$value) => $.set(scrollY, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_bind_scroll/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_scroll/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let scrollX = $.state(0);
+	let scrollY = $.state(0);
+	$.bind_window_scroll("x", () => $.get(scrollX), ($$value) => $.set(scrollX, $$value, true));
+	$.bind_window_scroll("y", () => $.get(scrollY), ($$value) => $.set(scrollY, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_bind_scroll/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_scroll/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let scrollX = $state(0);
+	let scrollY = $state(0);
+</script>
+
+<svelte:window bind:scrollX bind:scrollY />

--- a/tasks/compiler_tests/cases2/svelte_window_bind_size/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_size/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let w = $.state(0);
+	let h = $.state(0);
+	$.bind_window_size("innerWidth", ($$value) => $.set(w, $$value, true));
+	$.bind_window_size("innerHeight", ($$value) => $.set(h, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_bind_size/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_size/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let w = $.state(0);
+	let h = $.state(0);
+	$.bind_window_size("innerWidth", ($$value) => $.set(w, $$value, true));
+	$.bind_window_size("innerHeight", ($$value) => $.set(h, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_bind_size/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_bind_size/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let w = $state(0);
+	let h = $state(0);
+</script>
+
+<svelte:window bind:innerWidth={w} bind:innerHeight={h} />

--- a/tasks/compiler_tests/cases2/svelte_window_combined/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_combined/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let scrollY = $.state(0);
+	function handleResize() {
+		console.log("resized");
+	}
+	$.event("resize", $.window, handleResize);
+	$.bind_window_scroll("y", () => $.get(scrollY), ($$value) => $.set(scrollY, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_combined/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_combined/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let scrollY = $.state(0);
+	function handleResize() {
+		console.log("resized");
+	}
+	$.event("resize", $.window, handleResize);
+	$.bind_window_scroll("y", () => $.get(scrollY), ($$value) => $.set(scrollY, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_combined/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_combined/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let scrollY = $state(0);
+
+	function handleResize() {
+		console.log('resized');
+	}
+</script>
+
+<svelte:window on:resize={handleResize} bind:scrollY />

--- a/tasks/compiler_tests/cases2/svelte_window_event_attr/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_event_attr/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleScroll() {
+		console.log("scrolled");
+	}
+	$.event("scroll", $.window, handleScroll);
+}

--- a/tasks/compiler_tests/cases2/svelte_window_event_attr/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_event_attr/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleScroll() {
+		console.log("scrolled");
+	}
+	$.event("scroll", $.window, handleScroll);
+}

--- a/tasks/compiler_tests/cases2/svelte_window_event_attr/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_event_attr/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleScroll() {
+		console.log('scrolled');
+	}
+</script>
+
+<svelte:window onscroll={handleScroll} />

--- a/tasks/compiler_tests/cases2/svelte_window_event_legacy/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_event_legacy/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleScroll() {
+		console.log("scrolled");
+	}
+	$.event("scroll", $.window, handleScroll);
+}

--- a/tasks/compiler_tests/cases2/svelte_window_event_legacy/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_event_legacy/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleScroll() {
+		console.log("scrolled");
+	}
+	$.event("scroll", $.window, handleScroll);
+}

--- a/tasks/compiler_tests/cases2/svelte_window_event_legacy/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_event_legacy/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleScroll() {
+		console.log('scrolled');
+	}
+</script>
+
+<svelte:window on:scroll={handleScroll} />

--- a/tasks/compiler_tests/cases2/svelte_window_reactive/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_window_reactive/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let innerWidth = $.state(0);
+	let innerHeight = $.state(0);
+	let outerWidth = $.state(0);
+	let outerHeight = $.state(0);
+	let devicePixelRatio = $.state(1);
+	$.bind_window_size("innerWidth", ($$value) => $.set(innerWidth, $$value, true));
+	$.bind_window_size("innerHeight", ($$value) => $.set(innerHeight, $$value, true));
+	$.bind_window_size("outerWidth", ($$value) => $.set(outerWidth, $$value, true));
+	$.bind_window_size("outerHeight", ($$value) => $.set(outerHeight, $$value, true));
+	$.bind_property("devicePixelRatio", "resize", $.window, ($$value) => $.set(devicePixelRatio, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_reactive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_window_reactive/case-svelte.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let innerWidth = $.state(0);
+	let innerHeight = $.state(0);
+	let outerWidth = $.state(0);
+	let outerHeight = $.state(0);
+	let devicePixelRatio = $.state(1);
+	$.bind_window_size("innerWidth", ($$value) => $.set(innerWidth, $$value, true));
+	$.bind_window_size("innerHeight", ($$value) => $.set(innerHeight, $$value, true));
+	$.bind_window_size("outerWidth", ($$value) => $.set(outerWidth, $$value, true));
+	$.bind_window_size("outerHeight", ($$value) => $.set(outerHeight, $$value, true));
+	$.bind_property("devicePixelRatio", "resize", $.window, ($$value) => $.set(devicePixelRatio, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_window_reactive/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_window_reactive/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let innerWidth = $state(0);
+	let innerHeight = $state(0);
+	let outerWidth = $state(0);
+	let outerHeight = $state(0);
+	let devicePixelRatio = $state(1);
+</script>
+
+<svelte:window bind:innerWidth bind:innerHeight bind:outerWidth bind:outerHeight bind:devicePixelRatio />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -689,6 +689,42 @@ fn svelte_head_with_content() {
     assert_compiler("svelte_head_with_content");
 }
 
+// svelte:window tests
+#[rstest]
+fn svelte_window_event_legacy() {
+    assert_compiler("svelte_window_event_legacy");
+}
+
+#[rstest]
+fn svelte_window_event_attr() {
+    assert_compiler("svelte_window_event_attr");
+}
+
+#[rstest]
+fn svelte_window_bind_scroll() {
+    assert_compiler("svelte_window_bind_scroll");
+}
+
+#[rstest]
+fn svelte_window_bind_size() {
+    assert_compiler("svelte_window_bind_size");
+}
+
+#[rstest]
+fn svelte_window_bind_online() {
+    assert_compiler("svelte_window_bind_online");
+}
+
+#[rstest]
+fn svelte_window_combined() {
+    assert_compiler("svelte_window_combined");
+}
+
+#[rstest]
+fn svelte_window_reactive() {
+    assert_compiler("svelte_window_reactive");
+}
+
 #[rstest]
 fn svelte_element_basic() {
     assert_compiler("svelte_element_basic");


### PR DESCRIPTION
Add full support for <svelte:window> events and bindings:
- AST: SvelteWindow node type with attributes and empty fragment
- Parser: convert_svelte_window() converts Element to SvelteWindow
- Analysis: walker, lower, scope, parse_js, resolve_references updates
- Codegen: new svelte_window.rs with event and binding generation
- Transform: walk SvelteWindow attributes for rune transforms

Events: legacy on:event and Svelte 5 onscroll={} both generate
$.event(name, $.window, handler) in init (parent-first).

Bindings: scrollX/Y → $.bind_window_scroll, innerWidth/Height/
outerWidth/Height → $.bind_window_size, online → $.bind_online,
devicePixelRatio → $.bind_property with resize event.

7 test cases, all 140 compiler tests passing.

https://claude.ai/code/session_01SsVhs5J7BpxNkGe91XvxaH