### PR TITLE
Port <svelte:document> — events and bindings (Tier 5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,6 +78,7 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 - [x] `<svelte:options>` — compiler options tag (parser + validation)
 - [x] `<svelte:head>` — document head insertion
 - [x] `<svelte:window>` — window events (`on:`, `onscroll`), bindings (`scrollX/Y`, `innerWidth/Height`, `outerWidth/Height`, `online`, `devicePixelRatio`)
+- [x] `<svelte:document>` — document events (`on:`, `onkeydown`), bindings (`activeElement`, `fullscreenElement`, `pointerLockElement`, `visibilityState`)
 
 ### Module compilation
 - [x] `compile_module()` entry point + `analyze_module()` + WASM export
@@ -197,17 +198,10 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - **Constraint**: Top-level only, no children
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteWindow.js`
 
-### `<svelte:document>` — Document events & bindings
+### ~~`<svelte:document>` — Document events & bindings~~ ✅
 - **Phases**: P, A, T
 - **Constraint**: Top-level only, no children
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteDocument.js`
-
-| Binding | Runtime |
-|---------|---------|
-| `bind:activeElement` | `$.bind_active_element(set)` |
-| `bind:fullscreenElement` | `$.bind_property(document, ...)` |
-| `bind:pointerLockElement` | `$.bind_property(document, ...)` |
-| `bind:visibilityState` | `$.bind_property(document, ...)` |
 
 ### `<svelte:body>` — Body events & actions
 - **Phases**: P, A, T
@@ -424,7 +418,6 @@ Items discovered during porting but not critical for the feature to work. Groupe
 
 ### Bind directives (Tier 3)
 - [ ] `bind:property={get, set}` — function bindings (Svelte 5)
-- [ ] Document bindings (`activeElement`, `fullscreenElement`, etc.) — blocked on `<svelte:document>` (Tier 5)
 
 ### `use:action` (Tier 4)
 - [ ] `use:action` with `await` expression (requires `run_after_blockers`)
@@ -450,6 +443,12 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: no children allowed (diagnostic)
 - [ ] Validation: no spread attributes, only event/bind directives
 - [ ] Validation: only one `<svelte:window>` per component
+
+### `<svelte:document>` (Tier 5)
+- [ ] Validation: only allowed at root level (not nested)
+- [ ] Validation: no children allowed (diagnostic)
+- [ ] Validation: no spread attributes, only event/bind directives
+- [ ] Validation: only one `<svelte:document>` per component
 
 ### `<svelte:head>` (Tier 5)
 - [ ] Validation: only allowed at root level

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -57,7 +57,7 @@ fn lower_fragment(
             Node::SvelteElement(el) => {
                 lower_fragment(&el.fragment, FragmentKey::SvelteElementBody(el.id), component, data);
             }
-            Node::SvelteWindow(_) => {}
+            Node::SvelteWindow(_) | Node::SvelteDocument(_) => {}
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
     }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -219,6 +219,9 @@ fn walk_node<'a>(
         Node::SvelteWindow(w) => {
             walk_attrs(alloc, &w.attributes, component, data, parsed, diags);
         }
+        Node::SvelteDocument(d) => {
+            walk_attrs(alloc, &d.attributes, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::{ReferenceFlags as OxcReferenceFlags, ScopeId};
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
-    KeyBlock, NodeId, RenderTag, SvelteElement, SvelteWindow,
+    KeyBlock, NodeId, RenderTag, SvelteDocument, SvelteElement, SvelteWindow,
 };
 
 use crate::data::AnalysisData;
@@ -160,6 +160,20 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
         data: &mut AnalysisData,
     ) {
         for attr in &w.attributes {
+            resolve_attr_refs(attr.id(), scope, data);
+            if let Attribute::BindDirective(dir) = attr {
+                self.resolve_bind(dir, scope, data);
+            }
+        }
+    }
+
+    fn visit_svelte_document(
+        &mut self,
+        doc: &SvelteDocument,
+        scope: ScopeId,
+        data: &mut AnalysisData,
+    ) {
+        for attr in &doc.attributes {
             resolve_attr_refs(attr.id(), scope, data);
             if let Attribute::BindDirective(dir) = attr {
                 self.resolve_bind(dir, scope, data);

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -326,7 +326,7 @@ fn walk_template_scopes(
                     }
                 }
             }
-            Node::SvelteWindow(_) => {}
+            Node::SvelteWindow(_) | Node::SvelteDocument(_) => {}
             Node::ExpressionTag(_) | Node::Text(_) | Node::Comment(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -2,7 +2,7 @@ use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
-    SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
+    SvelteDocument, SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -30,6 +30,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -132,6 +133,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
             Node::SvelteWindow(w) => {
                 visitor.visit_svelte_window(w, scope, data);
             }
+            Node::SvelteDocument(d) => {
+                visitor.visit_svelte_document(d, scope, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -176,6 +180,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_svelte_window(w, scope, data);)+
+        }
+        fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_svelte_document(doc, scope, data);)+
         }
         fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_attribute(attr, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -125,8 +125,9 @@ impl_node_enum! {
     KeyBlock(KeyBlock)           => is_key_block / as_key_block,
     SvelteHead(SvelteHead)       => is_svelte_head / as_svelte_head,
     SvelteElement(SvelteElement) => is_svelte_element / as_svelte_element,
-    SvelteWindow(SvelteWindow)   => is_svelte_window / as_svelte_window,
-    Error(ErrorNode)             => is_error / as_error,
+    SvelteWindow(SvelteWindow)       => is_svelte_window / as_svelte_window,
+    SvelteDocument(SvelteDocument)   => is_svelte_document / as_svelte_document,
+    Error(ErrorNode)                 => is_error / as_error,
 }
 
 pub struct ErrorNode {
@@ -340,6 +341,17 @@ pub struct SvelteElement {
 // ---------------------------------------------------------------------------
 
 pub struct SvelteWindow {
+    pub id: NodeId,
+    pub span: Span,
+    pub attributes: Vec<Attribute>,
+    pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteDocument — <svelte:document on:event={handler} bind:activeElement />
+// ---------------------------------------------------------------------------
+
+pub struct SvelteDocument {
     pub id: NodeId,
     pub span: Span,
     pub attributes: Vec<Attribute>,

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, ContentStrategy, FragmentKey, IdentGen, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteElement, SvelteWindow};
+use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteDocument, SvelteElement, SvelteWindow};
 use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 use svelte_transform::TransformData;
@@ -20,6 +20,7 @@ struct NodeIndex<'a> {
     const_tags: FxHashMap<NodeId, &'a ConstTag>,
     svelte_elements: FxHashMap<NodeId, &'a SvelteElement>,
     svelte_windows: FxHashMap<NodeId, &'a SvelteWindow>,
+    svelte_documents: FxHashMap<NodeId, &'a SvelteDocument>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -35,6 +36,7 @@ impl<'a> NodeIndex<'a> {
             const_tags: FxHashMap::default(),
             svelte_elements: FxHashMap::default(),
             svelte_windows: FxHashMap::default(),
+            svelte_documents: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -89,6 +91,9 @@ impl<'a> NodeIndex<'a> {
                 }
                 Node::SvelteWindow(w) => {
                     self.svelte_windows.insert(w.id, w);
+                }
+                Node::SvelteDocument(d) => {
+                    self.svelte_documents.insert(d.id, d);
                 }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
@@ -162,6 +167,7 @@ impl<'a> Ctx<'a> {
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag { self.get_node(&self.index.render_tags, id, "render tag") }
     pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.get_node(&self.index.svelte_elements, id, "svelte element") }
     pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow { self.get_node(&self.index.svelte_windows, id, "svelte window") }
+    pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument { self.get_node(&self.index.svelte_documents, id, "svelte document") }
     fn get_node<T>(&self, map: &FxHashMap<NodeId, &'a T>, id: NodeId, label: &str) -> &'a T {
         map.get(&id).copied()
             .unwrap_or_else(|| panic!("{} {:?} not found in index", label, id))

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{ExportDefaultDeclarationKind, Statement};
 use oxc_codegen::Codegen;
 
 use svelte_analyze::{AnalysisData, IdentGen, ParsedExprs};
-use svelte_ast::Component;
+use svelte_ast::{Attribute, Component, Node};
 use svelte_transform::TransformData;
 
 use builder::{Arg, Builder, ObjProp};
@@ -136,7 +136,19 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
 
     let import_svelte = b.import_all("$", "svelte/internal/client");
 
-    let fn_params = if ctx.analysis.props.is_some() || needs_push {
+    // Bubble events on special elements (on:event with no expression) reference $$props
+    let has_bubble_events = component.fragment.nodes.iter().any(|n| {
+        let attrs = match n {
+            Node::SvelteWindow(w) => Some(&w.attributes),
+            Node::SvelteDocument(d) => Some(&d.attributes),
+            _ => None,
+        };
+        attrs.is_some_and(|attrs| attrs.iter().any(|a| {
+            matches!(a, Attribute::OnDirectiveLegacy(od) if od.expression_span.is_none())
+        }))
+    });
+
+    let fn_params = if ctx.analysis.props.is_some() || needs_push || has_bubble_events {
         b.params(["$$anchor", "$$props"])
     } else {
         b.params(["$$anchor"])

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod key_block;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
 pub(crate) mod svelte_element;
+pub(crate) mod svelte_document;
 pub(crate) mod svelte_head;
 pub(crate) mod svelte_window;
 pub(crate) mod traverse;
@@ -98,6 +99,14 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
         .collect();
     for id in svelte_window_ids {
         svelte_window::gen_svelte_window(ctx, id, &mut body);
+    }
+
+    // Generate svelte:document events/bindings — go to init (before template)
+    let svelte_document_ids: Vec<_> = ctx.component.fragment.nodes.iter()
+        .filter_map(|n| n.as_svelte_document().map(|d| d.id))
+        .collect();
+    for id in svelte_document_ids {
+        svelte_document::gen_svelte_document(ctx, id, &mut body);
     }
 
     // Collect SvelteHead IDs — $.head() calls are generated after main template init

--- a/crates/svelte_codegen_client/src/template/svelte_document.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_document.rs
@@ -1,0 +1,205 @@
+//! SvelteDocument code generation — `<svelte:document on:event bind:prop />`.
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_ast::{Attribute, NodeId};
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::expression::get_attr_expr;
+
+/// Generate event listeners and bindings for `<svelte:document>`.
+///
+/// Events → `$.event(name, $.document, handler)` pushed to init.
+/// Bindings → `$.bind_active_element` / `$.bind_property`.
+pub(crate) fn gen_svelte_document<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let doc = ctx.svelte_document(id);
+    let attrs: Vec<_> = doc.attributes.clone();
+
+    for attr in &attrs {
+        match attr {
+            Attribute::OnDirectiveLegacy(od) => {
+                let attr_id = attr.id();
+                gen_legacy_event(ctx, od, attr_id, stmts);
+            }
+            Attribute::ExpressionAttribute(ea) => {
+                if let Some(event_name) = ea.name.strip_prefix("on") {
+                    let attr_id = attr.id();
+                    gen_event_attr(ctx, attr_id, event_name, stmts);
+                }
+            }
+            Attribute::BindDirective(bind) => {
+                gen_document_binding(ctx, bind, stmts);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Legacy `on:event` → `$.event("name", $.document, handler)`.
+fn gen_legacy_event<'a>(
+    ctx: &mut Ctx<'a>,
+    od: &svelte_ast::OnDirectiveLegacy,
+    attr_id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = if od.expression_span.is_none() {
+        // Bubble event
+        let bubble_call = ctx.b.static_member_expr(
+            ctx.b.rid_expr("$.bubble_event"),
+            "call",
+        );
+        let call = ctx.b.call_expr_callee(bubble_call, [
+            Arg::Expr(ctx.b.this_expr()),
+            Arg::Ident("$$props"),
+            Arg::Ident("$$arg"),
+        ]);
+        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
+    } else {
+        let expr = get_attr_expr(ctx, attr_id);
+        build_event_handler(ctx, expr)
+    };
+
+    let mut wrapped = handler;
+    for modifier in &[
+        "stopPropagation",
+        "stopImmediatePropagation",
+        "preventDefault",
+        "self",
+        "trusted",
+        "once",
+    ] {
+        if od.modifiers.iter().any(|m| m == modifier) {
+            let fn_name = format!("$.{}", modifier);
+            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
+        }
+    }
+
+    let capture = od.modifiers.iter().any(|m| m == "capture");
+    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
+        "passive" => Some(true),
+        "nonpassive" => Some(false),
+        _ => None,
+    });
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Str(od.name.clone()),
+        Arg::Ident("$.document"),
+        Arg::Expr(wrapped),
+    ];
+    if capture || passive.is_some() {
+        args.push(Arg::Bool(capture));
+    }
+    if let Some(p) = passive {
+        args.push(Arg::Bool(p));
+    }
+
+    stmts.push(ctx.b.call_stmt("$.event", args));
+}
+
+/// Svelte 5 event attribute `onkeydown={handler}` → `$.event("keydown", $.document, handler)`.
+fn gen_event_attr<'a>(
+    ctx: &mut Ctx<'a>,
+    attr_id: NodeId,
+    event_name: &str,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = get_attr_expr(ctx, attr_id);
+
+    stmts.push(ctx.b.call_stmt("$.event", [
+        Arg::Str(event_name.to_string()),
+        Arg::Ident("$.document"),
+        Arg::Expr(handler),
+    ]));
+}
+
+/// Build event handler for legacy on:directive (non-dev mode).
+fn build_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
+    match &handler {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
+        Expression::Identifier(_) => handler,
+        _ => {
+            let apply = ctx.b.static_member_expr(handler, "apply");
+            let call = ctx.b.call_expr_callee(apply, [
+                Arg::Expr(ctx.b.this_expr()),
+                Arg::Ident("$$args"),
+            ]);
+            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
+        }
+    }
+}
+
+/// Generate document-specific bind directives.
+fn gen_document_binding<'a>(
+    ctx: &mut Ctx<'a>,
+    bind: &svelte_ast::BindDirective,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let var_name = if bind.shorthand {
+        bind.name.clone()
+    } else if let Some(span) = bind.expression_span {
+        ctx.component.source_text(span).trim().to_string()
+    } else {
+        return;
+    };
+
+    // Document binding setters use `$.set(var, $$value, true)` — the `true` prevents
+    // re-triggering reactivity within the binding's own effect.
+    let build_setter = |ctx: &mut Ctx<'a>, var: String| -> Expression<'a> {
+        let body = if ctx.is_mutable_rune(&var) {
+            ctx.b.call_expr("$.set", [
+                Arg::Ident(&var),
+                Arg::Ident("$$value"),
+                Arg::Bool(true),
+            ])
+        } else {
+            ctx.b.assign_expr(
+                crate::builder::AssignLeft::Ident(var),
+                crate::builder::AssignRight::Expr(ctx.b.rid_expr("$$value")),
+            )
+        };
+        ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+    };
+
+    let stmt = match bind.name.as_str() {
+        "activeElement" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_active_element", [Arg::Expr(setter)])
+        }
+        "fullscreenElement" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("fullscreenElement".to_string()),
+                Arg::Str("fullscreenchange".to_string()),
+                Arg::Ident("$.document"),
+                Arg::Expr(setter),
+            ])
+        }
+        "pointerLockElement" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("pointerLockElement".to_string()),
+                Arg::Str("pointerlockchange".to_string()),
+                Arg::Ident("$.document"),
+                Arg::Expr(setter),
+            ])
+        }
+        "visibilityState" => {
+            let setter = build_setter(ctx, var_name);
+            ctx.b.call_stmt("$.bind_property", [
+                Arg::Str("visibilityState".to_string()),
+                Arg::Str("visibilitychange".to_string()),
+                Arg::Ident("$.document"),
+                Arg::Expr(setter),
+            ])
+        }
+        _ => return,
+    };
+
+    stmts.push(stmt);
+}

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -10,7 +10,7 @@ use svelte_ast::{
     CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
     KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute,
-    StyleDirective, StyleDirectiveValue, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
+    StyleDirective, StyleDirectiveValue, SvelteDocument, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
     TransitionDirection, UseDirective,
 };
 
@@ -352,6 +352,9 @@ impl<'a> Parser<'a> {
 
         // Convert <svelte:window> elements to SvelteWindow nodes
         Self::convert_svelte_window(&mut component);
+
+        // Convert <svelte:document> elements to SvelteDocument nodes
+        Self::convert_svelte_document(&mut component);
 
         // Convert <svelte:element> elements to SvelteElement nodes
         Self::convert_svelte_element(&mut component.fragment);
@@ -1225,6 +1228,23 @@ impl<'a> Parser<'a> {
                         fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
                     };
                     *node = Node::SvelteWindow(window);
+                }
+            }
+        }
+    }
+
+    /// Convert `<svelte:document>` Element nodes in the root fragment to SvelteDocument nodes.
+    fn convert_svelte_document(component: &mut Component) {
+        for node in &mut component.fragment.nodes {
+            if let Node::Element(el) = node {
+                if el.name == "svelte:document" {
+                    let doc = SvelteDocument {
+                        id: el.id,
+                        span: el.span,
+                        attributes: std::mem::take(&mut el.attributes),
+                        fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
+                    };
+                    *node = Node::SvelteDocument(doc);
                 }
             }
         }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -177,6 +177,9 @@ fn walk_node<'a>(
         Node::SvelteWindow(w) => {
             transform_attrs(ctx, &w.attributes, parsed, scope);
         }
+        Node::SvelteDocument(d) => {
+            transform_attrs(ctx, &d.attributes, parsed, scope);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/compiler_tests/cases2/svelte_document_bind_active_element/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_active_element/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	$.bind_active_element(($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_active_element/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_active_element/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	$.bind_active_element(($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_active_element/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_active_element/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let el = $state(null);
+</script>
+
+<svelte:document bind:activeElement={el} />

--- a/tasks/compiler_tests/cases2/svelte_document_bind_fullscreen/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_fullscreen/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	$.bind_property("fullscreenElement", "fullscreenchange", $.document, ($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_fullscreen/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_fullscreen/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	$.bind_property("fullscreenElement", "fullscreenchange", $.document, ($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_fullscreen/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_fullscreen/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let el = $state(null);
+</script>
+
+<svelte:document bind:fullscreenElement={el} />

--- a/tasks/compiler_tests/cases2/svelte_document_bind_pointer_lock/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_pointer_lock/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	$.bind_property("pointerLockElement", "pointerlockchange", $.document, ($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_pointer_lock/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_pointer_lock/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	$.bind_property("pointerLockElement", "pointerlockchange", $.document, ($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_pointer_lock/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_pointer_lock/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let el = $state(null);
+</script>
+
+<svelte:document bind:pointerLockElement={el} />

--- a/tasks/compiler_tests/cases2/svelte_document_bind_visibility/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_visibility/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let state = $.state("visible");
+	$.bind_property("visibilityState", "visibilitychange", $.document, ($$value) => $.set(state, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_visibility/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_visibility/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let state = $.state("visible");
+	$.bind_property("visibilityState", "visibilitychange", $.document, ($$value) => $.set(state, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bind_visibility/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_bind_visibility/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let state = $state('visible');
+</script>
+
+<svelte:document bind:visibilityState={state} />

--- a/tasks/compiler_tests/cases2/svelte_document_bubble/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bubble/case-rust.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	$.event("keydown", $.document, function($$arg) {
+		$.bubble_event.call(this, $$props, $$arg);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bubble/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_bubble/case-svelte.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	$.event("keydown", $.document, function($$arg) {
+		$.bubble_event.call(this, $$props, $$arg);
+	});
+}

--- a/tasks/compiler_tests/cases2/svelte_document_bubble/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_bubble/case.svelte
@@ -1,0 +1,1 @@
+<svelte:document on:keydown />

--- a/tasks/compiler_tests/cases2/svelte_document_combined/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_combined/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, handleKeydown);
+	$.bind_active_element(($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_combined/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_combined/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let el = $.state(null);
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, handleKeydown);
+	$.bind_active_element(($$value) => $.set(el, $$value, true));
+}

--- a/tasks/compiler_tests/cases2/svelte_document_combined/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_combined/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let el = $state(null);
+
+	function handleKeydown(e) {
+		console.log('keydown', e.key);
+	}
+</script>
+
+<svelte:document on:keydown={handleKeydown} bind:activeElement={el} />

--- a/tasks/compiler_tests/cases2/svelte_document_event_attr/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_event_attr/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, handleKeydown);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_event_attr/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_event_attr/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, handleKeydown);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_event_attr/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_event_attr/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleKeydown(e) {
+		console.log('keydown', e.key);
+	}
+</script>
+
+<svelte:document onkeydown={handleKeydown} />

--- a/tasks/compiler_tests/cases2/svelte_document_event_legacy/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_event_legacy/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, handleKeydown);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_event_legacy/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_event_legacy/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, handleKeydown);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_event_legacy/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_event_legacy/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleKeydown(e) {
+		console.log('keydown', e.key);
+	}
+</script>
+
+<svelte:document on:keydown={handleKeydown} />

--- a/tasks/compiler_tests/cases2/svelte_document_event_modifiers/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_event_modifiers/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, $.once(handleKeydown), true);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_event_modifiers/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_event_modifiers/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown", e.key);
+	}
+	$.event("keydown", $.document, $.once(handleKeydown), true);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_event_modifiers/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_event_modifiers/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleKeydown(e) {
+		console.log('keydown', e.key);
+	}
+</script>
+
+<svelte:document on:keydown|capture|once={handleKeydown} />

--- a/tasks/compiler_tests/cases2/svelte_document_multiple_events/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_document_multiple_events/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown");
+	}
+	function handleKeyup(e) {
+		console.log("keyup");
+	}
+	$.event("keydown", $.document, handleKeydown);
+	$.event("keyup", $.document, handleKeyup);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_multiple_events/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_document_multiple_events/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleKeydown(e) {
+		console.log("keydown");
+	}
+	function handleKeyup(e) {
+		console.log("keyup");
+	}
+	$.event("keydown", $.document, handleKeydown);
+	$.event("keyup", $.document, handleKeyup);
+}

--- a/tasks/compiler_tests/cases2/svelte_document_multiple_events/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_document_multiple_events/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	function handleKeydown(e) {
+		console.log('keydown');
+	}
+	function handleKeyup(e) {
+		console.log('keyup');
+	}
+</script>
+
+<svelte:document on:keydown={handleKeydown} on:keyup={handleKeyup} />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -726,6 +726,56 @@ fn svelte_window_reactive() {
 }
 
 #[rstest]
+fn svelte_document_event_legacy() {
+    assert_compiler("svelte_document_event_legacy");
+}
+
+#[rstest]
+fn svelte_document_event_attr() {
+    assert_compiler("svelte_document_event_attr");
+}
+
+#[rstest]
+fn svelte_document_event_modifiers() {
+    assert_compiler("svelte_document_event_modifiers");
+}
+
+#[rstest]
+fn svelte_document_multiple_events() {
+    assert_compiler("svelte_document_multiple_events");
+}
+
+#[rstest]
+fn svelte_document_bubble() {
+    assert_compiler("svelte_document_bubble");
+}
+
+#[rstest]
+fn svelte_document_bind_active_element() {
+    assert_compiler("svelte_document_bind_active_element");
+}
+
+#[rstest]
+fn svelte_document_bind_fullscreen() {
+    assert_compiler("svelte_document_bind_fullscreen");
+}
+
+#[rstest]
+fn svelte_document_bind_visibility() {
+    assert_compiler("svelte_document_bind_visibility");
+}
+
+#[rstest]
+fn svelte_document_bind_pointer_lock() {
+    assert_compiler("svelte_document_bind_pointer_lock");
+}
+
+#[rstest]
+fn svelte_document_combined() {
+    assert_compiler("svelte_document_combined");
+}
+
+#[rstest]
 fn svelte_element_basic() {
     assert_compiler("svelte_element_basic");
 }


### PR DESCRIPTION
Add full support for <svelte:document> special element:
- AST: SvelteDocument struct (attributes + fragment)
- Parser: convert_svelte_document() for root-level elements
- Analysis: walker visitor, resolve_references for bind mutations
- Codegen: events (legacy on:, Svelte 5 attrs, modifiers, bubble)
  and bindings (activeElement, fullscreenElement, pointerLockElement,
  visibilityState)
- 10 test cases covering all use cases

Also fixes $$props parameter detection for bubble events on special
elements (svelte:window, svelte:document).

https://claude.ai/code/session_01X4AiHjkCT3Eg9R15Ej3oPP