### PR TITLE
Port component bind:this edge cases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -220,7 +220,7 @@ Theme: `<svelte:*>` elements for global bindings, dynamic elements, error bounda
 - **Phases**: T
 - **Codegen**: `$.document.title = value` with `$.effect()` / `$.deferred_template_effect()` wrapping
 
-### Component `bind:this`
+### ~~Component `bind:this`~~ ✅
 - **Phases**: T
 - **Codegen**: `$.bind_this(component, setter, getter)` — different from element `bind:this`, binds to component instance
 - **Ref**: `reference/compiler/phases/3-transform/client/visitors/shared/component.js`
@@ -485,6 +485,9 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] `experimental.async` handling for const tag scoping changes
 - [ ] Dev mode: snippet wrapping with `$.wrap_snippet`
 - [ ] Handler wrapping for snippet params used as event handlers (`function(...$$args) { reset()?.apply(this, $$args) }`)
+
+### Component `bind:this` (Tier 5)
+- [ ] SequenceExpression custom getter/setter: `bind:this={() => get(), (v) => set(v)}` — rarely used, needs expression visitor in codegen
 
 ### `on:directive` legacy (Tier 10)
 - [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -11,6 +11,7 @@ use oxc_ast::{
     },
     AstBuilder, NONE,
 };
+use oxc_parser::Parser as OxcParser;
 use oxc_span::{Atom, SourceType, SPAN};
 use oxc_syntax::node::NodeId as OxcNodeId;
 use std::cell::Cell;
@@ -615,6 +616,23 @@ impl<'a> Builder<'a> {
         parts: impl IntoIterator<Item = TemplatePart<'a>>,
     ) -> Expression<'a> {
         Expression::TemplateLiteral(self.alloc(self.template_parts(parts)))
+    }
+
+    // -----------------------------------------------------------------------
+    // Expression parsing
+    // -----------------------------------------------------------------------
+
+    /// Parse a JS expression from text. Falls back to a string literal on parse failure.
+    pub fn parse_expression(&self, text: &str) -> Expression<'a> {
+        let alloc = self.ast.allocator;
+        let arena_text: &'a str = alloc.alloc_str(text);
+        match OxcParser::new(alloc, arena_text, SourceType::default()).parse_expression() {
+            Ok(expr) => expr,
+            Err(_) => {
+                debug_assert!(false, "codegen: failed to parse expression: {text}");
+                self.str_expr(text)
+            }
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -140,6 +140,10 @@ pub struct Ctx<'a> {
 
     /// Event names that use delegation (e.g., "click" from `onclick={handler}`).
     pub delegated_events: Vec<String>,
+
+    /// Names of variables from enclosing each-block scopes (context + index).
+    /// Pushed on entry to each-block body, popped on exit.
+    pub each_vars: Vec<String>,
 }
 
 impl<'a> Ctx<'a> {
@@ -165,6 +169,7 @@ impl<'a> Ctx<'a> {
             needs_binding_group: false,
             snippet_param_names: Vec::new(),
             delegated_events: Vec::new(),
+            each_vars: Vec::new(),
         }
     }
 

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -175,35 +175,158 @@ pub(crate) fn gen_component<'a>(
             return;
         };
 
-        let setter = if ctx.is_mutable_rune(&var_name) {
-            let var_str = ctx.b.alloc_str(&var_name);
-            let body = ctx.b.call_expr("$.set", [
-                Arg::Ident(var_str), Arg::Ident("$$value"), Arg::Expr(ctx.b.bool_expr(true)),
-            ]);
-            ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
-        } else {
-            let body = ctx.b.assign_expr(
-                AssignLeft::Ident(var_name.clone()),
-                AssignRight::Expr(ctx.b.rid_expr("$$value")),
-            );
-            ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
-        };
-
-        let getter = if ctx.is_mutable_rune(&var_name) {
-            let var_str = ctx.b.alloc_str(&var_name);
-            let body = ctx.b.call_expr("$.get", [Arg::Ident(var_str)]);
-            ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
-        } else {
-            let body = ctx.b.rid_expr(&var_name);
-            ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
-        };
-
-        ctx.b.call_expr("$.bind_this", [
-            Arg::Expr(component_call), Arg::Expr(setter), Arg::Expr(getter),
-        ])
+        build_bind_this_call(ctx, &var_name, component_call)
     } else {
         component_call
     };
 
     init.push(ctx.b.expr_stmt(final_expr));
+}
+
+/// Check if a string is a simple JS identifier (no member access, no computed access).
+fn is_simple_identifier(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_' || c == '$')
+        && s.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+}
+
+/// Add optional chaining to all member accesses in an expression string.
+/// `obj.ref` → `obj?.ref`, `refs[i]` → `refs?.[i]`, `a.b.c` → `a?.b?.c`
+fn add_optional_chaining(expr: &str) -> String {
+    let mut result = String::new();
+    let mut depth = 0i32;
+    for c in expr.chars() {
+        match c {
+            '.' if depth == 0 => result.push_str("?."),
+            '[' if depth == 0 => {
+                result.push_str("?.[");
+                depth += 1;
+            }
+            '[' => {
+                result.push('[');
+                depth += 1;
+            }
+            ']' => {
+                result.push(']');
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            c => result.push(c),
+        }
+    }
+    result
+}
+
+/// Extract identifier-like tokens from an expression string.
+fn extract_identifiers(expr: &str) -> Vec<String> {
+    expr.split(|c: char| !c.is_alphanumeric() && c != '_' && c != '$')
+        .filter(|s| {
+            !s.is_empty()
+                && s.chars()
+                    .next()
+                    .is_some_and(|c| c.is_alphabetic() || c == '_' || c == '$')
+        })
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Build `$.bind_this(value, setter, getter[, context_thunk])` for component bind:this.
+fn build_bind_this_call<'a>(
+    ctx: &mut Ctx<'a>,
+    expr_text: &str,
+    value: Expression<'a>,
+) -> Expression<'a> {
+    if is_simple_identifier(expr_text) {
+        // Simple identifier: use $.set/$.get for mutable runes, plain assignment otherwise
+        let setter = if ctx.is_mutable_rune(expr_text) {
+            let var_str = ctx.b.alloc_str(expr_text);
+            let body = ctx.b.call_expr("$.set", [
+                Arg::Ident(var_str),
+                Arg::Ident("$$value"),
+                Arg::Expr(ctx.b.bool_expr(true)),
+            ]);
+            ctx.b
+                .arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+        } else {
+            let body = ctx.b.assign_expr(
+                AssignLeft::Ident(expr_text.to_string()),
+                AssignRight::Expr(ctx.b.rid_expr("$$value")),
+            );
+            ctx.b
+                .arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+        };
+
+        let getter = if ctx.is_mutable_rune(expr_text) {
+            let var_str = ctx.b.alloc_str(expr_text);
+            let body = ctx.b.call_expr("$.get", [Arg::Ident(var_str)]);
+            ctx.b
+                .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
+        } else {
+            let body = ctx.b.rid_expr(expr_text);
+            ctx.b
+                .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
+        };
+
+        ctx.b.call_expr("$.bind_this", [
+            Arg::Expr(value),
+            Arg::Expr(setter),
+            Arg::Expr(getter),
+        ])
+    } else {
+        // Member/computed expression: use raw assignment for setter, optional chaining for getter
+        let each_context: Vec<String> = extract_identifiers(expr_text)
+            .into_iter()
+            .filter(|id| ctx.each_vars.contains(id))
+            .collect();
+
+        // Setter: ($$value[, ctx_vars]) => <expr> = $$value
+        let setter_body = format!("{expr_text} = $$value");
+        let setter_expr = ctx.b.parse_expression(&setter_body);
+        let mut setter_params: Vec<&str> = vec!["$$value"];
+        let each_ctx_owned: Vec<String> = each_context.clone();
+        for v in &each_ctx_owned {
+            setter_params.push(v);
+        }
+        let setter = ctx
+            .b
+            .arrow_expr(ctx.b.params(setter_params), [ctx.b.expr_stmt(setter_expr)]);
+
+        // Getter: ([ctx_vars]) => <expr_with_optional_chaining>
+        let getter_text = add_optional_chaining(expr_text);
+        let getter_expr = ctx.b.parse_expression(&getter_text);
+        let mut getter_params: Vec<&str> = Vec::new();
+        for v in &each_ctx_owned {
+            getter_params.push(v);
+        }
+        let getter = ctx
+            .b
+            .arrow_expr(ctx.b.params(getter_params), [ctx.b.expr_stmt(getter_expr)]);
+
+        if each_context.is_empty() {
+            ctx.b.call_expr("$.bind_this", [
+                Arg::Expr(value),
+                Arg::Expr(setter),
+                Arg::Expr(getter),
+            ])
+        } else {
+            // 4th arg: () => [ctx_var1, ctx_var2, ...]
+            let context_values: Vec<Arg<'_, '_>> = each_context
+                .iter()
+                .map(|v| {
+                    let s = ctx.b.alloc_str(v);
+                    Arg::Ident(s)
+                })
+                .collect();
+            let context_array = ctx.b.array_from_args(context_values);
+            let context_thunk = ctx.b.thunk(context_array);
+
+            ctx.b.call_expr("$.bind_this", [
+                Arg::Expr(value),
+                Arg::Expr(setter),
+                Arg::Expr(getter),
+                Arg::Expr(context_thunk),
+            ])
+        }
+    }
 }

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -56,6 +56,9 @@ pub(crate) fn gen_each_block<'a>(
         flags |= EACH_IS_ANIMATED;
     }
 
+    let index_name = block.index_span
+        .map(|span| ctx.component.source_text(span).to_string());
+
     let expr_source = ctx.component.source_text(expr_span).trim();
     let root = ctx.analysis.scoping.root_scope_id();
     let is_prop_source = ctx.analysis.scoping.find_binding(root, expr_source)
@@ -77,11 +80,25 @@ pub(crate) fn gen_each_block<'a>(
         ctx.b.rid_expr("$.index")
     };
 
+    // Track each-block variables for bind:this context detection
+    ctx.each_vars.push(context_name.clone());
+    if let Some(ref idx) = index_name {
+        ctx.each_vars.push(idx.clone());
+    }
+
     let frag_body = gen_fragment(ctx, body_key);
 
-    let frag_fn = ctx
-        .b
-        .arrow_expr(ctx.b.params(["$$anchor", &context_name]), frag_body);
+    // Pop each-block variables
+    if index_name.is_some() {
+        ctx.each_vars.pop();
+    }
+    ctx.each_vars.pop();
+
+    let frag_fn = if let Some(ref idx) = index_name {
+        ctx.b.arrow_block_expr(ctx.b.params(["$$anchor", &context_name, idx]), frag_body)
+    } else {
+        ctx.b.arrow_expr(ctx.b.params(["$$anchor", &context_name]), frag_body)
+    };
 
     body.push(ctx.b.call_stmt(
         "$.each",

--- a/tasks/compiler_tests/cases2/component_bind_this_each/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_each/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let items = [
+		1,
+		2,
+		3
+	];
+	let refs = $.proxy([]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item, i) => {
+		$.bind_this(Component($$anchor, {}), ($$value, i) => refs[i] = $$value, (i) => refs?.[i], () => [i]);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_each/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_each/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let items = [
+		1,
+		2,
+		3
+	];
+	let refs = $.proxy([]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item, i) => {
+		$.bind_this(Component($$anchor, {}), ($$value, i) => refs[i] = $$value, (i) => refs?.[i], () => [i]);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_each/case.svelte
+++ b/tasks/compiler_tests/cases2/component_bind_this_each/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Component from './Component.svelte';
+	let items = [1, 2, 3];
+	let refs = $state([]);
+</script>
+
+{#each items as item, i}
+	<Component bind:this={refs[i]} />
+{/each}

--- a/tasks/compiler_tests/cases2/component_bind_this_member/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_member/case-rust.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let obj = { ref: null };
+	$.bind_this(Component($$anchor, {}), ($$value) => obj.ref = $$value, () => obj?.ref);
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_member/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_member/case-svelte.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let obj = { ref: null };
+	$.bind_this(Component($$anchor, {}), ($$value) => obj.ref = $$value, () => obj?.ref);
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_member/case.svelte
+++ b/tasks/compiler_tests/cases2/component_bind_this_member/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Component from './Component.svelte';
+	let obj = { ref: null };
+</script>
+
+<Component bind:this={obj.ref} />

--- a/tasks/compiler_tests/cases2/component_bind_this_plain/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_plain/case-rust.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let ref;
+	$.bind_this(Component($$anchor, {}), ($$value) => ref = $$value, () => ref);
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_plain/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_plain/case-svelte.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	let ref;
+	$.bind_this(Component($$anchor, {}), ($$value) => ref = $$value, () => ref);
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_plain/case.svelte
+++ b/tasks/compiler_tests/cases2/component_bind_this_plain/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Component from './Component.svelte';
+	let ref;
+</script>
+
+<Component bind:this={ref} />

--- a/tasks/compiler_tests/cases2/component_bind_this_props/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_props/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+var root_1 = $.from_html(`<p>child content</p>`);
+export default function App($$anchor) {
+	let ref = $.state(void 0);
+	$.bind_this(Component($$anchor, {
+		name: "test",
+		children: ($$anchor, $$slotProps) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		},
+		$$slots: { default: true }
+	}), ($$value) => $.set(ref, $$value, true), () => $.get(ref));
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_props/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_bind_this_props/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+import Component from "./Component.svelte";
+var root_1 = $.from_html(`<p>child content</p>`);
+export default function App($$anchor) {
+	let ref = $.state(void 0);
+	$.bind_this(Component($$anchor, {
+		name: "test",
+		children: ($$anchor, $$slotProps) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		},
+		$$slots: { default: true }
+	}), ($$value) => $.set(ref, $$value, true), () => $.get(ref));
+}

--- a/tasks/compiler_tests/cases2/component_bind_this_props/case.svelte
+++ b/tasks/compiler_tests/cases2/component_bind_this_props/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Component from './Component.svelte';
+	let ref = $state();
+</script>
+
+<Component bind:this={ref} name="test">
+	<p>child content</p>
+</Component>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -507,6 +507,26 @@ fn component_bind_this() {
 }
 
 #[rstest]
+fn component_bind_this_plain() {
+    assert_compiler("component_bind_this_plain");
+}
+
+#[rstest]
+fn component_bind_this_props() {
+    assert_compiler("component_bind_this_props");
+}
+
+#[rstest]
+fn component_bind_this_member() {
+    assert_compiler("component_bind_this_member");
+}
+
+#[rstest]
+fn component_bind_this_each() {
+    assert_compiler("component_bind_this_each");
+}
+
+#[rstest]
 fn bind_focused() {
     assert_compiler("bind_focused");
 }


### PR DESCRIPTION
Complete the component bind:this feature with support for:
- Plain (non-$state) variables
- Components with props + children alongside bind:this
- Member expression bindings (obj.ref) with optional chaining on getter
- Each-block context variables (refs[i]) with 4th thunk argument

Also adds each-block index parameter to callback when index_span is present,
and tracks each-block variables in Ctx for context variable detection.

https://claude.ai/code/session_01UncpMMjE2aNJFzPYGwRLF6