### PR TITLE
Port <svelte:body> — events and actions (Tier 5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,7 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 - [x] `<svelte:head>` — document head insertion
 - [x] `<svelte:window>` — window events (`on:`, `onscroll`), bindings (`scrollX/Y`, `innerWidth/Height`, `outerWidth/Height`, `online`, `devicePixelRatio`)
 - [x] `<svelte:document>` — document events (`on:`, `onkeydown`), bindings (`activeElement`, `fullscreenElement`, `pointerLockElement`, `visibilityState`)
+- [x] `<svelte:body>` — body events (`on:`, `onclick`), actions (`use:action`)
 
 ### Module compilation
 - [x] `compile_module()` entry point + `analyze_module()` + WASM export
@@ -203,12 +204,10 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - **Constraint**: Top-level only, no children
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteDocument.js`
 
-### `<svelte:body>` — Body events & actions
+### ~~`<svelte:body>` — Body events & actions~~ ✅
 - **Phases**: P, A, T
-- **Codegen**: Events → `$.event($.body, ...)`. Supports `use:action`.
+- **Codegen**: Events → `$.event($.document.body, ...)`. Supports `use:action`.
 - **Constraint**: Top-level only, no children
-- **Deps**: `use:action` (done)
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteBody.js`
 
 ### `<svelte:boundary>` — Error boundary (Svelte 5.3+)
 - **Phases**: P, A, T
@@ -468,6 +467,12 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] HMR support — `$.hmr()` wrapper, `import.meta.hot.accept()`
 - [ ] `fragments: 'tree'` option — alternative DOM fragment strategy
 - [ ] `{await expr}` experimental template syntax (Svelte 5.36+, requires `experimental.async`)
+
+### `<svelte:body>` (Tier 5)
+- [ ] Validation: only event attributes and directives allowed (reject non-event attrs, spreads)
+- [ ] Validation: no children allowed (`disallow_children`)
+- [ ] Validation: only allowed at root level (not nested)
+- [ ] Validation: only one `<svelte:body>` per component
 
 ### `on:directive` legacy (Tier 10)
 - [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -57,7 +57,7 @@ fn lower_fragment(
             Node::SvelteElement(el) => {
                 lower_fragment(&el.fragment, FragmentKey::SvelteElementBody(el.id), component, data);
             }
-            Node::SvelteWindow(_) | Node::SvelteDocument(_) => {}
+            Node::SvelteWindow(_) | Node::SvelteDocument(_) | Node::SvelteBody(_) => {}
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
     }
@@ -77,7 +77,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
     let mut regular: Vec<&Node> = Vec::new();
     for node in &fragment.nodes {
         match node {
-            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::SvelteHead(_) | Node::SvelteWindow(_) | Node::Error(_) => continue,
+            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::SvelteHead(_) | Node::SvelteWindow(_) | Node::SvelteBody(_) | Node::Error(_) => continue,
             _ => regular.push(node),
         }
     }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -222,6 +222,9 @@ fn walk_node<'a>(
         Node::SvelteDocument(d) => {
             walk_attrs(alloc, &d.attributes, component, data, parsed, diags);
         }
+        Node::SvelteBody(b) => {
+            walk_attrs(alloc, &b.attributes, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::{ReferenceFlags as OxcReferenceFlags, ScopeId};
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
-    KeyBlock, NodeId, RenderTag, SvelteDocument, SvelteElement, SvelteWindow,
+    KeyBlock, NodeId, RenderTag, SvelteBody, SvelteDocument, SvelteElement, SvelteWindow,
 };
 
 use crate::data::AnalysisData;
@@ -178,6 +178,17 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
             if let Attribute::BindDirective(dir) = attr {
                 self.resolve_bind(dir, scope, data);
             }
+        }
+    }
+
+    fn visit_svelte_body(
+        &mut self,
+        body: &SvelteBody,
+        scope: ScopeId,
+        data: &mut AnalysisData,
+    ) {
+        for attr in &body.attributes {
+            resolve_attr_refs(attr.id(), scope, data);
         }
     }
 }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -326,7 +326,7 @@ fn walk_template_scopes(
                     }
                 }
             }
-            Node::SvelteWindow(_) | Node::SvelteDocument(_) => {}
+            Node::SvelteWindow(_) | Node::SvelteDocument(_) | Node::SvelteBody(_) => {}
             Node::ExpressionTag(_) | Node::Text(_) | Node::Comment(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::Error(_) => {}
         }
     }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -2,7 +2,7 @@ use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
-    SvelteDocument, SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
+    SvelteBody, SvelteDocument, SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -31,6 +31,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -136,6 +137,9 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
             Node::SvelteDocument(d) => {
                 visitor.visit_svelte_document(d, scope, data);
             }
+            Node::SvelteBody(b) => {
+                visitor.visit_svelte_body(b, scope, data);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -183,6 +187,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_svelte_document(doc, scope, data);)+
+        }
+        fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_svelte_body(body, scope, data);)+
         }
         fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_attribute(attr, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -127,6 +127,7 @@ impl_node_enum! {
     SvelteElement(SvelteElement) => is_svelte_element / as_svelte_element,
     SvelteWindow(SvelteWindow)       => is_svelte_window / as_svelte_window,
     SvelteDocument(SvelteDocument)   => is_svelte_document / as_svelte_document,
+    SvelteBody(SvelteBody)           => is_svelte_body / as_svelte_body,
     Error(ErrorNode)                 => is_error / as_error,
 }
 
@@ -352,6 +353,17 @@ pub struct SvelteWindow {
 // ---------------------------------------------------------------------------
 
 pub struct SvelteDocument {
+    pub id: NodeId,
+    pub span: Span,
+    pub attributes: Vec<Attribute>,
+    pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteBody — <svelte:body onclick={handler} use:action />
+// ---------------------------------------------------------------------------
+
+pub struct SvelteBody {
     pub id: NodeId,
     pub span: Span,
     pub attributes: Vec<Attribute>,

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, ContentStrategy, FragmentKey, IdentGen, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteDocument, SvelteElement, SvelteWindow};
+use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteDocument, SvelteElement, SvelteWindow};
 use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 use svelte_transform::TransformData;
@@ -21,6 +21,7 @@ struct NodeIndex<'a> {
     svelte_elements: FxHashMap<NodeId, &'a SvelteElement>,
     svelte_windows: FxHashMap<NodeId, &'a SvelteWindow>,
     svelte_documents: FxHashMap<NodeId, &'a SvelteDocument>,
+    svelte_bodies: FxHashMap<NodeId, &'a SvelteBody>,
     expr_spans: FxHashMap<NodeId, Span>,
 }
 
@@ -37,6 +38,7 @@ impl<'a> NodeIndex<'a> {
             svelte_elements: FxHashMap::default(),
             svelte_windows: FxHashMap::default(),
             svelte_documents: FxHashMap::default(),
+            svelte_bodies: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
         };
         index.walk(fragment);
@@ -94,6 +96,9 @@ impl<'a> NodeIndex<'a> {
                 }
                 Node::SvelteDocument(d) => {
                     self.svelte_documents.insert(d.id, d);
+                }
+                Node::SvelteBody(b) => {
+                    self.svelte_bodies.insert(b.id, b);
                 }
                 Node::ExpressionTag(t) => {
                     self.expr_spans.insert(t.id, t.expression_span);
@@ -168,6 +173,7 @@ impl<'a> Ctx<'a> {
     pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.get_node(&self.index.svelte_elements, id, "svelte element") }
     pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow { self.get_node(&self.index.svelte_windows, id, "svelte window") }
     pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument { self.get_node(&self.index.svelte_documents, id, "svelte document") }
+    pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody { self.get_node(&self.index.svelte_bodies, id, "svelte body") }
     fn get_node<T>(&self, map: &FxHashMap<NodeId, &'a T>, id: NodeId, label: &str) -> &'a T {
         map.get(&id).copied()
             .unwrap_or_else(|| panic!("{} {:?} not found in index", label, id))

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -757,6 +757,17 @@ pub(crate) fn process_attrs_spread<'a>(
 // use:action directive codegen
 // ---------------------------------------------------------------------------
 
+/// Generate `$.action(target, ...)` for `use:action` on special elements (svelte:body, etc.).
+pub(crate) fn gen_use_directive_on<'a>(
+    ctx: &mut Ctx<'a>,
+    ud: &svelte_ast::UseDirective,
+    attr_id: NodeId,
+    el_name: &str,
+    init: &mut Vec<Statement<'a>>,
+) {
+    gen_use_directive(ctx, ud, attr_id, el_name, init);
+}
+
 /// Generate `$.action(el, ($$node) => name?.($$node), () => expr)`.
 /// Reference: `UseDirective.js`.
 fn gen_use_directive<'a>(

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod key_block;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
 pub(crate) mod svelte_element;
+pub(crate) mod svelte_body;
 pub(crate) mod svelte_document;
 pub(crate) mod svelte_head;
 pub(crate) mod svelte_window;
@@ -107,6 +108,14 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
         .collect();
     for id in svelte_document_ids {
         svelte_document::gen_svelte_document(ctx, id, &mut body);
+    }
+
+    // Generate svelte:body events/actions — go to init (before template)
+    let svelte_body_ids: Vec<_> = ctx.component.fragment.nodes.iter()
+        .filter_map(|n| n.as_svelte_body().map(|b| b.id))
+        .collect();
+    for id in svelte_body_ids {
+        svelte_body::gen_svelte_body(ctx, id, &mut body);
     }
 
     // Collect SvelteHead IDs — $.head() calls are generated after main template init

--- a/crates/svelte_codegen_client/src/template/svelte_body.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_body.rs
@@ -1,0 +1,137 @@
+//! SvelteBody code generation — `<svelte:body onclick={handler} use:action />`.
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_ast::{Attribute, NodeId};
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::attributes::gen_use_directive_on;
+use super::expression::get_attr_expr;
+
+/// Generate event listeners and actions for `<svelte:body>`.
+///
+/// Events → `$.event(name, $.document.body, handler)` pushed to init.
+/// Actions → `$.action($.document.body, handler, thunk)`.
+pub(crate) fn gen_svelte_body<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let body = ctx.svelte_body(id);
+    let attrs: Vec<_> = body.attributes.clone();
+
+    for attr in &attrs {
+        match attr {
+            Attribute::OnDirectiveLegacy(od) => {
+                let attr_id = attr.id();
+                gen_legacy_event(ctx, od, attr_id, stmts);
+            }
+            Attribute::ExpressionAttribute(ea) => {
+                if let Some(event_name) = ea.name.strip_prefix("on") {
+                    let attr_id = attr.id();
+                    gen_event_attr(ctx, attr_id, event_name, stmts);
+                }
+            }
+            Attribute::UseDirective(ud) => {
+                let attr_id = attr.id();
+                gen_use_directive_on(ctx, ud, attr_id, "$.document.body", stmts);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Legacy `on:event` → `$.event("name", $.document.body, handler)`.
+fn gen_legacy_event<'a>(
+    ctx: &mut Ctx<'a>,
+    od: &svelte_ast::OnDirectiveLegacy,
+    attr_id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = if od.expression_span.is_none() {
+        // Bubble event
+        let bubble_call = ctx.b.static_member_expr(
+            ctx.b.rid_expr("$.bubble_event"),
+            "call",
+        );
+        let call = ctx.b.call_expr_callee(bubble_call, [
+            Arg::Expr(ctx.b.this_expr()),
+            Arg::Ident("$$props"),
+            Arg::Ident("$$arg"),
+        ]);
+        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
+    } else {
+        let expr = get_attr_expr(ctx, attr_id);
+        build_event_handler(ctx, expr)
+    };
+
+    let mut wrapped = handler;
+    for modifier in &[
+        "stopPropagation",
+        "stopImmediatePropagation",
+        "preventDefault",
+        "self",
+        "trusted",
+        "once",
+    ] {
+        if od.modifiers.iter().any(|m| m == modifier) {
+            let fn_name = format!("$.{}", modifier);
+            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
+        }
+    }
+
+    let capture = od.modifiers.iter().any(|m| m == "capture");
+    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
+        "passive" => Some(true),
+        "nonpassive" => Some(false),
+        _ => None,
+    });
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Str(od.name.clone()),
+        Arg::Ident("$.document.body"),
+        Arg::Expr(wrapped),
+    ];
+    if capture || passive.is_some() {
+        args.push(Arg::Bool(capture));
+    }
+    if let Some(p) = passive {
+        args.push(Arg::Bool(p));
+    }
+
+    stmts.push(ctx.b.call_stmt("$.event", args));
+}
+
+/// Svelte 5 event attribute `onclick={handler}` → `$.event("click", $.document.body, handler)`.
+fn gen_event_attr<'a>(
+    ctx: &mut Ctx<'a>,
+    attr_id: NodeId,
+    event_name: &str,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = get_attr_expr(ctx, attr_id);
+
+    stmts.push(ctx.b.call_stmt("$.event", [
+        Arg::Str(event_name.to_string()),
+        Arg::Ident("$.document.body"),
+        Arg::Expr(handler),
+    ]));
+}
+
+/// Build event handler for legacy on:directive (non-dev mode).
+fn build_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
+    match &handler {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
+        Expression::Identifier(_) => handler,
+        _ => {
+            let apply = ctx.b.static_member_expr(handler, "apply");
+            let call = ctx.b.call_expr_callee(apply, [
+                Arg::Expr(ctx.b.this_expr()),
+                Arg::Ident("$$args"),
+            ]);
+            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
+        }
+    }
+}

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -10,7 +10,7 @@ use svelte_ast::{
     CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
     KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute,
-    StyleDirective, StyleDirectiveValue, SvelteDocument, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
+    StyleDirective, StyleDirectiveValue, SvelteBody, SvelteDocument, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
     TransitionDirection, UseDirective,
 };
 
@@ -355,6 +355,9 @@ impl<'a> Parser<'a> {
 
         // Convert <svelte:document> elements to SvelteDocument nodes
         Self::convert_svelte_document(&mut component);
+
+        // Convert <svelte:body> elements to SvelteBody nodes
+        Self::convert_svelte_body(&mut component);
 
         // Convert <svelte:element> elements to SvelteElement nodes
         Self::convert_svelte_element(&mut component.fragment);
@@ -1245,6 +1248,23 @@ impl<'a> Parser<'a> {
                         fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
                     };
                     *node = Node::SvelteDocument(doc);
+                }
+            }
+        }
+    }
+
+    /// Convert `<svelte:body>` Element nodes in the root fragment to SvelteBody nodes.
+    fn convert_svelte_body(component: &mut Component) {
+        for node in &mut component.fragment.nodes {
+            if let Node::Element(el) = node {
+                if el.name == "svelte:body" {
+                    let body = SvelteBody {
+                        id: el.id,
+                        span: el.span,
+                        attributes: std::mem::take(&mut el.attributes),
+                        fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
+                    };
+                    *node = Node::SvelteBody(body);
                 }
             }
         }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -180,6 +180,9 @@ fn walk_node<'a>(
         Node::SvelteDocument(d) => {
             transform_attrs(ctx, &d.attributes, parsed, scope);
         }
+        Node::SvelteBody(b) => {
+            transform_attrs(ctx, &b.attributes, parsed, scope);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/compiler_tests/cases2/svelte_body_action/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_body_action/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+import tooltip from "./tooltip.js";
+export default function App($$anchor) {
+	$.action($.document.body, ($$node) => tooltip?.($$node));
+}

--- a/tasks/compiler_tests/cases2/svelte_body_action/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_body_action/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+import tooltip from "./tooltip.js";
+export default function App($$anchor) {
+	$.action($.document.body, ($$node) => tooltip?.($$node));
+}

--- a/tasks/compiler_tests/cases2/svelte_body_action/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_body_action/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	import tooltip from './tooltip.js';
+</script>
+
+<svelte:body use:tooltip />

--- a/tasks/compiler_tests/cases2/svelte_body_combined/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_body_combined/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import tooltip from "./tooltip.js";
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	$.event("click", $.document.body, handleClick);
+	$.action($.document.body, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => "hello");
+}

--- a/tasks/compiler_tests/cases2/svelte_body_combined/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_body_combined/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import tooltip from "./tooltip.js";
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	$.event("click", $.document.body, handleClick);
+	$.action($.document.body, ($$node, $$action_arg) => tooltip?.($$node, $$action_arg), () => "hello");
+}

--- a/tasks/compiler_tests/cases2/svelte_body_combined/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_body_combined/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	import tooltip from './tooltip.js';
+
+	function handleClick() {
+		console.log('clicked');
+	}
+</script>
+
+<svelte:body onclick={handleClick} use:tooltip={'hello'} />

--- a/tasks/compiler_tests/cases2/svelte_body_event_attr/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_body_event_attr/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	$.event("click", $.document.body, handleClick);
+}

--- a/tasks/compiler_tests/cases2/svelte_body_event_attr/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_body_event_attr/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	$.event("click", $.document.body, handleClick);
+}

--- a/tasks/compiler_tests/cases2/svelte_body_event_attr/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_body_event_attr/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleClick() {
+		console.log('clicked');
+	}
+</script>
+
+<svelte:body onclick={handleClick} />

--- a/tasks/compiler_tests/cases2/svelte_body_event_legacy/case-rust.js
+++ b/tasks/compiler_tests/cases2/svelte_body_event_legacy/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	$.event("click", $.document.body, handleClick);
+}

--- a/tasks/compiler_tests/cases2/svelte_body_event_legacy/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svelte_body_event_legacy/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	function handleClick() {
+		console.log("clicked");
+	}
+	$.event("click", $.document.body, handleClick);
+}

--- a/tasks/compiler_tests/cases2/svelte_body_event_legacy/case.svelte
+++ b/tasks/compiler_tests/cases2/svelte_body_event_legacy/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	function handleClick() {
+		console.log('clicked');
+	}
+</script>
+
+<svelte:body on:click={handleClick} />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -824,3 +824,23 @@ fn svelte_element_xmlns() {
 fn svelte_element_children_expr() {
     assert_compiler("svelte_element_children_expr");
 }
+
+#[rstest]
+fn svelte_body_event_attr() {
+    assert_compiler("svelte_body_event_attr");
+}
+
+#[rstest]
+fn svelte_body_event_legacy() {
+    assert_compiler("svelte_body_event_legacy");
+}
+
+#[rstest]
+fn svelte_body_action() {
+    assert_compiler("svelte_body_action");
+}
+
+#[rstest]
+fn svelte_body_combined() {
+    assert_compiler("svelte_body_combined");
+}


### PR DESCRIPTION
Add full support for <svelte:body> special element with event attributes,
legacy on:event directives, and use:action directives. Events generate
$.event("name", $.document.body, handler), actions generate
$.action($.document.body, handler, thunk).

Changes span all compiler phases: AST type, parser conversion, analysis
passes (walker, lower, scope, parse_js, resolve_references, transform),
and codegen. Includes 4 test cases covering event attr, legacy event,
action, and combined usage.

https://claude.ai/code/session_01EpCxpERBcZrQPW6wAsMzrc