### PR TITLE
feat: implement <title> special handling in <svelte:head>

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -216,10 +216,9 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - **Codegen**: `$.boundary(anchor, props, ($$anchor) => { ... })`
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/SvelteBoundary.js` (~126 lines)
 
-### `<title>` — Special handling in `<svelte:head>`
+### ~~`<title>` — Special handling in `<svelte:head>`~~ ✅
 - **Phases**: T
-- **Codegen**: Special text update handling for `<title>` element content
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/TitleElement.js`
+- **Codegen**: `$.document.title = value` with `$.effect()` / `$.deferred_template_effect()` wrapping
 
 ### Component `bind:this`
 - **Phases**: T
@@ -453,6 +452,10 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: only allowed at root level
 - [ ] Validation: no attributes allowed (diagnostic)
 - [ ] `filename` parameter for `compile()` to produce correct hash (currently uses `"(unknown)"` default)
+
+### `<title>` in `<svelte:head>` (Tier 5)
+- [ ] Validation: `<title>` cannot have attributes (`title_illegal_attribute`)
+- [ ] Validation: `<title>` children must be Text or ExpressionTag only (`title_invalid_content`)
 
 ### Render tag
 - [ ] Optional chaining: `{@render fn?.()}` → `$.noop` fallback when fn is nullish

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -39,7 +39,8 @@ fn item_is_dynamic(
         | FragmentItem::HtmlTag(id)
         | FragmentItem::KeyBlock(id)
         | FragmentItem::SvelteElement(id)
-        | FragmentItem::SvelteBoundary(id) => dynamic_nodes.contains(id),
+        | FragmentItem::SvelteBoundary(id)
+        | FragmentItem::TitleElement(id) => dynamic_nodes.contains(id),
     }
 }
 
@@ -59,6 +60,7 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
             FragmentItem::ComponentNode(id) => return ContentStrategy::SingleBlock(SingleBlockKind::ComponentNode(*id)),
             FragmentItem::SvelteElement(id) => return ContentStrategy::SingleBlock(SingleBlockKind::SvelteElement(*id)),
             FragmentItem::SvelteBoundary(id) => return ContentStrategy::SingleBlock(SingleBlockKind::SvelteBoundary(*id)),
+            FragmentItem::TitleElement(id) => return ContentStrategy::SingleBlock(SingleBlockKind::TitleElement(*id)),
             FragmentItem::TextConcat { .. } => {}
         }
     }
@@ -78,7 +80,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
             | FragmentItem::HtmlTag(_)
             | FragmentItem::KeyBlock(_)
             | FragmentItem::SvelteElement(_)
-            | FragmentItem::SvelteBoundary(_) => has_block = true,
+            | FragmentItem::SvelteBoundary(_)
+            | FragmentItem::TitleElement(_) => has_block = true,
             FragmentItem::TextConcat { has_expr, .. } => {
                 if *has_expr {
                     has_dynamic_text = true;

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -272,6 +272,8 @@ pub enum FragmentItem {
     SvelteElement(NodeId),
     /// A SvelteBoundary (<svelte:boundary>).
     SvelteBoundary(NodeId),
+    /// A <title> element inside <svelte:head>, special-cased to assign document.title.
+    TitleElement(NodeId),
     /// Adjacent text nodes and expression tags grouped together.
     TextConcat { parts: Vec<ConcatPart>, has_expr: bool },
 }
@@ -296,7 +298,8 @@ impl FragmentItem {
             | FragmentItem::HtmlTag(id)
             | FragmentItem::KeyBlock(id)
             | FragmentItem::SvelteElement(id)
-            | FragmentItem::SvelteBoundary(id) => *id,
+            | FragmentItem::SvelteBoundary(id)
+            | FragmentItem::TitleElement(id) => *id,
             FragmentItem::TextConcat { .. } => panic!("TextConcat has no single NodeId"),
         }
     }
@@ -375,6 +378,7 @@ pub enum SingleBlockKind {
     ComponentNode(NodeId),
     SvelteElement(NodeId),
     SvelteBoundary(NodeId),
+    TitleElement(NodeId),
 }
 
 impl SingleBlockKind {
@@ -382,7 +386,8 @@ impl SingleBlockKind {
         match self {
             Self::IfBlock(id) | Self::EachBlock(id) | Self::HtmlTag(id)
             | Self::KeyBlock(id) | Self::RenderTag(id) | Self::ComponentNode(id)
-            | Self::SvelteElement(id) | Self::SvelteBoundary(id) => *id,
+            | Self::SvelteElement(id) | Self::SvelteBoundary(id)
+            | Self::TitleElement(id) => *id,
         }
     }
 }

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -14,6 +14,8 @@ fn lower_fragment(
     component: &Component,
     data: &mut AnalysisData,
 ) {
+    let inside_head = matches!(key, FragmentKey::SvelteHeadBody(_));
+
     // Collect ConstTag node IDs for this fragment
     let const_ids: Vec<_> = fragment.nodes.iter()
         .filter_map(|n| n.as_const_tag().map(|ct| ct.id))
@@ -22,7 +24,7 @@ fn lower_fragment(
         data.const_tags.by_fragment.insert(key, const_ids);
     }
 
-    let items = build_items(fragment, component);
+    let items = build_items(fragment, component, inside_head);
     data.fragments.lowered.insert(key, LoweredFragment { items });
 
     for node in &fragment.nodes {
@@ -75,7 +77,7 @@ fn lower_fragment(
 /// 4. For internal Text nodes: collapse boundary whitespace to single space,
 ///    but preserve whitespace adjacent to ExpressionTag
 /// 5. Group consecutive Text + ExpressionTag into TextConcat
-fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> {
+fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) -> Vec<FragmentItem> {
     // Step 1: collect regular nodes (skip comments and snippets)
     let mut regular: Vec<&Node> = Vec::new();
     for node in &fragment.nodes {
@@ -153,7 +155,13 @@ fn build_items(fragment: &Fragment, component: &Component) -> Vec<FragmentItem> 
                 prev_text_ends_ws = false;
                 flush(&mut concat, &mut items);
                 match other {
-                    Node::Element(el) => items.push(FragmentItem::Element(el.id)),
+                    Node::Element(el) => {
+                        if inside_head && el.name == "title" {
+                            items.push(FragmentItem::TitleElement(el.id));
+                        } else {
+                            items.push(FragmentItem::Element(el.id));
+                        }
+                    }
                     Node::ComponentNode(cn) => items.push(FragmentItem::ComponentNode(cn.id)),
                     Node::IfBlock(block) => items.push(FragmentItem::IfBlock(block.id)),
                     Node::EachBlock(block) => items.push(FragmentItem::EachBlock(block.id)),
@@ -397,7 +405,7 @@ mod tests {
     fn trim_leading_and_trailing() {
         let src = "\n  hello  \n";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["hello"]);
     }
 
@@ -405,7 +413,7 @@ mod tests {
     fn preserve_internal_newlines() {
         let src = "hello\n  world";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["hello\n  world"]);
     }
 
@@ -413,7 +421,7 @@ mod tests {
     fn tabs_and_crlf() {
         let src = "\r\n\thello\r\n";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["hello"]);
     }
 
@@ -421,7 +429,7 @@ mod tests {
     fn pure_whitespace_only_is_removed() {
         let src = "  \n\t  ";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let items = build_items(&comp.fragment, &comp);
+        let items = build_items(&comp.fragment, &comp, false);
         assert!(items.is_empty());
     }
 
@@ -432,7 +440,7 @@ mod tests {
             expr_node(1),
             text_node(2, 6, src.len() as u32),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["\n  hello"]);
     }
 
@@ -443,7 +451,7 @@ mod tests {
             text_node(1, 0, 8),
             expr_node(2),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["hello  \n"]);
     }
 
@@ -454,7 +462,7 @@ mod tests {
             text_node(1, 0, 1),
             text_node(2, 1, 2),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert!(texts.is_empty());
     }
 
@@ -462,7 +470,7 @@ mod tests {
     fn ws_between_non_expr_nodes_collapses_to_space() {
         let src = "hello\n\n  world";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["hello\n\n  world"]);
     }
 
@@ -474,7 +482,7 @@ mod tests {
             text_node(2, 3, 7),
             expr_node(3),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["\n  \n"]);
     }
 
@@ -486,7 +494,7 @@ mod tests {
             text_node(2, 6, 16),
             text_node(3, 16, 18),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
         assert_eq!(texts, vec!["\n  hello ", "x"]);
     }
 

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -63,6 +63,6 @@ fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
             // Already computed: leave_element processes children before parents
             data.element_flags.needs_var.contains(id)
         }
-        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) => true,
+        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) | FragmentItem::TitleElement(_) => true,
     }
 }

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -398,6 +398,16 @@ impl<'a> Builder<'a> {
         self.arrow_expr(self.no_params(), [self.expr_stmt(expr)])
     }
 
+    /// `() => { ...stmts }` — zero-arg arrow wrapping a block body.
+    pub fn thunk_block(&self, stmts: Vec<Statement<'a>>) -> Expression<'a> {
+        self.arrow_block_expr(self.no_params(), stmts)
+    }
+
+    /// `left ?? right` — nullish coalescing.
+    pub fn logical_coalesce(&self, left: Expression<'a>, right: Expression<'a>) -> Expression<'a> {
+        self.ast.expression_logical(SPAN, left, ast::LogicalOperator::Coalesce, right)
+    }
+
     pub fn function_decl(
         &self,
         id: BindingIdentifier<'a>,

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -161,7 +161,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
         svelte_analyze::FragmentItem::Element(id) => ctx.needs_var(*id),
-        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) | svelte_analyze::FragmentItem::SvelteBoundary(_) => {
+        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) | svelte_analyze::FragmentItem::SvelteBoundary(_) | svelte_analyze::FragmentItem::TitleElement(_) => {
             true
         }
     }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -215,7 +215,7 @@ pub(crate) fn emit_trailing_next<'a>(
 pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
-        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) | FragmentItem::SvelteBoundary(id) => {
+        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) | FragmentItem::SvelteBoundary(id) | FragmentItem::TitleElement(id) => {
             ctx.is_dynamic(*id)
         }
     }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -31,7 +31,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
                 let el = ctx.element(*id);
                 html.push_str(&element_html(ctx, el));
             }
-            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) => html.push_str("<!>"),
+            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) | FragmentItem::TitleElement(_) => html.push_str("<!>"),
         }
     }
     html

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod svelte_body;
 pub(crate) mod svelte_document;
 pub(crate) mod svelte_head;
 pub(crate) mod svelte_window;
+pub(crate) mod title_element;
 pub(crate) mod traverse;
 
 use oxc_ast::ast::Statement;
@@ -236,6 +237,10 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, kind: &SingleBlockKind, body: &m
             gen_component(ctx, *id, ctx.b.rid_expr("$$anchor"), body);
             return;
         }
+        SingleBlockKind::TitleElement(id) => {
+            title_element::gen_title_element(ctx, *id, body);
+            return;
+        }
         _ => {}
     }
 
@@ -419,6 +424,10 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                 SingleBlockKind::ComponentNode(id) => {
                     ctx.gen_ident("fragment");
                     gen_component(ctx, *id, ctx.b.rid_expr("$$anchor"), &mut body);
+                }
+                SingleBlockKind::TitleElement(id) => {
+                    ctx.gen_ident("fragment");
+                    title_element::gen_title_element(ctx, *id, &mut body);
                 }
                 _ => {
                     let frag = ctx.gen_ident("fragment");

--- a/crates/svelte_codegen_client/src/template/title_element.rs
+++ b/crates/svelte_codegen_client/src/template/title_element.rs
@@ -1,0 +1,65 @@
+//! TitleElement code generation — `<title>` inside `<svelte:head>`.
+//!
+//! Generates `$.document.title = <value>` with reactive effect wrapping.
+//! When value has reactive state: wraps in `$.deferred_template_effect()`.
+//! When value is non-reactive: wraps in `$.effect()`.
+
+use oxc_ast::ast::Statement;
+
+use svelte_analyze::FragmentKey;
+use svelte_ast::NodeId;
+
+use crate::builder::{Arg, AssignLeft, AssignRight};
+use crate::context::Ctx;
+
+use super::expression::{build_concat_from_parts, parts_are_dynamic};
+
+/// Generate `$.document.title = <value>` wrapped in an effect.
+pub(crate) fn gen_title_element<'a>(
+    ctx: &mut Ctx<'a>,
+    id: NodeId,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let key = FragmentKey::Element(id);
+    let lf = ctx.lowered_fragment(&key);
+    let items = lf.items.clone();
+
+    // Build the value expression and check dynamism from the title's lowered children.
+    // Title children are lowered as a single TextConcat item (text + expression tags).
+    let (value, has_state) = if let Some(svelte_analyze::FragmentItem::TextConcat { parts, .. }) = items.first() {
+        let is_dyn = parts_are_dynamic(parts, ctx);
+        let expr = build_concat_from_parts(ctx, parts);
+        (expr, is_dyn)
+    } else {
+        // Empty title or no text content
+        (ctx.b.str_expr(""), false)
+    };
+
+    // For a single expression, apply `?? ""` fallback.
+    // build_concat_from_parts already handles this for template literals (multi-part),
+    // but for a single expression we need explicit nullish coalescing.
+    let value = if items.first().is_some_and(|item| {
+        matches!(item, svelte_analyze::FragmentItem::TextConcat { parts, .. } if parts.len() == 1 && matches!(parts[0], svelte_analyze::ConcatPart::Expr(_)))
+    }) {
+        // Single expression: value ?? ""
+        ctx.b.logical_coalesce(value, ctx.b.str_expr(""))
+    } else {
+        value
+    };
+
+    // Build: $.document.title = value
+    let doc_expr = ctx.b.static_member_expr(ctx.b.rid_expr("$"), "document");
+    let title_member = ctx.b.static_member(doc_expr, "title");
+    let assignment = ctx.b.assign_stmt(AssignLeft::StaticMember(title_member), AssignRight::Expr(value));
+
+    // Wrap in effect
+    if has_state {
+        // Reactive: $.deferred_template_effect(() => { $.document.title = value })
+        let arrow = ctx.b.thunk_block(vec![assignment]);
+        stmts.push(ctx.b.call_stmt("$.deferred_template_effect", [Arg::Expr(arrow)]));
+    } else {
+        // Static: $.effect(() => { $.document.title = value })
+        let arrow = ctx.b.thunk_block(vec![assignment]);
+        stmts.push(ctx.b.call_stmt("$.effect", [Arg::Expr(arrow)]));
+    }
+}

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -94,7 +94,8 @@ pub(crate) fn traverse_items<'a>(
                 | FragmentItem::HtmlTag(_)
                 | FragmentItem::KeyBlock(_)
                 | FragmentItem::SvelteElement(_)
-                | FragmentItem::SvelteBoundary(_) => {
+                | FragmentItem::SvelteBoundary(_)
+                | FragmentItem::TitleElement(_) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
                     sibling_offset = 1;
@@ -111,6 +112,7 @@ pub(crate) fn traverse_items<'a>(
                         FragmentItem::KeyBlock(id) => gen_key_block(ctx, *id, anchor, init),
                         FragmentItem::SvelteElement(id) => super::svelte_element::gen_svelte_element(ctx, *id, anchor, init),
                         FragmentItem::SvelteBoundary(id) => super::svelte_boundary::gen_svelte_boundary(ctx, *id, anchor, init),
+                        FragmentItem::TitleElement(id) => super::title_element::gen_title_element(ctx, *id, init),
                         _ => unreachable!(),
                     }
                     prev_ident = Some(node_name);

--- a/tasks/compiler_tests/cases2/title_dynamic/case-rust.js
+++ b/tasks/compiler_tests/cases2/title_dynamic/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let pageTitle = $.state("Home");
+	$.set(pageTitle, "Other");
+	$.head("q2w0q4", ($$anchor) => {
+		$.deferred_template_effect(() => {
+			$.document.title = $.get(pageTitle) ?? "";
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_dynamic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/title_dynamic/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let pageTitle = $.state("Home");
+	$.set(pageTitle, "Other");
+	$.head("q2w0q4", ($$anchor) => {
+		$.deferred_template_effect(() => {
+			$.document.title = $.get(pageTitle) ?? "";
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_dynamic/case.svelte
+++ b/tasks/compiler_tests/cases2/title_dynamic/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let pageTitle = $state("Home");
+	pageTitle = "Other";
+</script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+</svelte:head>

--- a/tasks/compiler_tests/cases2/title_empty/case-rust.js
+++ b/tasks/compiler_tests/cases2/title_empty/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		$.effect(() => {
+			$.document.title = "";
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_empty/case-svelte.js
+++ b/tasks/compiler_tests/cases2/title_empty/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		$.effect(() => {
+			$.document.title = "";
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_empty/case.svelte
+++ b/tasks/compiler_tests/cases2/title_empty/case.svelte
@@ -1,0 +1,3 @@
+<svelte:head>
+	<title></title>
+</svelte:head>

--- a/tasks/compiler_tests/cases2/title_mixed/case-rust.js
+++ b/tasks/compiler_tests/cases2/title_mixed/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let section = $.state("Dashboard");
+	$.set(section, "Settings");
+	$.head("q2w0q4", ($$anchor) => {
+		$.deferred_template_effect(() => {
+			$.document.title = `App - ${$.get(section) ?? ""}`;
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_mixed/case-svelte.js
+++ b/tasks/compiler_tests/cases2/title_mixed/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let section = $.state("Dashboard");
+	$.set(section, "Settings");
+	$.head("q2w0q4", ($$anchor) => {
+		$.deferred_template_effect(() => {
+			$.document.title = `App - ${$.get(section) ?? ""}`;
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_mixed/case.svelte
+++ b/tasks/compiler_tests/cases2/title_mixed/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let section = $state("Dashboard");
+	section = "Settings";
+</script>
+
+<svelte:head>
+	<title>App - {section}</title>
+</svelte:head>

--- a/tasks/compiler_tests/cases2/title_static/case-rust.js
+++ b/tasks/compiler_tests/cases2/title_static/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		$.effect(() => {
+			$.document.title = "My Page";
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_static/case-svelte.js
+++ b/tasks/compiler_tests/cases2/title_static/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	$.head("q2w0q4", ($$anchor) => {
+		$.effect(() => {
+			$.document.title = "My Page";
+		});
+	});
+}

--- a/tasks/compiler_tests/cases2/title_static/case.svelte
+++ b/tasks/compiler_tests/cases2/title_static/case.svelte
@@ -1,0 +1,3 @@
+<svelte:head>
+	<title>My Page</title>
+</svelte:head>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -689,6 +689,27 @@ fn svelte_head_with_content() {
     assert_compiler("svelte_head_with_content");
 }
 
+// <title> in <svelte:head> tests
+#[rstest]
+fn title_static() {
+    assert_compiler("title_static");
+}
+
+#[rstest]
+fn title_dynamic() {
+    assert_compiler("title_dynamic");
+}
+
+#[rstest]
+fn title_mixed() {
+    assert_compiler("title_mixed");
+}
+
+#[rstest]
+fn title_empty() {
+    assert_compiler("title_empty");
+}
+
 // svelte:window tests
 #[rstest]
 fn svelte_window_event_legacy() {


### PR DESCRIPTION
<title> inside <svelte:head> now generates $.document.title = value
with reactive effect wrapping instead of DOM manipulation.

- Lowering detects <title> inside head → FragmentItem::TitleElement
- Static titles: $.effect(() => { $.document.title = "..." })
- Reactive titles: $.deferred_template_effect(() => { $.document.title = ... })
- Single expression applies ?? "" nullish coalescing fallback
- 4 test cases: static, dynamic, mixed, empty

https://claude.ai/code/session_018BYoZojAKncDdDMZRNsG1w