### PR TITLE
Port {#await promise} async blocks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,7 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 - [x] `{@const x = expr}` — block-scoped constant (incl. destructuring)
 - [x] `style:prop` directive (shorthand, expression, string, concat, `|important`)
 - [x] `class` object/array syntax (Svelte 5)
+- [x] `{#await promise}` — async blocks (full form, short then/catch, no bindings, destructured, pending only)
 
 ### Event handling
 - [x] Svelte 5 event attributes — `onclick={handler}` → `$.delegated()` for delegatable events
@@ -161,13 +162,9 @@ Ref: `reference/compiler/phases/3-transform/client/visitors/shared/utils.js` (Me
 
 ## Tier 2 — Remaining Template Blocks
 
-### `{#await promise}` — Async blocks
+### ~~`{#await promise}` — Async blocks~~ ✅
 - **Phases**: P, A, T
-- **AST**: `Node::AwaitBlock { id, span, expression_span, pending, then_binding, then, catch_binding, catch }`
-- **Parser**: `{#await expr}...{:then val}...{:catch err}...{/await}`, short form `{#await expr then val}...{/await}`
 - **Codegen**: `$.await(anchor, () => promise, pending_fn, then_fn, catch_fn)`
-- **Notes**: Needs child scopes for `then`/`catch` bindings. Common in real apps (data fetching).
-- **Ref**: `reference/compiler/phases/3-transform/client/visitors/AwaitBlock.js` (~124 lines)
 
 ### `{@debug vars}` — Dev-mode debugger
 - **Phases**: P, T
@@ -485,6 +482,12 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] `experimental.async` handling for const tag scoping changes
 - [ ] Dev mode: snippet wrapping with `$.wrap_snippet`
 - [ ] Handler wrapping for snippet params used as event handlers (`function(...$$args) { reset()?.apply(this, $$args) }`)
+
+### `{#await}` (Tier 2)
+- [ ] `has_blockers` / `$.async()` wrapping for experimental async mode
+- [ ] Dev-mode `$.apply()` wrapping for await expression
+- [ ] Array destructuring in then/catch bindings (e.g., `{:then [a, b]}`)
+- [ ] Validation: duplicate `{:then}` or `{:catch}` clauses
 
 ### Component `bind:this` (Tier 5)
 - [ ] SequenceExpression custom getter/setter: `bind:this={() => get(), (v) => set(v)}` — rarely used, needs expression visitor in codegen

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -40,6 +40,7 @@ fn item_is_dynamic(
         | FragmentItem::KeyBlock(id)
         | FragmentItem::SvelteElement(id)
         | FragmentItem::SvelteBoundary(id)
+        | FragmentItem::AwaitBlock(id)
         | FragmentItem::TitleElement(id) => dynamic_nodes.contains(id),
     }
 }
@@ -60,6 +61,7 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
             FragmentItem::ComponentNode(id) => return ContentStrategy::SingleBlock(SingleBlockKind::ComponentNode(*id)),
             FragmentItem::SvelteElement(id) => return ContentStrategy::SingleBlock(SingleBlockKind::SvelteElement(*id)),
             FragmentItem::SvelteBoundary(id) => return ContentStrategy::SingleBlock(SingleBlockKind::SvelteBoundary(*id)),
+            FragmentItem::AwaitBlock(id) => return ContentStrategy::SingleBlock(SingleBlockKind::AwaitBlock(*id)),
             FragmentItem::TitleElement(id) => return ContentStrategy::SingleBlock(SingleBlockKind::TitleElement(*id)),
             FragmentItem::TextConcat { .. } => {}
         }
@@ -81,6 +83,7 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
             | FragmentItem::KeyBlock(_)
             | FragmentItem::SvelteElement(_)
             | FragmentItem::SvelteBoundary(_)
+            | FragmentItem::AwaitBlock(_)
             | FragmentItem::TitleElement(_) => has_block = true,
             FragmentItem::TextConcat { has_expr, .. } => {
                 if *has_expr {

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -54,6 +54,9 @@ pub enum FragmentKey {
     SvelteHeadBody(NodeId),
     SvelteElementBody(NodeId),
     SvelteBoundaryBody(NodeId),
+    AwaitPending(NodeId),
+    AwaitThen(NodeId),
+    AwaitCatch(NodeId),
 }
 
 // ---------------------------------------------------------------------------
@@ -272,6 +275,8 @@ pub enum FragmentItem {
     SvelteElement(NodeId),
     /// A SvelteBoundary (<svelte:boundary>).
     SvelteBoundary(NodeId),
+    /// An AwaitBlock ({#await expr}...{/await}).
+    AwaitBlock(NodeId),
     /// A <title> element inside <svelte:head>, special-cased to assign document.title.
     TitleElement(NodeId),
     /// Adjacent text nodes and expression tags grouped together.
@@ -299,6 +304,7 @@ impl FragmentItem {
             | FragmentItem::KeyBlock(id)
             | FragmentItem::SvelteElement(id)
             | FragmentItem::SvelteBoundary(id)
+            | FragmentItem::AwaitBlock(id)
             | FragmentItem::TitleElement(id) => *id,
             FragmentItem::TextConcat { .. } => panic!("TextConcat has no single NodeId"),
         }
@@ -378,6 +384,7 @@ pub enum SingleBlockKind {
     ComponentNode(NodeId),
     SvelteElement(NodeId),
     SvelteBoundary(NodeId),
+    AwaitBlock(NodeId),
     TitleElement(NodeId),
 }
 
@@ -387,6 +394,7 @@ impl SingleBlockKind {
             Self::IfBlock(id) | Self::EachBlock(id) | Self::HtmlTag(id)
             | Self::KeyBlock(id) | Self::RenderTag(id) | Self::ComponentNode(id)
             | Self::SvelteElement(id) | Self::SvelteBoundary(id)
+            | Self::AwaitBlock(id)
             | Self::TitleElement(id) => *id,
         }
     }

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -62,6 +62,17 @@ fn lower_fragment(
             Node::SvelteBoundary(b) => {
                 lower_fragment(&b.fragment, FragmentKey::SvelteBoundaryBody(b.id), component, data);
             }
+            Node::AwaitBlock(block) => {
+                if let Some(ref p) = block.pending {
+                    lower_fragment(p, FragmentKey::AwaitPending(block.id), component, data);
+                }
+                if let Some(ref t) = block.then {
+                    lower_fragment(t, FragmentKey::AwaitThen(block.id), component, data);
+                }
+                if let Some(ref c) = block.catch {
+                    lower_fragment(c, FragmentKey::AwaitCatch(block.id), component, data);
+                }
+            }
             Node::SvelteWindow(_) | Node::SvelteDocument(_) | Node::SvelteBody(_) => {}
             Node::Text(_) | Node::Comment(_) | Node::ExpressionTag(_) | Node::RenderTag(_) | Node::HtmlTag(_) | Node::ConstTag(_) | Node::Error(_) => {}
         }
@@ -170,6 +181,7 @@ fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) ->
                     Node::KeyBlock(block) => items.push(FragmentItem::KeyBlock(block.id)),
                     Node::SvelteElement(el) => items.push(FragmentItem::SvelteElement(el.id)),
                     Node::SvelteBoundary(b) => items.push(FragmentItem::SvelteBoundary(b.id)),
+                    Node::AwaitBlock(block) => items.push(FragmentItem::AwaitBlock(block.id)),
                     _ => {}
                 }
             }

--- a/crates/svelte_analyze/src/needs_var.rs
+++ b/crates/svelte_analyze/src/needs_var.rs
@@ -63,6 +63,6 @@ fn item_needs_var(item: &FragmentItem, data: &AnalysisData) -> bool {
             // Already computed: leave_element processes children before parents
             data.element_flags.needs_var.contains(id)
         }
-        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) | FragmentItem::TitleElement(_) => true,
+        FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) | FragmentItem::AwaitBlock(_) | FragmentItem::TitleElement(_) => true,
     }
 }

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -188,6 +188,19 @@ fn walk_node<'a>(
             parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
             walk_fragment(alloc, &block.fragment, component, data, parsed, diags);
         }
+        Node::AwaitBlock(block) => {
+            let source = component.source_text(block.expression_span);
+            parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
+            if let Some(ref p) = block.pending {
+                walk_fragment(alloc, p, component, data, parsed, diags);
+            }
+            if let Some(ref t) = block.then {
+                walk_fragment(alloc, t, component, data, parsed, diags);
+            }
+            if let Some(ref c) = block.catch {
+                walk_fragment(alloc, c, component, data, parsed, diags);
+            }
+        }
         Node::ConstTag(tag) => {
             let decl_text = component.source_text(tag.declaration_span);
             let arena_source: &'a str = alloc.alloc_str(decl_text);

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,6 +1,6 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
+    AnimateDirective, AttachTag, Attribute, AwaitBlock, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, HtmlTag, IfBlock, KeyBlock, NodeId, RenderTag, SvelteBoundary,
     TransitionDirective, UseDirective,
 };
@@ -105,6 +105,11 @@ impl TemplateVisitor for ReactivityVisitor {
         if self.expr_is_dynamic(&block.id, data) {
             data.dynamic_nodes.insert(block.id);
         }
+    }
+
+    fn visit_await_block(&mut self, block: &AwaitBlock, _scope: ScopeId, data: &mut AnalysisData) {
+        // Await blocks are always dynamic
+        data.dynamic_nodes.insert(block.id);
     }
 
     fn visit_component_attribute(&mut self, attr: &Attribute, cn: &ComponentNode, _scope: ScopeId, data: &mut AnalysisData) {

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -21,8 +21,10 @@ pub struct Rune {
 pub struct ComponentScoping {
     scoping: Scoping,
     runes: FxHashMap<SymbolId, Rune>,
-    /// Our AST NodeId → OXC ScopeId for scope-introducing nodes (each blocks, snippets).
+    /// Our AST NodeId → OXC ScopeId for scope-introducing nodes (each blocks, snippets, await then).
     node_scopes: FxHashMap<NodeId, ScopeId>,
+    /// AwaitBlock NodeId → ScopeId for the catch fragment (separate from node_scopes which stores then scope).
+    await_catch_scopes: FxHashMap<NodeId, ScopeId>,
     // SymbolId-keyed classification fields (single source of truth for semantic decisions)
     prop_source_syms: FxHashSet<SymbolId>,
     prop_non_source_names: FxHashMap<SymbolId, String>,
@@ -39,6 +41,7 @@ impl ComponentScoping {
             scoping,
             runes: FxHashMap::default(),
             node_scopes: FxHashMap::default(),
+            await_catch_scopes: FxHashMap::default(),
             prop_source_syms: FxHashSet::default(),
             prop_non_source_names: FxHashMap::default(),
             store_syms: FxHashMap::default(),
@@ -72,6 +75,14 @@ impl ComponentScoping {
 
     pub fn set_node_scope(&mut self, node_id: NodeId, scope_id: ScopeId) {
         self.node_scopes.insert(node_id, scope_id);
+    }
+
+    pub fn set_await_catch_scope(&mut self, node_id: NodeId, scope_id: ScopeId) {
+        self.await_catch_scopes.insert(node_id, scope_id);
+    }
+
+    pub fn await_catch_scope(&self, node_id: NodeId) -> Option<ScopeId> {
+        self.await_catch_scopes.get(&node_id).copied()
     }
 
     // -- Symbol management --
@@ -254,6 +265,32 @@ pub fn build_scoping(component: &Component, data: &mut AnalysisData) -> crate::m
     crate::markers::ScopingBuilt::new()
 }
 
+/// Extract binding names from a pattern string.
+/// Simple identifiers return themselves; destructured patterns like `{ name, age }` extract identifiers.
+fn extract_binding_names(pattern: &str) -> Vec<String> {
+    let trimmed = pattern.trim();
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        // Destructured — extract identifier names.
+        // Simple approach: strip braces/brackets, split by comma, strip defaults
+        let inner = &trimmed[1..trimmed.len()-1];
+        inner.split(',')
+            .filter_map(|s| {
+                // Handle `name = default` or just `name`
+                let s = s.split('=').next().unwrap_or("").trim();
+                // Handle `key: alias` (rename)
+                let s = if let Some((_key, alias)) = s.split_once(':') {
+                    alias.trim()
+                } else {
+                    s
+                };
+                if s.is_empty() { None } else { Some(s.to_string()) }
+            })
+            .collect()
+    } else {
+        vec![trimmed.to_string()]
+    }
+}
+
 fn walk_template_scopes(
     fragment: &Fragment,
     component: &Component,
@@ -326,6 +363,44 @@ fn walk_template_scopes(
                     for name in names {
                         let sym_id = scoping.add_binding(current_scope, name);
                         scoping.mark_rune(sym_id, RuneKind::Derived);
+                    }
+                }
+            }
+            Node::AwaitBlock(block) => {
+                // Pending fragment uses parent scope (no bindings)
+                if let Some(ref p) = block.pending {
+                    walk_template_scopes(p, component, scoping, current_scope, const_tag_names, snippet_params);
+                }
+
+                // Then fragment: create child scope if value binding exists
+                if let Some(ref t) = block.then {
+                    if let Some(val_span) = block.value_span {
+                        let then_scope = scoping.add_child_scope(current_scope);
+                        scoping.set_node_scope(block.id, then_scope);
+                        let binding_text = component.source_text(val_span);
+                        // For destructured bindings like `{ name, age }`, extract identifiers
+                        for name in extract_binding_names(binding_text) {
+                            scoping.add_binding(then_scope, &name);
+                        }
+                        walk_template_scopes(t, component, scoping, then_scope, const_tag_names, snippet_params);
+                    } else {
+                        walk_template_scopes(t, component, scoping, current_scope, const_tag_names, snippet_params);
+                    }
+                }
+
+                // Catch fragment: create child scope if error binding exists
+                if let Some(ref c) = block.catch {
+                    if let Some(err_span) = block.error_span {
+                        let catch_scope = scoping.add_child_scope(current_scope);
+                        // Store catch scope separately — we use await_catch_scopes map
+                        scoping.set_await_catch_scope(block.id, catch_scope);
+                        let binding_text = component.source_text(err_span);
+                        for name in extract_binding_names(binding_text) {
+                            scoping.add_binding(catch_scope, &name);
+                        }
+                        walk_template_scopes(c, component, scoping, catch_scope, const_tag_names, snippet_params);
+                    } else {
+                        walk_template_scopes(c, component, scoping, current_scope, const_tag_names, snippet_params);
                     }
                 }
             }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,6 +1,6 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
-    AnimateDirective, AttachTag, Attribute, BindDirective, ComponentNode, ConstTag, EachBlock,
+    AnimateDirective, AttachTag, Attribute, AwaitBlock, BindDirective, ComponentNode, ConstTag, EachBlock,
     Element, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, RenderTag, SnippetBlock,
     SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow, TransitionDirective, UseDirective,
 };
@@ -33,6 +33,7 @@ pub(crate) trait TemplateVisitor {
     fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_await_block(&mut self, block: &AwaitBlock, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_bind_directive(&mut self, dir: &BindDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_use_directive(&mut self, dir: &UseDirective, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
@@ -145,6 +146,20 @@ pub(crate) fn walk_template<V: TemplateVisitor>(
                 visitor.visit_svelte_boundary(b, scope, data);
                 walk_template(&b.fragment, data, scope, visitor);
             }
+            Node::AwaitBlock(block) => {
+                visitor.visit_await_block(block, scope, data);
+                if let Some(ref p) = block.pending {
+                    walk_template(p, data, scope, visitor);
+                }
+                if let Some(ref t) = block.then {
+                    let then_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
+                    walk_template(t, data, then_scope, visitor);
+                }
+                if let Some(ref c) = block.catch {
+                    let catch_scope = data.scoping.await_catch_scope(block.id).unwrap_or(scope);
+                    walk_template(c, data, catch_scope, visitor);
+                }
+            }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
     }
@@ -198,6 +213,9 @@ macro_rules! delegate_visitor_methods {
         }
         fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_svelte_boundary(boundary, scope, data);)+
+        }
+        fn visit_await_block(&mut self, block: &AwaitBlock, scope: ScopeId, data: &mut AnalysisData) {
+            $(self.$idx.visit_await_block(block, scope, data);)+
         }
         fn visit_attribute(&mut self, attr: &Attribute, el: &Element, scope: ScopeId, data: &mut AnalysisData) {
             $(self.$idx.visit_attribute(attr, el, scope, data);)+

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -129,6 +129,7 @@ impl_node_enum! {
     SvelteDocument(SvelteDocument)   => is_svelte_document / as_svelte_document,
     SvelteBody(SvelteBody)           => is_svelte_body / as_svelte_body,
     SvelteBoundary(SvelteBoundary)   => is_svelte_boundary / as_svelte_boundary,
+    AwaitBlock(AwaitBlock)           => is_await_block / as_await_block,
     Error(ErrorNode)                 => is_error / as_error,
 }
 
@@ -380,6 +381,27 @@ pub struct SvelteBoundary {
     pub span: Span,
     pub attributes: Vec<Attribute>,
     pub fragment: Fragment,
+}
+
+// ---------------------------------------------------------------------------
+// AwaitBlock — {#await expr}...{:then val}...{:catch err}...{/await}
+// ---------------------------------------------------------------------------
+
+pub struct AwaitBlock {
+    pub id: NodeId,
+    pub span: Span,
+    /// Span of the promise expression.
+    pub expression_span: Span,
+    /// Span of the then binding pattern (e.g., `value` or `{name, age}`). None if no binding.
+    pub value_span: Option<Span>,
+    /// Span of the catch binding pattern (e.g., `error`). None if no binding.
+    pub error_span: Option<Span>,
+    /// Content shown while promise is pending. None if short form.
+    pub pending: Option<Fragment>,
+    /// Content shown when promise resolves.
+    pub then: Option<Fragment>,
+    /// Content shown when promise rejects.
+    pub catch: Option<Fragment>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -85,6 +85,15 @@ impl<'a> Builder<'a> {
         self.ast.expression_null_literal(SPAN)
     }
 
+    /// `void 0` expression — used where `undefined` is needed but `null` is semantically wrong.
+    pub fn void_zero_expr(&self) -> Expression<'a> {
+        self.ast.expression_unary(
+            SPAN,
+            ast::UnaryOperator::Void,
+            self.num_expr(0.0),
+        )
+    }
+
     pub fn num(&self, value: f64) -> NumericLiteral<'a> {
         self.ast.numeric_literal(SPAN, value, None, ast::NumberBase::Decimal)
     }
@@ -237,6 +246,56 @@ impl<'a> Builder<'a> {
             false,
         );
         Statement::VariableDeclaration(self.alloc(declaration))
+    }
+
+    /// `var { a, b } = init;` — object destructuring var declaration.
+    pub fn var_object_destruct_stmt(&self, names: &[String], init: Expression<'a>) -> Statement<'a> {
+        let properties: Vec<_> = names.iter().map(|name| {
+            let atom = self.ast.atom(name.as_str());
+            let key = ast::PropertyKey::StaticIdentifier(
+                self.alloc(self.ast.identifier_name(SPAN, atom)),
+            );
+            let value = self.ast.binding_pattern_binding_identifier(SPAN, self.ast.atom(name.as_str()));
+            self.ast.binding_property(SPAN, key, value, true, false)
+        }).collect();
+        let object_pattern = self.ast.object_pattern(
+            SPAN,
+            self.ast.vec_from_iter(properties),
+            NONE,
+        );
+        let pattern = ast::BindingPattern::ObjectPattern(self.alloc(object_pattern));
+        let decl = self.ast.variable_declarator(
+            SPAN, VariableDeclarationKind::Var, pattern, NONE, Some(init), false,
+        );
+        let declaration = self.ast.variable_declaration(
+            SPAN,
+            VariableDeclarationKind::Var,
+            self.ast.vec_from_array([decl]),
+            false,
+        );
+        Statement::VariableDeclaration(self.alloc(declaration))
+    }
+
+    /// `{ a, b }` — shorthand object expression.
+    pub fn shorthand_object_expr(&self, names: &[String]) -> Expression<'a> {
+        let properties: Vec<_> = names.iter().map(|name| {
+            let atom = self.ast.atom(name.as_str());
+            let key = ast::PropertyKey::StaticIdentifier(
+                self.alloc(self.ast.identifier_name(SPAN, atom)),
+            );
+            let value = self.rid_expr(name);
+            self.ast.object_property_kind_object_property(
+                SPAN,
+                ast::PropertyKind::Init,
+                key,
+                value,
+                false, true, false, // computed=false, shorthand=true, method=false
+            )
+        }).collect();
+        self.ast.expression_object(
+            SPAN,
+            self.ast.vec_from_iter(properties),
+        )
     }
 
     /// `const { a, b } = init;` — object destructuring const declaration.

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::Statement;
 use svelte_analyze::{AnalysisData, ContentStrategy, FragmentKey, IdentGen, LoweredFragment, ParsedExprs};
-use svelte_ast::{Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow};
+use svelte_ast::{AwaitBlock, Component, ComponentNode, ConstTag, EachBlock, Element, Fragment, IfBlock, Node, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow};
 use svelte_js::ExpressionInfo;
 use svelte_span::Span;
 use svelte_transform::TransformData;
@@ -20,6 +20,7 @@ struct NodeIndex<'a> {
     const_tags: FxHashMap<NodeId, &'a ConstTag>,
     svelte_elements: FxHashMap<NodeId, &'a SvelteElement>,
     svelte_boundaries: FxHashMap<NodeId, &'a SvelteBoundary>,
+    await_blocks: FxHashMap<NodeId, &'a AwaitBlock>,
     svelte_windows: FxHashMap<NodeId, &'a SvelteWindow>,
     svelte_documents: FxHashMap<NodeId, &'a SvelteDocument>,
     svelte_bodies: FxHashMap<NodeId, &'a SvelteBody>,
@@ -38,6 +39,7 @@ impl<'a> NodeIndex<'a> {
             const_tags: FxHashMap::default(),
             svelte_elements: FxHashMap::default(),
             svelte_boundaries: FxHashMap::default(),
+            await_blocks: FxHashMap::default(),
             svelte_windows: FxHashMap::default(),
             svelte_documents: FxHashMap::default(),
             svelte_bodies: FxHashMap::default(),
@@ -96,6 +98,12 @@ impl<'a> NodeIndex<'a> {
                 Node::SvelteBoundary(b) => {
                     self.svelte_boundaries.insert(b.id, b);
                     self.walk(&b.fragment);
+                }
+                Node::AwaitBlock(b) => {
+                    self.await_blocks.insert(b.id, b);
+                    if let Some(ref p) = b.pending { self.walk(p); }
+                    if let Some(ref t) = b.then { self.walk(t); }
+                    if let Some(ref c) = b.catch { self.walk(c); }
                 }
                 Node::SvelteWindow(w) => {
                     self.svelte_windows.insert(w.id, w);
@@ -183,6 +191,7 @@ impl<'a> Ctx<'a> {
     pub fn render_tag(&self, id: NodeId) -> &'a RenderTag { self.get_node(&self.index.render_tags, id, "render tag") }
     pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.get_node(&self.index.svelte_elements, id, "svelte element") }
     pub fn svelte_boundary(&self, id: NodeId) -> &'a SvelteBoundary { self.get_node(&self.index.svelte_boundaries, id, "svelte boundary") }
+    pub fn await_block(&self, id: NodeId) -> &'a AwaitBlock { self.get_node(&self.index.await_blocks, id, "await block") }
     pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow { self.get_node(&self.index.svelte_windows, id, "svelte window") }
     pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument { self.get_node(&self.index.svelte_documents, id, "svelte document") }
     pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody { self.get_node(&self.index.svelte_bodies, id, "svelte body") }

--- a/crates/svelte_codegen_client/src/template/await_block.rs
+++ b/crates/svelte_codegen_client/src/template/await_block.rs
@@ -1,0 +1,141 @@
+//! AwaitBlock code generation.
+
+use oxc_ast::ast::{Expression, Statement};
+
+use svelte_analyze::FragmentKey;
+use svelte_ast::NodeId;
+
+use crate::builder::Arg;
+use crate::context::Ctx;
+
+use super::gen_fragment;
+use super::expression::build_node_thunk;
+
+/// Generate statements for an `{#await ...}` block.
+///
+/// Order matches the reference compiler: expression → then → catch → pending.
+/// This matters because fragment generation assigns template variable numbers sequentially.
+pub(crate) fn gen_await_block<'a>(
+    ctx: &mut Ctx<'a>,
+    block_id: NodeId,
+    anchor: Expression<'a>,
+    body: &mut Vec<Statement<'a>>,
+) {
+    let block = ctx.await_block(block_id);
+    let has_pending = block.pending.is_some();
+    let has_then = block.then.is_some();
+    let has_catch = block.catch.is_some();
+    let value_span = block.value_span;
+    let error_span = block.error_span;
+
+    // Expression thunk: () => promise (visit expression first for correct scope order)
+    let expression = build_node_thunk(ctx, block_id);
+
+    // Then callback (generated before pending to match reference compiler ordering)
+    let then_fn = if has_then {
+        let then_key = FragmentKey::AwaitThen(block_id);
+        gen_await_callback(ctx, then_key, value_span)
+    } else if has_catch {
+        ctx.b.void_zero_expr()
+    } else {
+        ctx.b.null_expr()
+    };
+
+    // Catch callback
+    let catch_fn = if has_catch {
+        let catch_key = FragmentKey::AwaitCatch(block_id);
+        gen_await_callback(ctx, catch_key, error_span)
+    } else {
+        ctx.b.null_expr()
+    };
+
+    // Pending callback (generated last)
+    let pending_fn = if has_pending {
+        let pending_key = FragmentKey::AwaitPending(block_id);
+        let frag_body = gen_fragment(ctx, pending_key);
+        ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), frag_body)
+    } else {
+        ctx.b.null_expr()
+    };
+
+    // Build args, trimming trailing nulls
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Expr(anchor),
+        Arg::Expr(expression),
+        Arg::Expr(pending_fn),
+    ];
+
+    if has_then || has_catch {
+        args.push(Arg::Expr(then_fn));
+    }
+    if has_catch {
+        args.push(Arg::Expr(catch_fn));
+    }
+
+    body.push(ctx.b.call_stmt("$.await", args));
+}
+
+/// Generate a callback for then/catch: `($$anchor, binding) => { ...fragment... }`
+fn gen_await_callback<'a>(
+    ctx: &mut Ctx<'a>,
+    fragment_key: FragmentKey,
+    binding_span: Option<svelte_span::Span>,
+) -> Expression<'a> {
+    let frag_body = gen_fragment(ctx, fragment_key);
+
+    if let Some(span) = binding_span {
+        let binding_text = ctx.component.source_text(span).to_string();
+        let trimmed = binding_text.trim();
+
+        if trimmed.starts_with('{') || trimmed.starts_with('[') {
+            gen_destructured_callback(ctx, trimmed, frag_body)
+        } else {
+            ctx.b.arrow_block_expr(ctx.b.params(["$$anchor", trimmed]), frag_body)
+        }
+    } else {
+        ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), frag_body)
+    }
+}
+
+/// Generate callback for destructured bindings.
+fn gen_destructured_callback<'a>(
+    ctx: &mut Ctx<'a>,
+    pattern: &str,
+    frag_body: Vec<Statement<'a>>,
+) -> Expression<'a> {
+    let inner = &pattern[1..pattern.len()-1];
+    let names: Vec<String> = inner.split(',')
+        .filter_map(|s| {
+            let s = s.split('=').next().unwrap_or("").trim();
+            let s = if let Some((_key, alias)) = s.split_once(':') {
+                alias.trim()
+            } else {
+                s
+            };
+            if s.is_empty() { None } else { Some(s.to_string()) }
+        })
+        .collect();
+
+    let mut declarations: Vec<Statement<'a>> = Vec::new();
+
+    // var $$value = $.derived(() => { var { name, age } = $.get($$source); return { name, age }; });
+    let get_source = ctx.b.call_expr("$.get", [Arg::Ident("$$source")]);
+    let destruct_stmt = ctx.b.var_object_destruct_stmt(&names, get_source);
+    let return_obj = ctx.b.shorthand_object_expr(&names);
+    let return_stmt = ctx.b.return_stmt(return_obj);
+    let derived_fn = ctx.b.thunk_block(vec![destruct_stmt, return_stmt]);
+    let derived_call = ctx.b.call_expr("$.derived", [Arg::Expr(derived_fn)]);
+    declarations.push(ctx.b.var_stmt("$$value", derived_call));
+
+    // var name = $.derived(() => $.get($$value).name);
+    for name in &names {
+        let get_value = ctx.b.call_expr("$.get", [Arg::Ident("$$value")]);
+        let member = ctx.b.static_member_expr(get_value, name);
+        let getter_fn = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(member)]);
+        let per_field_derived = ctx.b.call_expr("$.derived", [Arg::Expr(getter_fn)]);
+        declarations.push(ctx.b.var_stmt(name, per_field_derived));
+    }
+
+    declarations.extend(frag_body);
+    ctx.b.arrow_block_expr(ctx.b.params(["$$anchor", "$$source"]), declarations)
+}

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -161,7 +161,7 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
     match item {
         svelte_analyze::FragmentItem::TextConcat { has_expr, .. } => *has_expr,
         svelte_analyze::FragmentItem::Element(id) => ctx.needs_var(*id),
-        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) | svelte_analyze::FragmentItem::SvelteBoundary(_) | svelte_analyze::FragmentItem::TitleElement(_) => {
+        svelte_analyze::FragmentItem::ComponentNode(_) | svelte_analyze::FragmentItem::IfBlock(_) | svelte_analyze::FragmentItem::EachBlock(_) | svelte_analyze::FragmentItem::RenderTag(_) | svelte_analyze::FragmentItem::HtmlTag(_) | svelte_analyze::FragmentItem::KeyBlock(_) | svelte_analyze::FragmentItem::SvelteElement(_) | svelte_analyze::FragmentItem::SvelteBoundary(_) | svelte_analyze::FragmentItem::AwaitBlock(_) | svelte_analyze::FragmentItem::TitleElement(_) => {
             true
         }
     }

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -215,7 +215,7 @@ pub(crate) fn emit_trailing_next<'a>(
 pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     match item {
         FragmentItem::TextConcat { parts, .. } => parts_are_dynamic(parts, ctx),
-        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) | FragmentItem::SvelteBoundary(id) | FragmentItem::TitleElement(id) => {
+        FragmentItem::Element(id) | FragmentItem::ComponentNode(id) | FragmentItem::IfBlock(id) | FragmentItem::EachBlock(id) | FragmentItem::RenderTag(id) | FragmentItem::HtmlTag(id) | FragmentItem::KeyBlock(id) | FragmentItem::SvelteElement(id) | FragmentItem::SvelteBoundary(id) | FragmentItem::AwaitBlock(id) | FragmentItem::TitleElement(id) => {
             ctx.is_dynamic(*id)
         }
     }

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -31,7 +31,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> String {
                 let el = ctx.element(*id);
                 html.push_str(&element_html(ctx, el));
             }
-            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) | FragmentItem::TitleElement(_) => html.push_str("<!>"),
+            FragmentItem::ComponentNode(_) | FragmentItem::IfBlock(_) | FragmentItem::EachBlock(_) | FragmentItem::RenderTag(_) | FragmentItem::HtmlTag(_) | FragmentItem::KeyBlock(_) | FragmentItem::SvelteElement(_) | FragmentItem::SvelteBoundary(_) | FragmentItem::AwaitBlock(_) | FragmentItem::TitleElement(_) => html.push_str("<!>"),
         }
     }
     html

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -1,6 +1,7 @@
 //! Template and DOM traversal code generation.
 
 pub(crate) mod attributes;
+pub(crate) mod await_block;
 pub(crate) mod component;
 pub(crate) mod const_tag;
 pub(crate) mod each_block;
@@ -32,6 +33,7 @@ use crate::context::Ctx;
 use element::process_element;
 use expression::{emit_template_effect, emit_text_update, emit_trailing_next};
 use html::{element_html, fragment_html};
+use await_block::gen_await_block;
 use component::gen_component;
 use if_block::gen_if_block;
 use each_block::gen_each_block;
@@ -272,7 +274,10 @@ fn gen_root_single_block<'a>(ctx: &mut Ctx<'a>, kind: &SingleBlockKind, body: &m
         SingleBlockKind::SvelteBoundary(id) => {
             gen_svelte_boundary(ctx, *id, ctx.b.rid_expr(&node), body);
         }
-        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element/boundary at this point"),
+        SingleBlockKind::AwaitBlock(id) => {
+            gen_await_block(ctx, *id, ctx.b.rid_expr(&node), body);
+        }
+        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element/boundary/await at this point"),
     }
 
     body.push(ctx.b.call_stmt(
@@ -457,7 +462,10 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
                         SingleBlockKind::SvelteBoundary(id) => {
                             gen_svelte_boundary(ctx, *id, ctx.b.rid_expr(&node), &mut body);
                         }
-                        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element/boundary at this point"),
+                        SingleBlockKind::AwaitBlock(id) => {
+                            gen_await_block(ctx, *id, ctx.b.rid_expr(&node), &mut body);
+                        }
+                        _ => unreachable!("SingleBlock should be if/each/html/key/svelte_element/boundary/await at this point"),
                     }
                     body.push(ctx.b.call_stmt(
                         "$.append",

--- a/crates/svelte_codegen_client/src/template/traverse.rs
+++ b/crates/svelte_codegen_client/src/template/traverse.rs
@@ -7,6 +7,7 @@ use svelte_analyze::FragmentItem;
 use crate::builder::{Arg, AssignLeft, AssignRight};
 use crate::context::Ctx;
 
+use super::await_block::gen_await_block;
 use super::component::gen_component;
 use super::each_block::gen_each_block;
 use super::element::{item_needs_var, process_element};
@@ -95,6 +96,7 @@ pub(crate) fn traverse_items<'a>(
                 | FragmentItem::KeyBlock(_)
                 | FragmentItem::SvelteElement(_)
                 | FragmentItem::SvelteBoundary(_)
+                | FragmentItem::AwaitBlock(_)
                 | FragmentItem::TitleElement(_) => {
                     let node_name = ctx.gen_ident("node");
                     init.push(ctx.b.var_stmt(&node_name, node_expr));
@@ -112,6 +114,7 @@ pub(crate) fn traverse_items<'a>(
                         FragmentItem::KeyBlock(id) => gen_key_block(ctx, *id, anchor, init),
                         FragmentItem::SvelteElement(id) => super::svelte_element::gen_svelte_element(ctx, *id, anchor, init),
                         FragmentItem::SvelteBoundary(id) => super::svelte_boundary::gen_svelte_boundary(ctx, *id, anchor, init),
+                        FragmentItem::AwaitBlock(id) => gen_await_block(ctx, *id, anchor, init),
                         FragmentItem::TitleElement(id) => super::title_element::gen_title_element(ctx, *id, init),
                         _ => unreachable!(),
                     }

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -5,7 +5,7 @@ use scanner::{
 use svelte_span::Span;
 
 use svelte_ast::{
-    AnimateDirective, Attribute, BindDirective, BooleanAttribute, ClassDirective, Comment,
+    AnimateDirective, Attribute, AwaitBlock, BindDirective, BooleanAttribute, ClassDirective, Comment,
     ComponentNode, ConstTag, ConcatPart, ConcatenationAttribute, Component, CssMode,
     CustomElementConfig, EachBlock, Element, ExpressionAttribute, Fragment, HtmlTag, IfBlock,
     KeyBlock, Namespace, Node, NodeIdAllocator, OnDirectiveLegacy, RawBlock, RenderTag, Script,
@@ -28,6 +28,7 @@ enum StackEntry {
     EachBlock(EachBlockEntry),
     SnippetBlock(SnippetBlockEntry),
     KeyBlock(KeyBlockEntry),
+    AwaitBlock(AwaitBlockEntry),
 }
 
 struct KeyBlockEntry {
@@ -64,6 +65,26 @@ struct SnippetBlockEntry {
     span_start: Span,
     name: String,
     params_span: Option<Span>,
+}
+
+/// Tracks which sub-fragment is currently being collected.
+enum AwaitPhase {
+    Pending,
+    Then,
+    Catch,
+}
+
+struct AwaitBlockEntry {
+    span: Span,
+    expression_span: Span,
+    value_span: Option<Span>,
+    error_span: Option<Span>,
+    /// Which phase we are currently collecting children for.
+    phase: AwaitPhase,
+    /// Pending children (collected before {:then}).
+    pending_children: Option<Vec<Node>>,
+    /// Then children (collected between {:then} and {:catch}).
+    then_children: Option<Vec<Node>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +270,38 @@ impl<'a> Parser<'a> {
                 }
                 TokenType::EndKeyTag => {
                     self.handle_end_key_tag(
+                        token.span,
+                        &mut entry_stack,
+                        &mut children_stack,
+                    );
+                }
+                TokenType::StartAwaitTag(await_tag) => {
+                    use scanner::token::AwaitInitialClause;
+                    let phase = match await_tag.initial_clause {
+                        AwaitInitialClause::Pending => AwaitPhase::Pending,
+                        AwaitInitialClause::Then => AwaitPhase::Then,
+                        AwaitInitialClause::Catch => AwaitPhase::Catch,
+                    };
+                    entry_stack.push(StackEntry::AwaitBlock(AwaitBlockEntry {
+                        span: token.span,
+                        expression_span: await_tag.expression_span,
+                        value_span: await_tag.value_span,
+                        error_span: await_tag.error_span,
+                        phase,
+                        pending_children: None,
+                        then_children: None,
+                    }));
+                    children_stack.push(vec![]);
+                }
+                TokenType::AwaitClauseTag(clause_tag) => {
+                    self.handle_await_clause_tag(
+                        &clause_tag,
+                        &mut entry_stack,
+                        &mut children_stack,
+                    );
+                }
+                TokenType::EndAwaitTag => {
+                    self.handle_end_await_tag(
                         token.span,
                         &mut entry_stack,
                         &mut children_stack,
@@ -587,6 +640,100 @@ impl<'a> Parser<'a> {
         push_child(children_stack, node);
     }
 
+    fn handle_await_clause_tag(
+        &mut self,
+        clause_tag: &scanner::token::AwaitClauseTag,
+        entry_stack: &mut Vec<StackEntry>,
+        children_stack: &mut Vec<Vec<Node>>,
+    ) {
+        let entry = entry_stack.last_mut();
+
+        let Some(StackEntry::AwaitBlock(ab)) = entry else {
+            self.recover(Diagnostic::unexpected_token(Span::new(0, 0)));
+            return;
+        };
+
+        // Save current children to the appropriate phase
+        let current_children = pop_children(children_stack);
+        match ab.phase {
+            AwaitPhase::Pending => {
+                ab.pending_children = Some(current_children);
+            }
+            AwaitPhase::Then => {
+                ab.then_children = Some(current_children);
+            }
+            AwaitPhase::Catch => {
+                // Shouldn't happen — {:catch} after {:catch}
+                self.recover(Diagnostic::unexpected_token(Span::new(0, 0)));
+                children_stack.push(vec![]);
+                return;
+            }
+        }
+
+        match clause_tag.clause {
+            scanner::token::AwaitClause::Then => {
+                ab.value_span = clause_tag.binding_span;
+                ab.phase = AwaitPhase::Then;
+            }
+            scanner::token::AwaitClause::Catch => {
+                ab.error_span = clause_tag.binding_span;
+                ab.phase = AwaitPhase::Catch;
+            }
+        }
+
+        // Push new children list for the next phase
+        children_stack.push(vec![]);
+    }
+
+    fn handle_end_await_tag(
+        &mut self,
+        span: Span,
+        entry_stack: &mut Vec<StackEntry>,
+        children_stack: &mut Vec<Vec<Node>>,
+    ) {
+        let entry = entry_stack.pop();
+
+        let Some(StackEntry::AwaitBlock(ab)) = entry else {
+            self.recover(Diagnostic::unexpected_token(span));
+            if let Some(entry) = entry {
+                entry_stack.push(entry);
+            }
+            return;
+        };
+
+        // Save current children to the appropriate phase
+        let current_children = pop_children(children_stack);
+        let merged_span = ab.span.merge(&span);
+
+        let (pending, then, catch) = match ab.phase {
+            AwaitPhase::Pending => {
+                (Some(Fragment::new(current_children)), None, None)
+            }
+            AwaitPhase::Then => {
+                let pending = ab.pending_children.map(Fragment::new);
+                (pending, Some(Fragment::new(current_children)), None)
+            }
+            AwaitPhase::Catch => {
+                let pending = ab.pending_children.map(Fragment::new);
+                let then = ab.then_children.map(Fragment::new);
+                (pending, then, Some(Fragment::new(current_children)))
+            }
+        };
+
+        let node = Node::AwaitBlock(AwaitBlock {
+            id: self.ids.next(),
+            span: merged_span,
+            expression_span: ab.expression_span,
+            value_span: ab.value_span,
+            error_span: ab.error_span,
+            pending,
+            then,
+            catch,
+        });
+
+        push_child(children_stack, node);
+    }
+
     /// Auto-close all remaining open entries at EOF.
     fn auto_close_entries(
         &mut self,
@@ -709,6 +856,30 @@ impl<'a> Parser<'a> {
                     span: merged_span,
                     expression_span: kb.expression_span,
                     fragment: Fragment::new(body_children),
+                });
+
+                push_child(children_stack, node);
+            }
+            StackEntry::AwaitBlock(ab) => {
+                self.recover(Diagnostic::unclosed_node(ab.span));
+                let current_children = pop_children(children_stack);
+                let merged_span = ab.span.merge(&eof_span);
+
+                let (pending, then, catch) = match ab.phase {
+                    AwaitPhase::Pending => (Some(Fragment::new(current_children)), None, None),
+                    AwaitPhase::Then => (ab.pending_children.map(Fragment::new), Some(Fragment::new(current_children)), None),
+                    AwaitPhase::Catch => (ab.pending_children.map(Fragment::new), ab.then_children.map(Fragment::new), Some(Fragment::new(current_children))),
+                };
+
+                let node = Node::AwaitBlock(AwaitBlock {
+                    id: self.ids.next(),
+                    span: merged_span,
+                    expression_span: ab.expression_span,
+                    value_span: ab.value_span,
+                    error_span: ab.error_span,
+                    pending,
+                    then,
+                    catch,
                 });
 
                 push_child(children_stack, node);

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -856,6 +856,7 @@ impl<'a> Scanner<'a> {
                 self.add_token(TokenType::StartKeyTag(StartKeyTag { expression_span }));
                 Ok(())
             }
+            "await" => self.start_await_tag(),
             _ => Err(Diagnostic::unexpected_keyword(Span::new(
                 start as u32,
                 self.current as u32,
@@ -923,6 +924,17 @@ impl<'a> Scanner<'a> {
 
                 Ok(())
             }
+            "await" => {
+                self.skip_whitespace();
+
+                if !self.match_char('}') {
+                    self.recover(Diagnostic::unexpected_token(Span::new(start as u32, self.current as u32)));
+                }
+
+                self.add_token(TokenType::EndAwaitTag);
+
+                Ok(())
+            }
             _ => Err(Diagnostic::unexpected_keyword(Span::new(
                 start as u32,
                 self.current as u32,
@@ -976,6 +988,29 @@ impl<'a> Scanner<'a> {
                         expression_span: None,
                     }));
                 }
+
+                Ok(())
+            }
+            "then" | "catch" => {
+                let clause = if keyword == "then" {
+                    token::AwaitClause::Then
+                } else {
+                    token::AwaitClause::Catch
+                };
+
+                self.skip_whitespace();
+
+                let binding_span = if self.peek() == Some('}') {
+                    self.advance();
+                    None
+                } else {
+                    Some(self.collect_await_binding()?)
+                };
+
+                self.add_token(TokenType::AwaitClauseTag(token::AwaitClauseTag {
+                    clause,
+                    binding_span,
+                }));
 
                 Ok(())
             }
@@ -1420,6 +1455,157 @@ impl<'a> Scanner<'a> {
                 ']' if bracket_depth > 0 => bracket_depth -= 1,
                 // At depth 0: `,` means index follows, `(` means key follows, `}` means end of block
                 ',' | '}' | '(' if curly_depth == 0 && bracket_depth == 0 => {
+                    let raw = self.slice_source(start, self.prev);
+                    let trim_start = raw.len() - raw.trim_start().len();
+                    let trim_end = raw.len() - raw.trim_end().len();
+                    let span_start = start + trim_start;
+                    let span_end = self.prev - trim_end;
+
+                    return Ok(Span::new(span_start as u32, span_end as u32));
+                }
+                _ => {}
+            }
+        }
+
+        Err(Diagnostic::unexpected_end_of_file(Span::new(
+            start as u32,
+            self.current as u32,
+        )))
+    }
+
+    /// Parse `{#await expr}`, `{#await expr then val}`, or `{#await expr catch err}`.
+    ///
+    /// The expression ends where a top-level `then` or `catch` keyword appears
+    /// (preceded and followed by whitespace), or at the closing `}`.
+    fn start_await_tag(&mut self) -> Result<(), Diagnostic> {
+        self.skip_whitespace();
+
+        // Scan for the expression, watching for ` then ` or ` catch ` keywords at top level
+        let expr_start = self.current;
+        let mut depth: u32 = 0; // tracks {}, (), []
+        let mut expr_end = expr_start;
+        let mut found_keyword: Option<&str> = None;
+
+        while !self.is_at_end() {
+            let ch = self.peek().unwrap();
+
+            if ch == '\'' || ch == '"' || ch == '`' {
+                self.advance();
+                self.skip_js_string(ch)?;
+                continue;
+            }
+
+            match ch {
+                '{' | '(' | '[' => { self.advance(); depth += 1; }
+                '}' if depth > 0 => { self.advance(); depth -= 1; }
+                ')' | ']' if depth > 0 => { self.advance(); depth -= 1; }
+                '}' if depth == 0 => {
+                    // End of tag — no then/catch keyword found
+                    expr_end = self.current;
+                    self.advance(); // consume '}'
+                    break;
+                }
+                _ if depth == 0 && ch.is_ascii_whitespace() => {
+                    // Save position before whitespace
+                    let ws_start = self.current;
+                    self.skip_whitespace();
+
+                    if self.is_at_end() { break; }
+
+                    let kw_start = self.current;
+                    let kw = self.identifier();
+
+                    if (kw == "then" || kw == "catch") && self.peek().is_some_and(|c| c.is_ascii_whitespace() || c == '}') {
+                        // Found the keyword — expression ends at whitespace before it
+                        expr_end = ws_start;
+                        found_keyword = if kw == "then" { Some("then") } else { Some("catch") };
+                        break;
+                    }
+                    // Not a keyword — continue scanning (identifier was consumed, that's fine)
+                }
+                _ => { self.advance(); }
+            }
+        }
+
+        // Trim the expression span
+        let raw = self.slice_source(expr_start, expr_end);
+        let trim_start = raw.len() - raw.trim_start().len();
+        let trim_end = raw.len() - raw.trim_end().len();
+        let expression_span = Span::new(
+            (expr_start + trim_start) as u32,
+            (expr_end - trim_end) as u32,
+        );
+
+        match found_keyword {
+            Some("then") => {
+                // Short form: {#await expr then val}
+                self.skip_whitespace();
+                let binding_span = if self.peek() == Some('}') {
+                    self.advance();
+                    None
+                } else {
+                    Some(self.collect_await_binding()?)
+                };
+                self.add_token(TokenType::StartAwaitTag(token::StartAwaitTag {
+                    expression_span,
+                    value_span: binding_span,
+                    error_span: None,
+                    initial_clause: token::AwaitInitialClause::Then,
+                }));
+            }
+            Some("catch") => {
+                // Short form: {#await expr catch err}
+                self.skip_whitespace();
+                let binding_span = if self.peek() == Some('}') {
+                    self.advance();
+                    None
+                } else {
+                    Some(self.collect_await_binding()?)
+                };
+                self.add_token(TokenType::StartAwaitTag(token::StartAwaitTag {
+                    expression_span,
+                    value_span: None,
+                    error_span: binding_span,
+                    initial_clause: token::AwaitInitialClause::Catch,
+                }));
+            }
+            _ => {
+                // Implicit form: {#await expr}
+                self.add_token(TokenType::StartAwaitTag(token::StartAwaitTag {
+                    expression_span,
+                    value_span: None,
+                    error_span: None,
+                    initial_clause: token::AwaitInitialClause::Pending,
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Collect a binding pattern for `{:then val}` / `{:catch err}` / `{#await expr then val}`.
+    /// Handles simple identifiers and destructured patterns like `{name, age}` or `[a, b]`.
+    /// Stops at `}` at depth 0 (closing the tag).
+    fn collect_await_binding(&mut self) -> Result<Span, Diagnostic> {
+        let mut curly_depth: u32 = 0;
+        let mut bracket_depth: u32 = 0;
+        let start = self.current;
+
+        while !self.is_at_end() {
+            let char = self.advance();
+
+            if char == '\'' || char == '"' || char == '`' {
+                self.skip_js_string(char)?;
+                continue;
+            }
+
+            match char {
+                '{' => curly_depth += 1,
+                '}' if curly_depth > 0 => curly_depth -= 1,
+                '[' => bracket_depth += 1,
+                ']' if bracket_depth > 0 => bracket_depth -= 1,
+                '}' if curly_depth == 0 && bracket_depth == 0 => {
+                    // End of tag
                     let raw = self.slice_source(start, self.prev);
                     let trim_start = raw.len() - raw.trim_start().len();
                     let trim_end = raw.len() - raw.trim_end().len();

--- a/crates/svelte_parser/src/scanner/token.rs
+++ b/crates/svelte_parser/src/scanner/token.rs
@@ -21,6 +21,9 @@ pub enum TokenType {
     ConstTag(ConstTagToken),
     StartKeyTag(StartKeyTag),
     EndKeyTag,
+    StartAwaitTag(StartAwaitTag),
+    AwaitClauseTag(AwaitClauseTag),
+    EndAwaitTag,
     StyleTag(StyleTag),
     EOF,
 }
@@ -215,6 +218,39 @@ pub struct ConstTagToken {
 #[derive(Debug, PartialEq, Eq)]
 pub struct StartKeyTag {
     pub expression_span: Span,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StartAwaitTag {
+    pub expression_span: Span,
+    /// Then binding span if short form `{#await expr then val}`. None for implicit form.
+    pub value_span: Option<Span>,
+    /// Catch binding span if short form `{#await expr catch err}`. None for implicit form.
+    pub error_span: Option<Span>,
+    /// Which fragment to start collecting into.
+    pub initial_clause: AwaitInitialClause,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AwaitInitialClause {
+    /// Implicit form: `{#await expr}` — pending content follows.
+    Pending,
+    /// Short form: `{#await expr then val}` — then content follows.
+    Then,
+    /// Short form: `{#await expr catch err}` — catch content follows.
+    Catch,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AwaitClauseTag {
+    pub clause: AwaitClause,
+    pub binding_span: Option<Span>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AwaitClause {
+    Then,
+    Catch,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -189,6 +189,26 @@ fn walk_node<'a>(
                 walk_fragment(ctx, &b.fragment, component, parsed, scope);
             });
         }
+        Node::AwaitBlock(block) => {
+            transform_node_expr(ctx, block.id, parsed, scope);
+            if let Some(ref p) = block.pending {
+                with_alias_scope(ctx, |ctx| {
+                    walk_fragment(ctx, p, component, parsed, scope);
+                });
+            }
+            if let Some(ref t) = block.then {
+                let then_scope = ctx.analysis.scoping.node_scope(block.id).unwrap_or(scope);
+                with_alias_scope(ctx, |ctx| {
+                    walk_fragment(ctx, t, component, parsed, then_scope);
+                });
+            }
+            if let Some(ref c) = block.catch {
+                let catch_scope = ctx.analysis.scoping.await_catch_scope(block.id).unwrap_or(scope);
+                with_alias_scope(ctx, |ctx| {
+                    walk_fragment(ctx, c, component, parsed, catch_scope);
+                });
+            }
+        }
         Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
 }

--- a/tasks/compiler_tests/cases2/await_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_basic/case-rust.js
@@ -1,0 +1,26 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_2 = root_3();
+		$.append($$anchor, p_2);
+	}, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	}, ($$anchor, error) => {
+		var p_1 = root_2();
+		var text_1 = $.child(p_1, true);
+		$.reset(p_1);
+		$.template_effect(() => $.set_text(text_1, $.get(error).message));
+		$.append($$anchor, p_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_basic/case-svelte.js
@@ -1,0 +1,26 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p> </p>`);
+var root_3 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_2 = root_3();
+		$.append($$anchor, p_2);
+	}, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	}, ($$anchor, error) => {
+		var p_1 = root_2();
+		var text_1 = $.child(p_1, true);
+		$.reset(p_1);
+		$.template_effect(() => $.set_text(text_1, $.get(error).message));
+		$.append($$anchor, p_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/await_basic/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise}
+	<p>Loading...</p>
+{:then value}
+	<p>{value}</p>
+{:catch error}
+	<p>{error.message}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_destructured/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_destructured/case-rust.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, $$source) => {
+		var $$value = $.derived(() => {
+			var { name, age } = $.get($$source);
+			return {
+				name,
+				age
+			};
+		});
+		var name = $.derived(() => $.get($$value).name);
+		var age = $.derived(() => $.get($$value).age);
+		var p = root_1();
+		var text = $.child(p);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, `${$.get(name) ?? ""} is ${$.get(age) ?? ""}`));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_destructured/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_destructured/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, $$source) => {
+		var $$value = $.derived(() => {
+			var { name, age } = $.get($$source);
+			return {
+				name,
+				age
+			};
+		});
+		var name = $.derived(() => $.get($$value).name);
+		var age = $.derived(() => $.get($$value).age);
+		var p = root_1();
+		var text = $.child(p);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, `${$.get(name) ?? ""} is ${$.get(age) ?? ""}`));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_destructured/case.svelte
+++ b/tasks/compiler_tests/cases2/await_destructured/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise then { name, age }}
+	<p>{name} is {age}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_in_each/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_in_each/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const items = [fetch("/a"), fetch("/b")];
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		var fragment_1 = $.comment();
+		var node_1 = $.first_child(fragment_1);
+		$.await(node_1, () => $.get(item), null, ($$anchor, value) => {
+			var p = root_2();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, $.get(value)));
+			$.append($$anchor, p);
+		});
+		$.append($$anchor, fragment_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_in_each/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_in_each/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const items = [fetch("/a"), fetch("/b")];
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		var fragment_1 = $.comment();
+		var node_1 = $.first_child(fragment_1);
+		$.await(node_1, () => $.get(item), null, ($$anchor, value) => {
+			var p = root_2();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, $.get(value)));
+			$.append($$anchor, p);
+		});
+		$.append($$anchor, fragment_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_in_each/case.svelte
+++ b/tasks/compiler_tests/cases2/await_in_each/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	const items = [fetch('/a'), fetch('/b')];
+</script>
+
+{#each items as item}
+	{#await item then value}
+		<p>{value}</p>
+	{/await}
+{/each}

--- a/tasks/compiler_tests/cases2/await_in_if/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_in_if/case-rust.js
@@ -1,0 +1,26 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let show = true;
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var fragment_1 = $.comment();
+			var node_1 = $.first_child(fragment_1);
+			$.await(node_1, () => promise, null, ($$anchor, value) => {
+				var p = root_2();
+				var text = $.child(p, true);
+				$.reset(p);
+				$.template_effect(() => $.set_text(text, $.get(value)));
+				$.append($$anchor, p);
+			});
+			$.append($$anchor, fragment_1);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_in_if/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_in_if/case-svelte.js
@@ -1,0 +1,26 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let show = true;
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var fragment_1 = $.comment();
+			var node_1 = $.first_child(fragment_1);
+			$.await(node_1, () => promise, null, ($$anchor, value) => {
+				var p = root_2();
+				var text = $.child(p, true);
+				$.reset(p);
+				$.template_effect(() => $.set_text(text, $.get(value)));
+				$.append($$anchor, p);
+			});
+			$.append($$anchor, fragment_1);
+		};
+		$.if(node, ($$render) => {
+			if (show) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_in_if/case.svelte
+++ b/tasks/compiler_tests/cases2/await_in_if/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	let show = $state(true);
+	const promise = fetch('/api');
+</script>
+
+{#if show}
+	{#await promise then value}
+		<p>{value}</p>
+	{/await}
+{/if}

--- a/tasks/compiler_tests/cases2/await_nested_content/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_nested_content/case-rust.js
@@ -1,0 +1,30 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<div class="result"><h1>Result</h1> <p> </p></div>`);
+var root_2 = $.from_html(`<div class="error"><h1>Error</h1> <p> </p></div>`);
+var root_3 = $.from_html(`<div class="loading"><span>Please wait...</span></div>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var div_2 = root_3();
+		$.append($$anchor, div_2);
+	}, ($$anchor, value) => {
+		var div = root_1();
+		var p = $.sibling($.child(div), 2);
+		var text = $.child(p, true);
+		$.reset(p);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, div);
+	}, ($$anchor, error) => {
+		var div_1 = root_2();
+		var p_1 = $.sibling($.child(div_1), 2);
+		var text_1 = $.child(p_1, true);
+		$.reset(p_1);
+		$.reset(div_1);
+		$.template_effect(() => $.set_text(text_1, $.get(error).message));
+		$.append($$anchor, div_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_nested_content/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_nested_content/case-svelte.js
@@ -1,0 +1,30 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<div class="result"><h1>Result</h1> <p> </p></div>`);
+var root_2 = $.from_html(`<div class="error"><h1>Error</h1> <p> </p></div>`);
+var root_3 = $.from_html(`<div class="loading"><span>Please wait...</span></div>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var div_2 = root_3();
+		$.append($$anchor, div_2);
+	}, ($$anchor, value) => {
+		var div = root_1();
+		var p = $.sibling($.child(div), 2);
+		var text = $.child(p, true);
+		$.reset(p);
+		$.reset(div);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, div);
+	}, ($$anchor, error) => {
+		var div_1 = root_2();
+		var p_1 = $.sibling($.child(div_1), 2);
+		var text_1 = $.child(p_1, true);
+		$.reset(p_1);
+		$.reset(div_1);
+		$.template_effect(() => $.set_text(text_1, $.get(error).message));
+		$.append($$anchor, div_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_nested_content/case.svelte
+++ b/tasks/compiler_tests/cases2/await_nested_content/case.svelte
@@ -1,0 +1,19 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise}
+	<div class="loading">
+		<span>Please wait...</span>
+	</div>
+{:then value}
+	<div class="result">
+		<h1>Result</h1>
+		<p>{value}</p>
+	</div>
+{:catch error}
+	<div class="error">
+		<h1>Error</h1>
+		<p>{error.message}</p>
+	</div>
+{/await}

--- a/tasks/compiler_tests/cases2/await_no_bindings/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_no_bindings/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Done</p>`);
+var root_2 = $.from_html(`<p>Error</p>`);
+var root_3 = $.from_html(`<p>Loading</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_2 = root_3();
+		$.append($$anchor, p_2);
+	}, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	}, ($$anchor) => {
+		var p_1 = root_2();
+		$.append($$anchor, p_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_no_bindings/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_no_bindings/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Done</p>`);
+var root_2 = $.from_html(`<p>Error</p>`);
+var root_3 = $.from_html(`<p>Loading</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_2 = root_3();
+		$.append($$anchor, p_2);
+	}, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	}, ($$anchor) => {
+		var p_1 = root_2();
+		$.append($$anchor, p_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_no_bindings/case.svelte
+++ b/tasks/compiler_tests/cases2/await_no_bindings/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise}
+	<p>Loading</p>
+{:then}
+	<p>Done</p>
+{:catch}
+	<p>Error</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_pending_only/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_pending_only/case-rust.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_pending_only/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_pending_only/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_pending_only/case.svelte
+++ b/tasks/compiler_tests/cases2/await_pending_only/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise}
+	<p>Loading...</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_reactive/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_reactive/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let url = "/api";
+	let promise = $.derived(() => fetch(url));
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => $.get(promise), null, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_reactive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_reactive/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let url = "/api";
+	let promise = $.derived(() => fetch(url));
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => $.get(promise), null, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_reactive/case.svelte
+++ b/tasks/compiler_tests/cases2/await_reactive/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	let url = $state('/api');
+	let promise = $derived(fetch(url));
+</script>
+
+{#await promise then value}
+	<p>{value}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_short_catch/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_short_catch/case-rust.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, void 0, ($$anchor, error) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(error).message));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_short_catch/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_short_catch/case-svelte.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, void 0, ($$anchor, error) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(error).message));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_short_catch/case.svelte
+++ b/tasks/compiler_tests/cases2/await_short_catch/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise catch error}
+	<p>{error.message}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_short_then/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_short_then/case-rust.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_short_then/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_short_then/case-svelte.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_short_then/case.svelte
+++ b/tasks/compiler_tests/cases2/await_short_then/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise then value}
+	<p>{value}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_then_catch/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_then_catch/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	}, ($$anchor, error) => {
+		var p_1 = root_2();
+		var text_1 = $.child(p_1, true);
+		$.reset(p_1);
+		$.template_effect(() => $.set_text(text_1, $.get(error).message));
+		$.append($$anchor, p_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_then_catch/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_then_catch/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	}, ($$anchor, error) => {
+		var p_1 = root_2();
+		var text_1 = $.child(p_1, true);
+		$.reset(p_1);
+		$.template_effect(() => $.set_text(text_1, $.get(error).message));
+		$.append($$anchor, p_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_then_catch/case.svelte
+++ b/tasks/compiler_tests/cases2/await_then_catch/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise then value}
+	<p>{value}</p>
+{:catch error}
+	<p>{error.message}</p>
+{/await}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -950,3 +950,58 @@ fn boundary_in_if() {
 fn boundary_other_snippets() {
     assert_compiler("boundary_other_snippets");
 }
+
+#[rstest]
+fn await_basic() {
+    assert_compiler("await_basic");
+}
+
+#[rstest]
+fn await_short_then() {
+    assert_compiler("await_short_then");
+}
+
+#[rstest]
+fn await_short_catch() {
+    assert_compiler("await_short_catch");
+}
+
+#[rstest]
+fn await_then_catch() {
+    assert_compiler("await_then_catch");
+}
+
+#[rstest]
+fn await_no_bindings() {
+    assert_compiler("await_no_bindings");
+}
+
+#[rstest]
+fn await_pending_only() {
+    assert_compiler("await_pending_only");
+}
+
+#[rstest]
+fn await_destructured() {
+    assert_compiler("await_destructured");
+}
+
+#[rstest]
+fn await_in_if() {
+    assert_compiler("await_in_if");
+}
+
+#[rstest]
+fn await_in_each() {
+    assert_compiler("await_in_each");
+}
+
+#[rstest]
+fn await_reactive() {
+    assert_compiler("await_reactive");
+}
+
+#[rstest]
+fn await_nested_content() {
+    assert_compiler("await_nested_content");
+}


### PR DESCRIPTION
Full implementation of {#await} template blocks across all compiler layers:
- AST: AwaitBlock struct with expression, value/error binding spans, pending/then/catch fragments
- Scanner: {#await expr}, {#await expr then val}, {#await expr catch err}, {:then}, {:catch}, {/await}
- Parser: AwaitBlock assembly from tokens with phase tracking (pending→then→catch)
- Analysis: parse_js, scoping (child scopes for then/catch bindings), lowering, walker, reactivity, content_types, needs_var
- Codegen: $.await(anchor, () => expr, pending_fn, then_fn, catch_fn) with simple and destructured binding support
- 11 test cases covering all variants: basic, short then/catch, no bindings, pending only, destructured, nested in if/each, reactive, nested content

https://claude.ai/code/session_014NS3wcM9sMxQinPVoNQkYQ