### PR TITLE
Port $host() rune and basic custom element wrapping

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,8 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 - [x] `$inspect(vals)` → `$.inspect(...)` (dev-mode only)
 - [x] `$inspect.trace()` — dev-only trace
 - [x] `$props.id()` → `$.props_id()` (v5.20+)
+- [x] `$host()` → `$$props.$$host` (custom element host reference)
+- [x] `customElements.define()` — basic custom element wrapping (simple tag form)
 
 ### Template codegen
 - [x] Element (with all attribute types), Component (props + children-as-snippet)
@@ -113,17 +115,6 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 - [x] Compiler compiled to WASM for browser use
 
 ---
-
-## Tier 1 — Remaining Runes
-
-Theme: finish rune transformations. Purely script codegen (**S**), patterns already exist in `script.rs`.
-
-Ref: `reference/compiler/phases/3-transform/client/visitors/CallExpression.js`, `ExpressionStatement.js`, `VariableDeclaration.js`
-Key file: `crates/svelte_codegen_client/src/script.rs`
-
-| # | Feature | Transform | Phases | Notes |
-|---|---------|-----------|--------|-------|
-| 1 | `$host()` | `$$props.$$host` | S | Expression replacement, for custom elements |
 
 ---
 
@@ -311,6 +302,12 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] `$state.frozen` → `$state.raw` rename validation
 - [ ] `$state.eager(val)` — experimental async, requires `experimental.async` flag
 - [ ] `$effect.pending()` — requires `<svelte:boundary>` (Tier 5)
+
+### $host() (Tier 1)
+- [ ] Validation: `$host()` must have zero arguments (`rune_invalid_arguments`)
+- [ ] Validation: `$host()` only in custom element component instances (`host_invalid_placement`)
+- [ ] Validation: `$host()` not in `<script module>` context
+- [ ] Custom element `$.push`/`$.pop` lifecycle for `$host()` mutations (Tier 9 dependency)
 
 ### $inspect (Tier 1)
 - [ ] `$inspect().with(callback)` argument count validation

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{ExportDefaultDeclarationKind, Statement};
 use oxc_codegen::Codegen;
 
 use svelte_analyze::{AnalysisData, IdentGen, ParsedExprs};
-use svelte_ast::{Attribute, Component, Node};
+use svelte_ast::{Attribute, Component, CustomElementConfig, Node};
 use svelte_transform::TransformData;
 
 use builder::{Arg, AssignLeft, AssignRight, Builder, ObjProp};
@@ -196,6 +196,28 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
     program_body.extend(all_hoisted);
     program_body.push(export_default);
     program_body.extend(delegate_stmts);
+
+    // Custom element wrapping: customElements.define(tag, $.create_custom_element(App, ...))
+    if let Some(ce_tag) = component.options.as_ref().and_then(|o| o.custom_element.as_ref()) {
+        if let CustomElementConfig::Tag(tag) = ce_tag {
+            let create_ce = b.call_expr("$.create_custom_element", [
+                Arg::Ident(ctx.name),
+                Arg::Expr(b.object_expr(std::iter::empty::<ObjProp<'_>>())),
+                Arg::Expr(b.array_from_args(std::iter::empty::<Arg<'_, '_>>())),
+                Arg::Expr(b.array_from_args(std::iter::empty::<Arg<'_, '_>>())),
+                Arg::Expr(b.object_expr([ObjProp::KeyValue("mode", b.str_expr("open"))])),
+            ]);
+            let define_callee = b.static_member_expr(
+                b.rid_expr("customElements"),
+                "define",
+            );
+            let define_call = b.call_expr_callee(define_callee, [
+                Arg::Str(tag.clone()),
+                Arg::Expr(create_ce),
+            ]);
+            program_body.push(b.expr_stmt(define_call));
+        }
+    }
 
     let program = b.program(program_body);
 

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -936,6 +936,18 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
             }
             Expression::CallExpression(_) => {
                 let Expression::CallExpression(call) = node else { return };
+
+                // $host() → $$props.$$host (entire expression replacement, not callee rename)
+                if let Expression::Identifier(id) = &call.callee {
+                    if id.name.as_str() == "$host" {
+                        *node = self.b.static_member_expr(
+                            self.b.rid_expr("$$props"),
+                            "$$host",
+                        );
+                        return;
+                    }
+                }
+
                 let new_callee = match &call.callee {
                     Expression::Identifier(id) if id.name.as_str() == "$effect" => {
                         Some("$.user_effect")

--- a/tasks/compiler_tests/cases2/host_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/host_basic/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let host = $$props.$$host;
+}
+customElements.define("my-element", $.create_custom_element(App, {}, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/host_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/host_basic/case-svelte.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let host = $$props.$$host;
+}
+customElements.define("my-element", $.create_custom_element(App, {}, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/host_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/host_basic/case.svelte
@@ -1,0 +1,4 @@
+<svelte:options customElement="my-element" />
+<script>
+  let host = $host();
+</script>

--- a/tasks/compiler_tests/cases2/host_basic/config.json
+++ b/tasks/compiler_tests/cases2/host_basic/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -23,6 +23,9 @@ fn assert_compiler(case: &str) {
         if let Some(dev) = config.get("dev").and_then(|v| v.as_bool()) {
             opts.dev = dev;
         }
+        if let Some(ce) = config.get("customElement").and_then(|v| v.as_bool()) {
+            opts.custom_element = ce;
+        }
     }
     let result = compile(&input, &opts);
     let js = result
@@ -313,6 +316,11 @@ fn effect_root_cleanup() {
 #[rstest]
 fn effect_tracking() {
     assert_compiler("effect_tracking");
+}
+
+#[rstest]
+fn host_basic() {
+    assert_compiler("host_basic");
 }
 
 #[rstest]


### PR DESCRIPTION
Transform $host() → $$props.$$host in script codegen (expression
replacement, not callee rename). Add customElements.define() wrapping
for components with <svelte:options customElement="tag">.

Includes test case, test framework customElement config support,
and ROADMAP updates (Tier 1 complete, deferred validation items).

https://claude.ai/code/session_014XSeg6jLH55URqX7gdm2ky