### PR TITLE
feat: port component bind:this

### DIFF
--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -122,6 +122,9 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
         data: &mut AnalysisData,
     ) {
         resolve_attr_refs(attr.id(), scope, data);
+        if let Attribute::BindDirective(dir) = attr {
+            self.resolve_bind(dir, scope, data);
+        }
     }
 
     fn visit_bind_directive(

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -6,7 +6,7 @@ use svelte_analyze::{ContentStrategy, FragmentKey};
 use svelte_ast::{Attribute, NodeId};
 use svelte_span::Span;
 
-use crate::builder::{Arg, ObjProp};
+use crate::builder::{Arg, AssignLeft, AssignRight, ObjProp};
 use crate::context::Ctx;
 
 use super::expression::{build_attr_concat, get_attr_expr};
@@ -19,6 +19,7 @@ enum AttrKind<'a> {
     Expression { name: &'a str, attr_id: NodeId, shorthand: bool },
     Concatenation { name: &'a str, attr_id: NodeId },
     Shorthand { attr_id: NodeId },
+    BindThis { expression_span: Option<Span>, shorthand: bool, name: String },
     Spread,
     Skip,
 }
@@ -57,6 +58,11 @@ pub(crate) fn gen_component<'a>(
             Attribute::ShorthandOrSpread(a) => AttrKind::Shorthand {
                 attr_id: a.id,
             },
+            Attribute::BindDirective(b) if b.name == "this" => AttrKind::BindThis {
+                expression_span: b.expression_span,
+                shorthand: b.shorthand,
+                name: b.name.clone(),
+            },
             Attribute::BindDirective(_) | Attribute::ClassDirective(_) | Attribute::StyleDirective(_)
             | Attribute::UseDirective(_) | Attribute::OnDirectiveLegacy(_)
             | Attribute::TransitionDirective(_)
@@ -67,6 +73,7 @@ pub(crate) fn gen_component<'a>(
     }).collect();
 
     let mut props: Vec<ObjProp<'a>> = Vec::new();
+    let mut bind_this_info: Option<(Option<Span>, bool, String)> = None;
 
     for (kind, is_dynamic) in attr_infos {
         match kind {
@@ -121,6 +128,9 @@ pub(crate) fn gen_component<'a>(
                     props.push(ObjProp::Shorthand(key));
                 }
             }
+            AttrKind::BindThis { expression_span, shorthand, name } => {
+                bind_this_info = Some((expression_span, shorthand, name));
+            }
             AttrKind::Spread | AttrKind::Skip => {}
         }
     }
@@ -152,7 +162,48 @@ pub(crate) fn gen_component<'a>(
     }
 
     let props_expr = ctx.b.object_expr(props);
-    init.push(ctx.b.expr_stmt(
-        ctx.b.call_expr(name, [Arg::Expr(anchor), Arg::Expr(props_expr)]),
-    ));
+    let component_call = ctx.b.call_expr(name, [Arg::Expr(anchor), Arg::Expr(props_expr)]);
+
+    let final_expr = if let Some((expression_span, shorthand, bind_name)) = bind_this_info {
+        let var_name = if shorthand {
+            bind_name
+        } else if let Some(span) = expression_span {
+            ctx.component.source_text(span).trim().to_string()
+        } else {
+            // No expression — skip bind:this
+            init.push(ctx.b.expr_stmt(component_call));
+            return;
+        };
+
+        let setter = if ctx.is_mutable_rune(&var_name) {
+            let var_str = ctx.b.alloc_str(&var_name);
+            let body = ctx.b.call_expr("$.set", [
+                Arg::Ident(var_str), Arg::Ident("$$value"), Arg::Expr(ctx.b.bool_expr(true)),
+            ]);
+            ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+        } else {
+            let body = ctx.b.assign_expr(
+                AssignLeft::Ident(var_name.clone()),
+                AssignRight::Expr(ctx.b.rid_expr("$$value")),
+            );
+            ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+        };
+
+        let getter = if ctx.is_mutable_rune(&var_name) {
+            let var_str = ctx.b.alloc_str(&var_name);
+            let body = ctx.b.call_expr("$.get", [Arg::Ident(var_str)]);
+            ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
+        } else {
+            let body = ctx.b.rid_expr(&var_name);
+            ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
+        };
+
+        ctx.b.call_expr("$.bind_this", [
+            Arg::Expr(component_call), Arg::Expr(setter), Arg::Expr(getter),
+        ])
+    } else {
+        component_call
+    };
+
+    init.push(ctx.b.expr_stmt(final_expr));
 }

--- a/tasks/compiler_tests/cases2/component_bind_this/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_bind_this/case-rust.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let ref = $.state(void 0);
+	$.bind_this(Component($$anchor, {}), ($$value) => $.set(ref, $$value, true), () => $.get(ref));
+}

--- a/tasks/compiler_tests/cases2/component_bind_this/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_bind_this/case-svelte.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let ref = $.state(void 0);
+	$.bind_this(Component($$anchor, {}), ($$value) => $.set(ref, $$value, true), () => $.get(ref));
+}

--- a/tasks/compiler_tests/cases2/component_bind_this/case.svelte
+++ b/tasks/compiler_tests/cases2/component_bind_this/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Component from './Component.svelte';
+	let ref = $state();
+</script>
+
+<Component bind:this={ref} />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -502,6 +502,11 @@ fn bind_this() {
 }
 
 #[rstest]
+fn component_bind_this() {
+    assert_compiler("component_bind_this");
+}
+
+#[rstest]
 fn bind_focused() {
     assert_compiler("bind_focused");
 }


### PR DESCRIPTION
Wrap the component instantiation call with $.bind_this() when bind:this
is used. Also register bind directive mutations on components in the
analyzer so $state variables are correctly recognized.

https://claude.ai/code/session_011E3us5nZyT2NRZf9F1s1k4