### PR TITLE
Fix inspect_prod_strip: emit EmptyStatements for $inspect in prod mode

### DIFF
--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -775,15 +775,24 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
             }
         }
 
-        // Prod strip: remove $inspect(...) and $inspect(...).with(...) statements
+        // Prod strip: $inspect.trace() → remove entirely; $inspect()/$inspect().with() → 2 EmptyStatements
         if !self.dev {
-            stmts.retain(|stmt| {
-                if let Statement::ExpressionStatement(es) = stmt {
-                    !is_inspect_call(&es.expression)
-                } else {
-                    true
+            let mut i = 0;
+            while i < stmts.len() {
+                if let Statement::ExpressionStatement(es) = &stmts[i] {
+                    if is_inspect_trace_call(&es.expression) {
+                        stmts.remove(i);
+                        continue;
+                    }
+                    if is_inspect_call(&es.expression) {
+                        stmts[i] = Statement::EmptyStatement(self.b.ast.alloc_empty_statement(oxc_span::SPAN));
+                        stmts.insert(i + 1, Statement::EmptyStatement(self.b.ast.alloc_empty_statement(oxc_span::SPAN)));
+                        i += 2;
+                        continue;
+                    }
                 }
-            });
+                i += 1;
+            }
         }
 
         // Strip $props.id() declarations (regenerated at top of component fn_body)

--- a/tasks/compiler_tests/cases2/inspect_prod_strip/case-rust.js
+++ b/tasks/compiler_tests/cases2/inspect_prod_strip/case-rust.js
@@ -1,4 +1,6 @@
 import * as $ from "svelte/internal/client";
 export default function App($$anchor) {
 	let count = 0;
+	;
+	;
 }


### PR DESCRIPTION
Replace $inspect()/$inspect().with() with 2 EmptyStatements to match
reference Svelte compiler output. $inspect.trace() remains fully stripped.

https://claude.ai/code/session_01ERaQZr8fN1p8Ukc4U2HsSv