### PR TITLE
Port <svelte:boundary> — error/async boundary (Tier 5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -209,7 +209,7 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - **Codegen**: Events → `$.event($.document.body, ...)`. Supports `use:action`.
 - **Constraint**: Top-level only, no children
 
-### `<svelte:boundary>` — Error boundary (Svelte 5.3+)
+### ~~`<svelte:boundary>` — Error boundary (Svelte 5.3+)~~ ✅
 - **Phases**: P, A, T
 - **AST**: `Node::SvelteBoundary { id, span, attributes, fragment }`
 - **Snippets**: `failed` (receives error + reset), `pending` (initial loading)
@@ -473,6 +473,15 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: no children allowed (`disallow_children`)
 - [ ] Validation: only allowed at root level (not nested)
 - [ ] Validation: only one `<svelte:body>` per component
+
+### `<svelte:boundary>` (Tier 5)
+- [ ] Attribute validation: reject non-`onerror`/`failed`/`pending` attrs (`svelte_boundary_invalid_attribute`)
+- [ ] Attribute value validation: reject string/boolean values (`svelte_boundary_invalid_attribute_value`)
+- [ ] `@const` duplication into hoisted snippets (reference compiler duplicates const tags inside `failed`/`pending` snippets)
+- [ ] Import reactivity: imported identifiers used in boundary attributes should generate getters (`has_state`)
+- [ ] `experimental.async` handling for const tag scoping changes
+- [ ] Dev mode: snippet wrapping with `$.wrap_snippet`
+- [ ] Handler wrapping for snippet params used as event handlers (`function(...$$args) { reset()?.apply(this, $$args) }`)
 
 ### `on:directive` legacy (Tier 10)
 - [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -38,7 +38,8 @@ fn item_is_dynamic(
         | FragmentItem::RenderTag(id)
         | FragmentItem::HtmlTag(id)
         | FragmentItem::KeyBlock(id)
-        | FragmentItem::SvelteElement(id) => dynamic_nodes.contains(id),
+        | FragmentItem::SvelteElement(id)
+        | FragmentItem::SvelteBoundary(id) => dynamic_nodes.contains(id),
     }
 }
 
@@ -57,6 +58,7 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
             FragmentItem::RenderTag(id) => return ContentStrategy::SingleBlock(SingleBlockKind::RenderTag(*id)),
             FragmentItem::ComponentNode(id) => return ContentStrategy::SingleBlock(SingleBlockKind::ComponentNode(*id)),
             FragmentItem::SvelteElement(id) => return ContentStrategy::SingleBlock(SingleBlockKind::SvelteElement(*id)),
+            FragmentItem::SvelteBoundary(id) => return ContentStrategy::SingleBlock(SingleBlockKind::SvelteBoundary(*id)),
             FragmentItem::TextConcat { .. } => {}
         }
     }
@@ -75,7 +77,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
             | FragmentItem::RenderTag(_)
             | FragmentItem::HtmlTag(_)
             | FragmentItem::KeyBlock(_)
-            | FragmentItem::SvelteElement(_) => has_block = true,
+            | FragmentItem::SvelteElement(_)
+            | FragmentItem::SvelteBoundary(_) => has_block = true,
             FragmentItem::TextConcat { has_expr, .. } => {
                 if *has_expr {
                     has_dynamic_text = true;

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -53,6 +53,7 @@ pub enum FragmentKey {
     KeyBlockBody(NodeId),
     SvelteHeadBody(NodeId),
     SvelteElementBody(NodeId),
+    SvelteBoundaryBody(NodeId),
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +270,8 @@ pub enum FragmentItem {
     KeyBlock(NodeId),
     /// A SvelteElement (<svelte:element this={tag}>).
     SvelteElement(NodeId),
+    /// A SvelteBoundary (<svelte:boundary>).
+    SvelteBoundary(NodeId),
     /// Adjacent text nodes and expression tags grouped together.
     TextConcat { parts: Vec<ConcatPart>, has_expr: bool },
 }
@@ -292,7 +295,8 @@ impl FragmentItem {
             | FragmentItem::RenderTag(id)
             | FragmentItem::HtmlTag(id)
             | FragmentItem::KeyBlock(id)
-            | FragmentItem::SvelteElement(id) => *id,
+            | FragmentItem::SvelteElement(id)
+            | FragmentItem::SvelteBoundary(id) => *id,
             FragmentItem::TextConcat { .. } => panic!("TextConcat has no single NodeId"),
         }
     }
@@ -370,6 +374,7 @@ pub enum SingleBlockKind {
     RenderTag(NodeId),
     ComponentNode(NodeId),
     SvelteElement(NodeId),
+    SvelteBoundary(NodeId),
 }
 
 impl SingleBlockKind {
@@ -377,7 +382,7 @@ impl SingleBlockKind {
         match self {
             Self::IfBlock(id) | Self::EachBlock(id) | Self::HtmlTag(id)
             | Self::KeyBlock(id) | Self::RenderTag(id) | Self::ComponentNode(id)
-            | Self::SvelteElement(id) => *id,
+            | Self::SvelteElement(id) | Self::SvelteBoundary(id) => *id,
         }
     }
 }

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -181,6 +181,9 @@ fn register_snippet_params(
             svelte_ast::Node::SvelteElement(el) => {
                 register_snippet_params(&el.fragment, component, data);
             }
+            svelte_ast::Node::SvelteBoundary(b) => {
+                register_snippet_params(&b.fragment, component, data);
+            }
             _ => {}
         }
     }

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -57,6 +57,9 @@ fn lower_fragment(
             Node::SvelteElement(el) => {
                 lower_fragment(&el.fragment, FragmentKey::SvelteElementBody(el.id), component, data);
             }
+            Node::SvelteBoundary(b) => {
+                lower_fragment(&b.fragment, FragmentKey::SvelteBoundaryBody(b.id), component, data);
+            }
             Node::SvelteWindow(_) | Node::SvelteDocument(_) | Node::SvelteBody(_) => {}
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
@@ -158,6 +161,7 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
                     Node::HtmlTag(tag) => items.push(FragmentItem::HtmlTag(tag.id)),
                     Node::KeyBlock(block) => items.push(FragmentItem::KeyBlock(block.id)),
                     Node::SvelteElement(el) => items.push(FragmentItem::SvelteElement(el.id)),
+                    Node::SvelteBoundary(b) => items.push(FragmentItem::SvelteBoundary(b.id)),
                     _ => {}
                 }
             }

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -63,6 +63,6 @@ fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
             // Already computed: leave_element processes children before parents
             data.element_flags.needs_var.contains(id)
         }
-        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) => true,
+        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) => true,
     }
 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -225,6 +225,10 @@ fn walk_node<'a>(
         Node::SvelteBody(b) => {
             walk_attrs(alloc, &b.attributes, component, data, parsed, diags);
         }
+        Node::SvelteBoundary(b) => {
+            walk_attrs(alloc, &b.attributes, component, data, parsed, diags);
+            walk_fragment(alloc, &b.fragment, component, data, parsed, diags);
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
-    Element, ExpressionTag, HtmlTag, IfBlock, KeyBlock, NodeId, RenderTag,
+    Element, ExpressionTag, HtmlTag, IfBlock, KeyBlock, NodeId, RenderTag, SvelteBoundary,
     TransitionDirective, UseDirective,
 };
 use crate::data::AnalysisData;
@@ -112,6 +112,16 @@ impl TemplateVisitor for ReactivityVisitor {
             data.element_flags.dynamic_attrs.insert(attr.id());
         }
         let _ = cn;
+    }
+
+    fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, _scope: ScopeId, data: &mut AnalysisData) {
+        // Boundary attributes use the same has_state semantics as component props —
+        // reactive expressions get getters so the boundary can re-read reactively.
+        for attr in &boundary.attributes {
+            if component_attr_is_dynamic(attr, data) {
+                data.element_flags.dynamic_attrs.insert(attr.id());
+            }
+        }
     }
 
 }

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -1,7 +1,7 @@
 use oxc_semantic::{ReferenceFlags as OxcReferenceFlags, ScopeId};
 use svelte_ast::{
     Attribute, BindDirective, ComponentNode, EachBlock, Element, ExpressionTag, HtmlTag, IfBlock,
-    KeyBlock, NodeId, RenderTag, SvelteBody, SvelteDocument, SvelteElement, SvelteWindow,
+    KeyBlock, NodeId, RenderTag, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow,
 };
 
 use crate::data::AnalysisData;
@@ -188,6 +188,17 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
         data: &mut AnalysisData,
     ) {
         for attr in &body.attributes {
+            resolve_attr_refs(attr.id(), scope, data);
+        }
+    }
+
+    fn visit_svelte_boundary(
+        &mut self,
+        boundary: &SvelteBoundary,
+        scope: ScopeId,
+        data: &mut AnalysisData,
+    ) {
+        for attr in &boundary.attributes {
             resolve_attr_refs(attr.id(), scope, data);
         }
     }

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -318,6 +318,9 @@ fn walk_template_scopes(
             Node::SvelteElement(el) => {
                 walk_template_scopes(&el.fragment, component, scoping, current_scope, const_tag_names, snippet_params);
             }
+            Node::SvelteBoundary(b) => {
+                walk_template_scopes(&b.fragment, component, scoping, current_scope, const_tag_names, snippet_params);
+            }
             Node::ConstTag(tag) => {
                 if let Some(names) = const_tag_names.get(&tag.id) {
                     for name in names {

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -2,7 +2,7 @@ use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
-    SvelteBody, SvelteDocument, SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
+    SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
 };
 
 use crate::data::AnalysisData;
@@ -32,6 +32,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -140,6 +141,10 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
             Node::SvelteBody(b) => {
                 visitor.visit_svelte_body(b, scope, data);
             }
+            Node::SvelteBoundary(b) => {
+                visitor.visit_svelte_boundary(b, scope, data);
+                walk_template(&b.fragment, data, scope, visitor);
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -190,6 +195,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_svelte_body(body, scope, data);)+
+        }
+        fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_svelte_boundary(boundary, scope, data);)+
         }
         fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_attribute(attr, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -128,6 +128,7 @@ impl_node_enum! {
     SvelteWindow(SvelteWindow)       => is_svelte_window / as_svelte_window,
     SvelteDocument(SvelteDocument)   => is_svelte_document / as_svelte_document,
     SvelteBody(SvelteBody)           => is_svelte_body / as_svelte_body,
+    SvelteBoundary(SvelteBoundary)   => is_svelte_boundary / as_svelte_boundary,
     Error(ErrorNode)                 => is_error / as_error,
 }
 
@@ -364,6 +365,17 @@ pub struct SvelteDocument {
 // ---------------------------------------------------------------------------
 
 pub struct SvelteBody {
+    pub id: NodeId,
+    pub span: Span,
+    pub attributes: Vec<Attribute>,
+    pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// SvelteBoundary — <svelte:boundary onerror={fn} failed={snippet}>...</svelte:boundary>
+// ---------------------------------------------------------------------------
+
+pub struct SvelteBoundary {
     pub id: NodeId,
     pub span: Span,
     pub attributes: Vec<Attribute>,

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, ContentStrategy, FragmentKey, IdentGen, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteDocument, SvelteElement, SvelteWindow};
+use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow};
 use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 use svelte_transform::TransformData;
@@ -19,6 +19,7 @@ struct NodeIndex<'a> {
     render_tags: FxHashMap<NodeId, &'a RenderTag>,
     const_tags: FxHashMap<NodeId, &'a ConstTag>,
     svelte_elements: FxHashMap<NodeId, &'a SvelteElement>,
+    svelte_boundaries: FxHashMap<NodeId, &'a SvelteBoundary>,
     svelte_windows: FxHashMap<NodeId, &'a SvelteWindow>,
     svelte_documents: FxHashMap<NodeId, &'a SvelteDocument>,
     svelte_bodies: FxHashMap<NodeId, &'a SvelteBody>,
@@ -36,6 +37,7 @@ impl<'a> NodeIndex<'a> {
             render_tags: FxHashMap::default(),
             const_tags: FxHashMap::default(),
             svelte_elements: FxHashMap::default(),
+            svelte_boundaries: FxHashMap::default(),
             svelte_windows: FxHashMap::default(),
             svelte_documents: FxHashMap::default(),
             svelte_bodies: FxHashMap::default(),
@@ -90,6 +92,10 @@ impl<'a> NodeIndex<'a> {
                 Node::SvelteElement(el) => {
                     self.svelte_elements.insert(el.id, el);
                     self.walk(&el.fragment);
+                }
+                Node::SvelteBoundary(b) => {
+                    self.svelte_boundaries.insert(b.id, b);
+                    self.walk(&b.fragment);
                 }
                 Node::SvelteWindow(w) => {
                     self.svelte_windows.insert(w.id, w);
@@ -171,6 +177,7 @@ impl<'a> Ctx<'a> {
     pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock { self.get_node(&self.index.snippet_blocks, id, "snippet block") }
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag { self.get_node(&self.index.render_tags, id, "render tag") }
     pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.get_node(&self.index.svelte_elements, id, "svelte element") }
+    pub fn svelte_boundary(&self, id: NodeId) -> &'a SvelteBoundary { self.get_node(&self.index.svelte_boundaries, id, "svelte boundary") }
     pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow { self.get_node(&self.index.svelte_windows, id, "svelte window") }
     pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument { self.get_node(&self.index.svelte_documents, id, "svelte document") }
     pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody { self.get_node(&self.index.svelte_bodies, id, "svelte body") }

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -161,7 +161,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
         svelte_analyze::FragmentItem::Element(id) => ctx.needs_var(*id),
-        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) => {
+        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) | svelte_analyze::FragmentItem::SvelteBoundary(_) => {
             true
         }
     }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -215,7 +215,7 @@ pub(crate) fn emit_trailing_next<'a>(
 pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
-        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) => {
+        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) | FragmentItem::SvelteBoundary(id) => {
             ctx.is_dynamic(*id)
         }
     }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -31,7 +31,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
                 let el = ctx.element(*id);
                 html.push_str(&element_html(ctx, el));
             }
-            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) => html.push_str("<!>"),
+            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) => html.push_str("<!>"),
         }
     }
     html

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod html_tag;
 pub(crate) mod key_block;
 pub(crate) mod render_tag;
 pub(crate) mod snippet;
+pub(crate) mod svelte_boundary;
 pub(crate) mod svelte_element;
 pub(crate) mod svelte_body;
 pub(crate) mod svelte_document;
@@ -37,6 +38,7 @@ use html_tag::gen_html_tag;
 use key_block::gen_key_block;
 use render_tag::gen_render_tag;
 use const_tag::emit_const_tags;
+use svelte_boundary::gen_svelte_boundary;
 use svelte_element::gen_svelte_element;
 use traverse::traverse_items;
 
@@ -262,7 +264,10 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, kind: &SingleBlockKind, body: &m
         SingleBlockKind::SvelteElement(id) => {
             gen_svelte_element(ctx, *id, ctx.b.rid_expr(&node), body);
         }
-        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element at this point"),
+        SingleBlockKind::SvelteBoundary(id) => {
+            gen_svelte_boundary(ctx, *id, ctx.b.rid_expr(&node), body);
+        }
+        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element/boundary at this point"),
     }
 
     body.push(ctx.b.call_stmt(
@@ -440,7 +445,10 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                         SingleBlockKind::SvelteElement(id) => {
                             gen_svelte_element(ctx, *id, ctx.b.rid_expr(&node), &mut body);
                         }
-                        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element at this point"),
+                        SingleBlockKind::SvelteBoundary(id) => {
+                            gen_svelte_boundary(ctx, *id, ctx.b.rid_expr(&node), &mut body);
+                        }
+                        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element/boundary at this point"),
                     }
                     body.push(ctx.b.call_stmt(
                         "$.append",

--- a/crates/svelte_codegen_client/src/template/svelte_boundary.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_boundary.rs
@@ -1,0 +1,129 @@
+//! SvelteBoundary codegen — `<svelte:boundary>...</svelte:boundary>`.
+//!
+//! Generates: `$.boundary(node, props, ($$anchor) => { ... })`
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_analyze::FragmentKey;
+use svelte_ast::{Attribute, NodeId};
+
+use crate::builder::{Arg, ObjProp};
+use crate::context::Ctx;
+
+use super::expression::get_attr_expr;
+use super::gen_fragment;
+use super::snippet::gen_snippet_block;
+
+/// Generate `$.boundary(node, props, ($$anchor) => { ... })`.
+pub(crate) fn gen_svelte_boundary<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    node_expr: Expression<'a>,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let boundary = ctx.svelte_boundary(id);
+
+    // Collect attribute info while borrowing ctx immutably.
+    // Boundary only accepts ExpressionAttribute (onerror, failed, pending).
+    let attr_infos: Vec<(&str, NodeId, bool)> = boundary
+        .attributes
+        .iter()
+        .filter_map(|attr| {
+            if let Attribute::ExpressionAttribute(a) = attr {
+                let is_dynamic = ctx.is_dynamic_attr(a.id);
+                Some((a.name.as_str(), a.id, is_dynamic))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Identify which snippet children are named "failed" or "pending" (go into props),
+    // and collect all snippet block IDs for hoisting.
+    let boundary = ctx.svelte_boundary(id);
+    let mut hoisted_snippet_ids: Vec<(NodeId, Option<&str>)> = Vec::new();
+    for node in &boundary.fragment.nodes {
+        if let svelte_ast::Node::SnippetBlock(block) = node {
+            let name = block.name.as_str();
+            let prop_name = if name == "failed" || name == "pending" {
+                Some(name)
+            } else {
+                None
+            };
+            hoisted_snippet_ids.push((block.id, prop_name));
+        }
+    }
+    // Clone to release borrow
+    let hoisted_snippet_ids: Vec<(NodeId, Option<String>)> = hoisted_snippet_ids
+        .into_iter()
+        .map(|(id, name)| (id, name.map(String::from)))
+        .collect();
+
+    // Build props object
+    let mut props: Vec<ObjProp<'a>> = Vec::new();
+
+    // Add attribute props (onerror, failed, pending as attributes)
+    for (name, attr_id, is_dynamic) in &attr_infos {
+        let key = ctx.b.alloc_str(name);
+        let expr = get_attr_expr(ctx, *attr_id);
+        if *is_dynamic {
+            props.push(ObjProp::Getter(key, expr));
+        } else {
+            props.push(ObjProp::KeyValue(key, expr));
+        }
+    }
+
+    // Generate hoisted snippet declarations + add named ones to props
+    let mut hoisted_stmts: Vec<Statement<'a>> = Vec::new();
+    for (snippet_id, prop_name) in &hoisted_snippet_ids {
+        // Generate const tags that need to be duplicated into snippets
+        // (The reference compiler duplicates @const tags into hoisted snippets)
+        let boundary = ctx.svelte_boundary(id);
+        let const_tag_ids: Vec<NodeId> = boundary
+            .fragment
+            .nodes
+            .iter()
+            .filter_map(|n| {
+                if let svelte_ast::Node::ConstTag(tag) = n {
+                    Some(tag.id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let snippet_stmt = gen_snippet_block(ctx, *snippet_id);
+
+        // If there are const tags, inject their declarations into the snippet body.
+        // The reference compiler duplicates const tags into each hoisted snippet.
+        // For now we skip this duplication — it's a deferred item.
+        let _ = const_tag_ids;
+
+        hoisted_stmts.push(snippet_stmt);
+
+        if let Some(name) = prop_name {
+            let key = ctx.b.alloc_str(name);
+            props.push(ObjProp::Shorthand(key));
+        }
+    }
+
+    // Generate body fragment (excludes SnippetBlock and ConstTag children,
+    // which are handled separately by gen_fragment through the lowered fragment)
+    let body_stmts = gen_fragment(ctx, FragmentKey::SvelteBoundaryBody(id));
+
+    let props_expr = ctx.b.object_expr(props);
+    let body_fn = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), body_stmts);
+
+    let boundary_call = ctx.b.call_stmt(
+        "$.boundary",
+        [Arg::Expr(node_expr), Arg::Expr(props_expr), Arg::Expr(body_fn)],
+    );
+
+    if hoisted_stmts.is_empty() {
+        stmts.push(boundary_call);
+    } else {
+        // Wrap in a block: { ...hoisted; $.boundary(...) }
+        hoisted_stmts.push(boundary_call);
+        stmts.push(ctx.b.block_stmt(hoisted_stmts));
+    }
+}

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -93,7 +93,8 @@ pub(crate) fn traverse_items<'a>(
                 | FragmentItem::RenderTag(_)
                 | FragmentItem::HtmlTag(_)
                 | FragmentItem::KeyBlock(_)
-                | FragmentItem::SvelteElement(_) => {
+                | FragmentItem::SvelteElement(_)
+                | FragmentItem::SvelteBoundary(_) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
                     sibling_offset = 1;
@@ -109,6 +110,7 @@ pub(crate) fn traverse_items<'a>(
                         FragmentItem::HtmlTag(id) => gen_html_tag(ctx, *id, anchor, init),
                         FragmentItem::KeyBlock(id) => gen_key_block(ctx, *id, anchor, init),
                         FragmentItem::SvelteElement(id) => super::svelte_element::gen_svelte_element(ctx, *id, anchor, init),
+                        FragmentItem::SvelteBoundary(id) => super::svelte_boundary::gen_svelte_boundary(ctx, *id, anchor, init),
                         _ => unreachable!(),
                     }
                     prev_ident = Some(node_name);

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -10,7 +10,7 @@ use svelte_ast::{
     CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
     KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
     ScriptContext, ScriptLanguage, ShorthandOrSpread, SnippetBlock, StringAttribute,
-    StyleDirective, StyleDirectiveValue, SvelteBody, SvelteDocument, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
+    StyleDirective, StyleDirectiveValue, SvelteBody, SvelteBoundary, SvelteDocument, SvelteHead, SvelteOptions, SvelteWindow, Text, TransitionDirective,
     TransitionDirection, UseDirective,
 };
 
@@ -361,6 +361,9 @@ impl<'a> Parser<'a> {
 
         // Convert <svelte:element> elements to SvelteElement nodes
         Self::convert_svelte_element(&mut component.fragment);
+
+        // Convert <svelte:boundary> elements to SvelteBoundary nodes
+        Self::convert_svelte_boundary(&mut component.fragment);
 
         (component, self.diagnostics)
     }
@@ -1310,6 +1313,46 @@ impl<'a> Parser<'a> {
                 Node::KeyBlock(block) => Self::convert_svelte_element(&mut block.fragment),
                 Node::SvelteHead(head) => Self::convert_svelte_element(&mut head.fragment),
                 Node::SvelteElement(el) => Self::convert_svelte_element(&mut el.fragment),
+                Node::SvelteBoundary(b) => Self::convert_svelte_element(&mut b.fragment),
+                _ => {}
+            }
+        }
+    }
+
+    /// Convert `<svelte:boundary>` Element nodes to SvelteBoundary nodes.
+    /// Recursive — boundary can appear anywhere in the template.
+    fn convert_svelte_boundary(fragment: &mut Fragment) {
+        for node in &mut fragment.nodes {
+            match node {
+                Node::Element(el) if el.name == "svelte:boundary" => {
+                    let mut boundary = SvelteBoundary {
+                        id: el.id,
+                        span: el.span,
+                        attributes: std::mem::take(&mut el.attributes),
+                        fragment: std::mem::replace(&mut el.fragment, Fragment::empty()),
+                    };
+                    Self::convert_svelte_boundary(&mut boundary.fragment);
+                    *node = Node::SvelteBoundary(boundary);
+                }
+                Node::Element(el) => Self::convert_svelte_boundary(&mut el.fragment),
+                Node::ComponentNode(cn) => Self::convert_svelte_boundary(&mut cn.fragment),
+                Node::IfBlock(block) => {
+                    Self::convert_svelte_boundary(&mut block.consequent);
+                    if let Some(alt) = &mut block.alternate {
+                        Self::convert_svelte_boundary(alt);
+                    }
+                }
+                Node::EachBlock(block) => {
+                    Self::convert_svelte_boundary(&mut block.body);
+                    if let Some(fallback) = &mut block.fallback {
+                        Self::convert_svelte_boundary(fallback);
+                    }
+                }
+                Node::SnippetBlock(block) => Self::convert_svelte_boundary(&mut block.body),
+                Node::KeyBlock(block) => Self::convert_svelte_boundary(&mut block.fragment),
+                Node::SvelteHead(head) => Self::convert_svelte_boundary(&mut head.fragment),
+                Node::SvelteElement(el) => Self::convert_svelte_boundary(&mut el.fragment),
+                Node::SvelteBoundary(b) => Self::convert_svelte_boundary(&mut b.fragment),
                 _ => {}
             }
         }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -183,6 +183,12 @@ fn walk_node<'a>(
         Node::SvelteBody(b) => {
             transform_attrs(ctx, &b.attributes, parsed, scope);
         }
+        Node::SvelteBoundary(b) => {
+            transform_attrs(ctx, &b.attributes, parsed, scope);
+            with_alias_scope(ctx, |ctx| {
+                walk_fragment(ctx, &b.fragment, component, parsed, scope);
+            });
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/benchmark/benches/compiler/big_v5.svelte
+++ b/tasks/benchmark/benches/compiler/big_v5.svelte
@@ -31,6 +31,10 @@
     function action(node, arg) {
         return { destroy() {} };
     }
+
+    function handleError(error) {
+        console.error(error);
+    }
 </script>
 
 <svelte:head>
@@ -107,6 +111,13 @@
 
     {@render badge("chunk-0", "secondary")}
     {@render card(title, "Content for chunk 0")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 0: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 0: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -164,6 +175,13 @@
 
     {@render badge("chunk-1", "secondary")}
     {@render card(title, "Content for chunk 1")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 1: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 1: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -221,6 +239,13 @@
 
     {@render badge("chunk-2", "secondary")}
     {@render card(title, "Content for chunk 2")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 2: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 2: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -278,6 +303,13 @@
 
     {@render badge("chunk-3", "secondary")}
     {@render card(title, "Content for chunk 3")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 3: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 3: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -335,6 +367,13 @@
 
     {@render badge("chunk-4", "secondary")}
     {@render card(title, "Content for chunk 4")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 4: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 4: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -392,6 +431,13 @@
 
     {@render badge("chunk-5", "secondary")}
     {@render card(title, "Content for chunk 5")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 5: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 5: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -449,6 +495,13 @@
 
     {@render badge("chunk-6", "secondary")}
     {@render card(title, "Content for chunk 6")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 6: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 6: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -506,6 +559,13 @@
 
     {@render badge("chunk-7", "secondary")}
     {@render card(title, "Content for chunk 7")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 7: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 7: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -563,6 +623,13 @@
 
     {@render badge("chunk-8", "secondary")}
     {@render card(title, "Content for chunk 8")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 8: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 8: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -620,6 +687,13 @@
 
     {@render badge("chunk-9", "secondary")}
     {@render card(title, "Content for chunk 9")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 9: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 9: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -677,6 +751,13 @@
 
     {@render badge("chunk-10", "secondary")}
     {@render card(title, "Content for chunk 10")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 10: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 10: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -734,6 +815,13 @@
 
     {@render badge("chunk-11", "secondary")}
     {@render card(title, "Content for chunk 11")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 11: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 11: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -791,6 +879,13 @@
 
     {@render badge("chunk-12", "secondary")}
     {@render card(title, "Content for chunk 12")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 12: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 12: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -848,6 +943,13 @@
 
     {@render badge("chunk-13", "secondary")}
     {@render card(title, "Content for chunk 13")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 13: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 13: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -905,6 +1007,13 @@
 
     {@render badge("chunk-14", "secondary")}
     {@render card(title, "Content for chunk 14")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 14: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 14: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -962,6 +1071,13 @@
 
     {@render badge("chunk-15", "secondary")}
     {@render card(title, "Content for chunk 15")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 15: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 15: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1019,6 +1135,13 @@
 
     {@render badge("chunk-16", "secondary")}
     {@render card(title, "Content for chunk 16")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 16: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 16: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1076,6 +1199,13 @@
 
     {@render badge("chunk-17", "secondary")}
     {@render card(title, "Content for chunk 17")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 17: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 17: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1133,6 +1263,13 @@
 
     {@render badge("chunk-18", "secondary")}
     {@render card(title, "Content for chunk 18")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 18: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 18: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1190,6 +1327,13 @@
 
     {@render badge("chunk-19", "secondary")}
     {@render card(title, "Content for chunk 19")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 19: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 19: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1247,6 +1391,13 @@
 
     {@render badge("chunk-20", "secondary")}
     {@render card(title, "Content for chunk 20")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 20: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 20: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1304,6 +1455,13 @@
 
     {@render badge("chunk-21", "secondary")}
     {@render card(title, "Content for chunk 21")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 21: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 21: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1361,6 +1519,13 @@
 
     {@render badge("chunk-22", "secondary")}
     {@render card(title, "Content for chunk 22")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 22: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 22: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1418,6 +1583,13 @@
 
     {@render badge("chunk-23", "secondary")}
     {@render card(title, "Content for chunk 23")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 23: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 23: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1475,6 +1647,13 @@
 
     {@render badge("chunk-24", "secondary")}
     {@render card(title, "Content for chunk 24")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 24: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 24: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1532,6 +1711,13 @@
 
     {@render badge("chunk-25", "secondary")}
     {@render card(title, "Content for chunk 25")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 25: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 25: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1589,6 +1775,13 @@
 
     {@render badge("chunk-26", "secondary")}
     {@render card(title, "Content for chunk 26")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 26: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 26: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1646,6 +1839,13 @@
 
     {@render badge("chunk-27", "secondary")}
     {@render card(title, "Content for chunk 27")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 27: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 27: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1703,6 +1903,13 @@
 
     {@render badge("chunk-28", "secondary")}
     {@render card(title, "Content for chunk 28")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 28: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 28: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1760,6 +1967,13 @@
 
     {@render badge("chunk-29", "secondary")}
     {@render card(title, "Content for chunk 29")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 29: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 29: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1817,6 +2031,13 @@
 
     {@render badge("chunk-30", "secondary")}
     {@render card(title, "Content for chunk 30")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 30: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 30: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1874,6 +2095,13 @@
 
     {@render badge("chunk-31", "secondary")}
     {@render card(title, "Content for chunk 31")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 31: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 31: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1931,6 +2159,13 @@
 
     {@render badge("chunk-32", "secondary")}
     {@render card(title, "Content for chunk 32")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 32: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 32: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -1988,6 +2223,13 @@
 
     {@render badge("chunk-33", "secondary")}
     {@render card(title, "Content for chunk 33")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 33: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 33: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2045,6 +2287,13 @@
 
     {@render badge("chunk-34", "secondary")}
     {@render card(title, "Content for chunk 34")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 34: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 34: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2102,6 +2351,13 @@
 
     {@render badge("chunk-35", "secondary")}
     {@render card(title, "Content for chunk 35")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 35: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 35: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2159,6 +2415,13 @@
 
     {@render badge("chunk-36", "secondary")}
     {@render card(title, "Content for chunk 36")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 36: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 36: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2216,6 +2479,13 @@
 
     {@render badge("chunk-37", "secondary")}
     {@render card(title, "Content for chunk 37")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 37: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 37: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2273,6 +2543,13 @@
 
     {@render badge("chunk-38", "secondary")}
     {@render card(title, "Content for chunk 38")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 38: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 38: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2330,6 +2607,13 @@
 
     {@render badge("chunk-39", "secondary")}
     {@render card(title, "Content for chunk 39")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 39: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 39: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2387,6 +2671,13 @@
 
     {@render badge("chunk-40", "secondary")}
     {@render card(title, "Content for chunk 40")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 40: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 40: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2444,6 +2735,13 @@
 
     {@render badge("chunk-41", "secondary")}
     {@render card(title, "Content for chunk 41")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 41: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 41: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2501,6 +2799,13 @@
 
     {@render badge("chunk-42", "secondary")}
     {@render card(title, "Content for chunk 42")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 42: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 42: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2558,6 +2863,13 @@
 
     {@render badge("chunk-43", "secondary")}
     {@render card(title, "Content for chunk 43")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 43: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 43: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2615,6 +2927,13 @@
 
     {@render badge("chunk-44", "secondary")}
     {@render card(title, "Content for chunk 44")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 44: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 44: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2672,6 +2991,13 @@
 
     {@render badge("chunk-45", "secondary")}
     {@render card(title, "Content for chunk 45")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 45: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 45: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2729,6 +3055,13 @@
 
     {@render badge("chunk-46", "secondary")}
     {@render card(title, "Content for chunk 46")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 46: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 46: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2786,6 +3119,13 @@
 
     {@render badge("chunk-47", "secondary")}
     {@render card(title, "Content for chunk 47")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 47: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 47: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2843,6 +3183,13 @@
 
     {@render badge("chunk-48", "secondary")}
     {@render card(title, "Content for chunk 48")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 48: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 48: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 
 <div>
@@ -2900,5 +3247,12 @@
 
     {@render badge("chunk-49", "secondary")}
     {@render card(title, "Content for chunk 49")}
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 49: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 49: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
 </div>
 

--- a/tasks/compiler_tests/cases2/boundary_all_three/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_all_three/case-rust.js
@@ -1,0 +1,33 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>loading...</p>`);
+var root_2 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function handleError(error) {
+		console.error(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const pending = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		const failed = ($$anchor, error = $.noop) => {
+			var p_1 = root_2();
+			var text = $.child(p_1, true);
+			$.reset(p_1);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, p_1);
+		};
+		$.boundary(node, {
+			onerror: handleError,
+			pending,
+			failed
+		}, ($$anchor) => {
+			var p_2 = root_3();
+			$.append($$anchor, p_2);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_all_three/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_all_three/case-svelte.js
@@ -1,0 +1,33 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>loading...</p>`);
+var root_2 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function handleError(error) {
+		console.error(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const pending = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		const failed = ($$anchor, error = $.noop) => {
+			var p_1 = root_2();
+			var text = $.child(p_1, true);
+			$.reset(p_1);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, p_1);
+		};
+		$.boundary(node, {
+			onerror: handleError,
+			pending,
+			failed
+		}, ($$anchor) => {
+			var p_2 = root_3();
+			$.append($$anchor, p_2);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_all_three/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_all_three/case.svelte
@@ -1,0 +1,17 @@
+<script>
+	function handleError(error) {
+		console.error(error);
+	}
+</script>
+
+<svelte:boundary onerror={handleError}>
+	<p>content</p>
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+
+	{#snippet failed(error)}
+		<p>{error.message}</p>
+	{/snippet}
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_basic/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>hello</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, {}, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_basic/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>hello</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, {}, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_basic/case.svelte
@@ -1,0 +1,3 @@
+<svelte:boundary>
+	<p>hello</p>
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_const_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_const_tag/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let items = $.proxy(["a", "b"]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, {}, ($$anchor) => {
+		const count = $.derived(() => items.length);
+		var p = root_1();
+		var text = $.child(p);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, `Count: ${$.get(count) ?? ""}`));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_const_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_const_tag/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let items = $.proxy(["a", "b"]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, {}, ($$anchor) => {
+		const count = $.derived(() => items.length);
+		var p = root_1();
+		var text = $.child(p);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, `Count: ${$.get(count) ?? ""}`));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_const_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_const_tag/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let items = $state(["a", "b"]);
+</script>
+
+<svelte:boundary>
+	{@const count = items.length}
+	<p>Count: {count}</p>
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_failed_attribute/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_failed_attribute/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function myFailed($$anchor, error) {
+		console.log(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, { failed: myFailed }, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_failed_attribute/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_failed_attribute/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function myFailed($$anchor, error) {
+		console.log(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, { failed: myFailed }, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_failed_attribute/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_failed_attribute/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	function myFailed($$anchor, error) {
+		console.log(error);
+	}
+</script>
+
+<svelte:boundary failed={myFailed}>
+	<p>content</p>
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_failed_onerror/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_failed_onerror/case-rust.js
@@ -1,0 +1,27 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function handleError(error) {
+		console.error(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const failed = ($$anchor, error = $.noop) => {
+			var p = root_1();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, p);
+		};
+		$.boundary(node, {
+			onerror: handleError,
+			failed
+		}, ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_failed_onerror/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_failed_onerror/case-svelte.js
@@ -1,0 +1,27 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function handleError(error) {
+		console.error(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const failed = ($$anchor, error = $.noop) => {
+			var p = root_1();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, p);
+		};
+		$.boundary(node, {
+			onerror: handleError,
+			failed
+		}, ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_failed_onerror/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_failed_onerror/case.svelte
@@ -1,0 +1,13 @@
+<script>
+	function handleError(error) {
+		console.error(error);
+	}
+</script>
+
+<svelte:boundary onerror={handleError}>
+	<p>content</p>
+
+	{#snippet failed(error)}
+		<p>{error.message}</p>
+	{/snippet}
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_failed_snippet/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_failed_snippet/case-rust.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const failed = ($$anchor, error = $.noop) => {
+			var p = root_1();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, p);
+		};
+		$.boundary(node, { failed }, ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_failed_snippet/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_failed_snippet/case-svelte.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const failed = ($$anchor, error = $.noop) => {
+			var p = root_1();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, p);
+		};
+		$.boundary(node, { failed }, ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_failed_snippet/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_failed_snippet/case.svelte
@@ -1,0 +1,7 @@
+<svelte:boundary>
+	<p>content</p>
+
+	{#snippet failed(error)}
+		<p>{error.message}</p>
+	{/snippet}
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_in_if/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_in_if/case-rust.js
@@ -1,0 +1,32 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p>guarded</p>`);
+export default function App($$anchor) {
+	let show = true;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var fragment_1 = $.comment();
+			var node_1 = $.first_child(fragment_1);
+			{
+				const failed = ($$anchor, error = $.noop) => {
+					var p = root_2();
+					var text = $.child(p, true);
+					$.reset(p);
+					$.template_effect(() => $.set_text(text, error().message));
+					$.append($$anchor, p);
+				};
+				$.boundary(node_1, { failed }, ($$anchor) => {
+					var p_1 = root_3();
+					$.append($$anchor, p_1);
+				});
+			}
+			$.append($$anchor, fragment_1);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_in_if/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_in_if/case-svelte.js
@@ -1,0 +1,32 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p>guarded</p>`);
+export default function App($$anchor) {
+	let show = true;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var fragment_1 = $.comment();
+			var node_1 = $.first_child(fragment_1);
+			{
+				const failed = ($$anchor, error = $.noop) => {
+					var p = root_2();
+					var text = $.child(p, true);
+					$.reset(p);
+					$.template_effect(() => $.set_text(text, error().message));
+					$.append($$anchor, p);
+				};
+				$.boundary(node_1, { failed }, ($$anchor) => {
+					var p_1 = root_3();
+					$.append($$anchor, p_1);
+				});
+			}
+			$.append($$anchor, fragment_1);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_in_if/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_in_if/case.svelte
@@ -1,0 +1,13 @@
+<script>
+	let show = $state(true);
+</script>
+
+{#if show}
+	<svelte:boundary>
+		<p>guarded</p>
+
+		{#snippet failed(error)}
+			<p>{error.message}</p>
+		{/snippet}
+	</svelte:boundary>
+{/if}

--- a/tasks/compiler_tests/cases2/boundary_nested/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_nested/case-rust.js
@@ -1,0 +1,36 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p> </p>`);
+var root_4 = $.from_html(`<p>inner</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const failed = ($$anchor, error = $.noop) => {
+			var p = root_1();
+			var text = $.child(p);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, `outer: ${error().message ?? ""}`));
+			$.append($$anchor, p);
+		};
+		$.boundary(node, { failed }, ($$anchor) => {
+			var fragment_1 = $.comment();
+			var node_1 = $.first_child(fragment_1);
+			{
+				const failed = ($$anchor, error = $.noop) => {
+					var p_1 = root_3();
+					var text_1 = $.child(p_1, true);
+					$.reset(p_1);
+					$.template_effect(() => $.set_text(text_1, error().message));
+					$.append($$anchor, p_1);
+				};
+				$.boundary(node_1, { failed }, ($$anchor) => {
+					var p_2 = root_4();
+					$.append($$anchor, p_2);
+				});
+			}
+			$.append($$anchor, fragment_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_nested/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_nested/case-svelte.js
@@ -1,0 +1,36 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p> </p>`);
+var root_4 = $.from_html(`<p>inner</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const failed = ($$anchor, error = $.noop) => {
+			var p = root_1();
+			var text = $.child(p);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, `outer: ${error().message ?? ""}`));
+			$.append($$anchor, p);
+		};
+		$.boundary(node, { failed }, ($$anchor) => {
+			var fragment_1 = $.comment();
+			var node_1 = $.first_child(fragment_1);
+			{
+				const failed = ($$anchor, error = $.noop) => {
+					var p_1 = root_3();
+					var text_1 = $.child(p_1, true);
+					$.reset(p_1);
+					$.template_effect(() => $.set_text(text_1, error().message));
+					$.append($$anchor, p_1);
+				};
+				$.boundary(node_1, { failed }, ($$anchor) => {
+					var p_2 = root_4();
+					$.append($$anchor, p_2);
+				});
+			}
+			$.append($$anchor, fragment_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_nested/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_nested/case.svelte
@@ -1,0 +1,13 @@
+<svelte:boundary>
+	<svelte:boundary>
+		<p>inner</p>
+
+		{#snippet failed(error)}
+			<p>{error.message}</p>
+		{/snippet}
+	</svelte:boundary>
+
+	{#snippet failed(error)}
+		<p>outer: {error.message}</p>
+	{/snippet}
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_onerror/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_onerror/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function handleError(error) {
+		console.error(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, { onerror: handleError }, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_onerror/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_onerror/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	function handleError(error) {
+		console.error(error);
+	}
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, { onerror: handleError }, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_onerror/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_onerror/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	function handleError(error) {
+		console.error(error);
+	}
+</script>
+
+<svelte:boundary onerror={handleError}>
+	<p>content</p>
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_other_snippets/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_other_snippets/case-rust.js
@@ -1,0 +1,29 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<span>helper text</span>`);
+var root_2 = $.from_html(`<p> </p> <!>`, 1);
+var root_3 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const helper = ($$anchor) => {
+			var span = root_1();
+			$.append($$anchor, span);
+		};
+		const failed = ($$anchor, error = $.noop) => {
+			var fragment_1 = root_2();
+			var p = $.first_child(fragment_1);
+			var text = $.child(p, true);
+			$.reset(p);
+			var node_1 = $.sibling(p, 2);
+			helper(node_1);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, fragment_1);
+		};
+		$.boundary(node, { failed }, ($$anchor) => {
+			var p_1 = root_3();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_other_snippets/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_other_snippets/case-svelte.js
@@ -1,0 +1,29 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<span>helper text</span>`);
+var root_2 = $.from_html(`<p> </p> <!>`, 1);
+var root_3 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const helper = ($$anchor) => {
+			var span = root_1();
+			$.append($$anchor, span);
+		};
+		const failed = ($$anchor, error = $.noop) => {
+			var fragment_1 = root_2();
+			var p = $.first_child(fragment_1);
+			var text = $.child(p, true);
+			$.reset(p);
+			var node_1 = $.sibling(p, 2);
+			helper(node_1);
+			$.template_effect(() => $.set_text(text, error().message));
+			$.append($$anchor, fragment_1);
+		};
+		$.boundary(node, { failed }, ($$anchor) => {
+			var p_1 = root_3();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_other_snippets/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_other_snippets/case.svelte
@@ -1,0 +1,12 @@
+<svelte:boundary>
+	<p>content</p>
+
+	{#snippet helper()}
+		<span>helper text</span>
+	{/snippet}
+
+	{#snippet failed(error)}
+		<p>{error.message}</p>
+		{@render helper()}
+	{/snippet}
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_pending_snippet/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_pending_snippet/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>loading...</p>`);
+var root_2 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const pending = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		$.boundary(node, { pending }, ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_pending_snippet/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_pending_snippet/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>loading...</p>`);
+var root_2 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		const pending = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		$.boundary(node, { pending }, ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_pending_snippet/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_pending_snippet/case.svelte
@@ -1,0 +1,7 @@
+<svelte:boundary>
+	<p>content</p>
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+</svelte:boundary>

--- a/tasks/compiler_tests/cases2/boundary_reactive_onerror/case-rust.js
+++ b/tasks/compiler_tests/cases2/boundary_reactive_onerror/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	let handler = (error) => console.error(error);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, { get onerror() {
+		return handler;
+	} }, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_reactive_onerror/case-svelte.js
+++ b/tasks/compiler_tests/cases2/boundary_reactive_onerror/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>content</p>`);
+export default function App($$anchor) {
+	let handler = (error) => console.error(error);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.boundary(node, { get onerror() {
+		return handler;
+	} }, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/boundary_reactive_onerror/case.svelte
+++ b/tasks/compiler_tests/cases2/boundary_reactive_onerror/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	let handler = $state((error) => console.error(error));
+</script>
+
+<svelte:boundary onerror={handler}>
+	<p>content</p>
+</svelte:boundary>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -844,3 +844,63 @@ fn svelte_body_action() {
 fn svelte_body_combined() {
     assert_compiler("svelte_body_combined");
 }
+
+#[rstest]
+fn boundary_basic() {
+    assert_compiler("boundary_basic");
+}
+
+#[rstest]
+fn boundary_failed_snippet() {
+    assert_compiler("boundary_failed_snippet");
+}
+
+#[rstest]
+fn boundary_onerror() {
+    assert_compiler("boundary_onerror");
+}
+
+#[rstest]
+fn boundary_pending_snippet() {
+    assert_compiler("boundary_pending_snippet");
+}
+
+#[rstest]
+fn boundary_failed_onerror() {
+    assert_compiler("boundary_failed_onerror");
+}
+
+#[rstest]
+fn boundary_failed_attribute() {
+    assert_compiler("boundary_failed_attribute");
+}
+
+#[rstest]
+fn boundary_all_three() {
+    assert_compiler("boundary_all_three");
+}
+
+#[rstest]
+fn boundary_reactive_onerror() {
+    assert_compiler("boundary_reactive_onerror");
+}
+
+#[rstest]
+fn boundary_nested() {
+    assert_compiler("boundary_nested");
+}
+
+#[rstest]
+fn boundary_const_tag() {
+    assert_compiler("boundary_const_tag");
+}
+
+#[rstest]
+fn boundary_in_if() {
+    assert_compiler("boundary_in_if");
+}
+
+#[rstest]
+fn boundary_other_snippets() {
+    assert_compiler("boundary_other_snippets");
+}

--- a/tasks/generate_benchmark/src/main.rs
+++ b/tasks/generate_benchmark/src/main.rs
@@ -65,6 +65,10 @@ fn write_script(out: &mut String) {
     function action(node, arg) {
         return { destroy() {} };
     }
+
+    function handleError(error) {
+        console.error(error);
+    }
 </script>
 
 "#,
@@ -160,6 +164,13 @@ fn write_chunk(out: &mut String, i: usize) {
 
     {{@render badge("chunk-{i}", "secondary")}}
     {{@render card(title, "Content for chunk {i}")}}
+
+    <svelte:boundary onerror={{handleError}}>
+        <p>Boundary chunk {i}: {{title}}</p>
+        {{#snippet failed(error)}}
+            <p>Error in chunk {i}: {{error.message}}</p>
+        {{/snippet}}
+    </svelte:boundary>
 </div>
 
 "#,


### PR DESCRIPTION
Full-stack implementation: AST type, recursive parser, 9 analysis passes,
and codegen producing $.boundary(node, props, ($$anchor) => {...}).

Supports: basic boundary, onerror/failed/pending attributes, inline
failed/pending snippets (hoisted to block scope), reactive attribute
getters, nested boundaries, boundaries inside if/each, @const tags,
and non-prop snippets.

12 test cases, all passing. Benchmark updated (big_v5).

https://claude.ai/code/session_01UGdE5DTmDEqhHDDRScsipK