### PR TITLE
Port Tier 9 — Custom Elements: full $.create_custom_element() codegen

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,6 +114,16 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 ### WASM
 - [x] Compiler compiled to WASM for browser use
 
+### Custom Elements (Tier 9)
+- [x] `customElement` compile option — forces all props to prop sources with getter/setter exports
+- [x] `$.create_custom_element()` — full argument generation (props metadata, slots, accessors, shadow config, extend)
+- [x] Props metadata — auto-populated from `$props()` destructuring, explicit config with `attribute`, `reflect`, `type`
+- [x] Shadow DOM config — `"open"` (default) and `"none"` (omit shadow root)
+- [x] `extend` option — class inheritance for custom element
+- [x] Object form parsing — `customElement={{ tag, shadow, props, extend }}` expression span re-parsed in codegen
+- [x] Tag-less registration — no `customElements.define()`, just `$.create_custom_element()` call
+- [x] Accessors — exported names populate accessors array
+
 ---
 
 ---
@@ -224,18 +234,6 @@ Gates these features:
 - Component naming for devtools
 
 ---
-
-## Tier 9 — Custom Elements
-
-Theme: Web Component compilation — alternative output format.
-
-- **`customElement` option** — compile component as custom element with shadow DOM
-- **`$.create_custom_element()`** — wrapper for component function
-- **Shadow DOM config** — `{ mode: 'open' }`, `'none'`, or custom
-- **Props metadata** — `attribute`, `reflect`, `type` for each prop
-- **`extend` option** — class inheritance for custom element
-- **`customElements.define(tag, element)`** call generation
-- **Ref**: `reference/compiler/phases/3-transform/client/transform-client.js` lines 598–677
 
 ---
 
@@ -373,7 +371,7 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] `{@attach}` with async/blockers — `$.run_after_blockers()` wrapping
 
 ### `<svelte:options>` (Tier 5)
-- [ ] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties (expression span stored, analysis-phase parsing needed)
+- [x] `customElement` object form: full parsing of `tag`, `shadow`, `props`, `extend` properties (expression span re-parsed in codegen)
 - [ ] `namespace` affecting codegen: `$.from_svg()` / `$.from_mathml()` instead of `$.from_html()`
 
 ### `<svelte:element>` (Tier 5)
@@ -427,6 +425,14 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] HMR support — `$.hmr()` wrapper, `import.meta.hot.accept()`
 - [ ] `fragments: 'tree'` option — alternative DOM fragment strategy
 - [ ] `{await expr}` experimental template syntax (Svelte 5.36+, requires `experimental.async`)
+
+### Custom Elements (Tier 9)
+- [ ] `$host()` validation: zero args (`rune_invalid_arguments`), custom element context only (`host_invalid_placement`), not in `<script module>`
+- [ ] `custom_element_props_identifier` warning when `$props()` used without CE props config
+- [ ] HMR conditional registration: `if (customElements.get(tag) == null)`
+- [ ] Shadow DOM custom `ObjectExpression` (non-literal config)
+- [ ] `$.push`/`$.pop` lifecycle for `$host()` mutations
+- [ ] Auto-detect boolean type from prop default literal value (in CE props config)
 
 ### `on:directive` legacy (Tier 10)
 - [ ] Call memoization: `on:click={getHandler()}` → `$.derived(() => getHandler())` + `$.get()`. Needs `ExpressionMetadata.has_call` in analysis

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -275,6 +275,9 @@ pub struct AnalysisData {
     pub render_tag_arg_has_call: FxHashMap<NodeId, Vec<bool>>,
     /// Pre-computed bind/directive semantics (mutable rune targets, prop sources).
     pub bind_semantics: BindSemanticsData,
+    /// Whether this component is compiled as a custom element.
+    /// When true, all props become prop sources with getter/setter exports.
+    pub custom_element: bool,
 }
 
 impl AnalysisData {
@@ -297,6 +300,7 @@ impl AnalysisData {
             debug_tags: DebugTagData::new(),
             render_tag_arg_has_call: FxHashMap::default(),
             bind_semantics: BindSemanticsData::new(),
+            custom_element: false,
         }
     }
 }

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -50,7 +50,17 @@ pub fn analyze<'a>(
     alloc: &'a Allocator,
     component: &Component,
 ) -> (AnalysisData, ParsedExprs<'a>, Vec<Diagnostic>) {
+    analyze_with_options(alloc, component, false)
+}
+
+/// Analyze with compile options that affect analysis behavior.
+pub fn analyze_with_options<'a>(
+    alloc: &'a Allocator,
+    component: &Component,
+    custom_element: bool,
+) -> (AnalysisData, ParsedExprs<'a>, Vec<Diagnostic>) {
     let mut data = AnalysisData::new();
+    data.custom_element = custom_element;
     let mut parsed = ParsedExprs::new();
     let mut diags = Vec::new();
 

--- a/crates/svelte_analyze/src/props.rs
+++ b/crates/svelte_analyze/src/props.rs
@@ -26,10 +26,11 @@ pub fn analyze_props(data: &mut AnalysisData) {
         .map(|p| {
             // In runes mode, a prop needs $.prop() source when it has a default,
             // is reassigned, is mutated, or is bindable.
+            // In custom element mode, ALL props are prop sources (need getter/setter exports).
             let sym_id = data.scoping.find_binding(root, p.local_name.as_str());
             let is_mutated = sym_id.is_some_and(|id| data.scoping.is_mutated(id));
             let is_prop_source =
-                p.default_span.is_some() || is_mutated;
+                data.custom_element || p.default_span.is_some() || is_mutated;
 
             let is_lazy_default = p.default_text.as_ref()
                 .is_some_and(|text| !svelte_js::is_simple_expression(text));

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -948,6 +948,60 @@ impl<'a> Builder<'a> {
                 );
                 ast::ObjectPropertyKind::ObjectProperty(self.alloc(obj_prop))
             }
+            ObjProp::Setter(name, param_name, default_expr, body) => {
+                let name_atom = self.ast.atom(name);
+                let key_node = ast::PropertyKey::StaticIdentifier(
+                    self.alloc(self.ast.identifier_name(SPAN, name_atom)),
+                );
+                let param_atom = self.ast.atom(param_name);
+                let pattern = self.ast.binding_pattern_binding_identifier(SPAN, param_atom);
+                let param = self.ast.formal_parameter(
+                    SPAN,
+                    self.ast.vec(),
+                    pattern,
+                    NONE,
+                    default_expr.map(|e| self.alloc(e)),
+                    false,
+                    None,
+                    false,
+                    false,
+                );
+                let params = self.ast.formal_parameters(
+                    SPAN,
+                    ast::FormalParameterKind::FormalParameter,
+                    self.ast.vec_from_array([param]),
+                    NONE,
+                );
+                let fn_body = self.ast.alloc_function_body(
+                    SPAN,
+                    self.ast.vec(),
+                    self.ast.vec_from_iter(body),
+                );
+                let setter = self.ast.function(
+                    SPAN,
+                    FunctionType::FunctionExpression,
+                    None,
+                    false,
+                    false,
+                    false,
+                    NONE,
+                    NONE,
+                    params,
+                    NONE,
+                    Some(fn_body),
+                );
+                let value = Expression::FunctionExpression(self.alloc(setter));
+                let obj_prop = self.ast.object_property(
+                    SPAN,
+                    ast::PropertyKind::Set,
+                    key_node,
+                    value,
+                    false,  // method
+                    false,  // shorthand
+                    false,  // computed
+                );
+                ast::ObjectPropertyKind::ObjectProperty(self.alloc(obj_prop))
+            }
         }
     }
 }
@@ -962,4 +1016,6 @@ pub enum ObjProp<'a> {
     Spread(Expression<'a>),
     /// `get name() { return expr }`
     Getter(&'a str, Expression<'a>),
+    /// `set name(param_name = default?) { body }`
+    Setter(&'a str, &'a str, Option<Expression<'a>>, Vec<Statement<'a>>),
 }

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -158,6 +158,8 @@ pub struct Ctx<'a> {
     /// Event names that use delegation (e.g., "click" from `onclick={handler}`).
     pub delegated_events: Vec<String>,
 
+    /// Original component source text (for re-parsing expression spans in codegen).
+    pub source: &'a str,
 }
 
 impl<'a> Ctx<'a> {
@@ -170,6 +172,7 @@ impl<'a> Ctx<'a> {
         transform_data: TransformData,
         name: &str,
         dev: bool,
+        source: &'a str,
     ) -> Self {
         let index = NodeIndex::build(&component.fragment);
         let name = allocator.alloc_str(name);
@@ -188,6 +191,7 @@ impl<'a> Ctx<'a> {
             needs_binding_group: false,
             snippet_param_names: Vec::new(),
             delegated_events: Vec::new(),
+            source,
         }
     }
 

--- a/crates/svelte_codegen_client/src/custom_element.rs
+++ b/crates/svelte_codegen_client/src/custom_element.rs
@@ -1,0 +1,309 @@
+use oxc_ast::ast::{Expression, ObjectPropertyKind, PropertyKey, Statement};
+use oxc_span::GetSpan as _;
+use svelte_ast::CustomElementConfig;
+
+use crate::builder::{Arg, ObjProp};
+use crate::context::Ctx;
+
+// ---------------------------------------------------------------------------
+// Parsed custom element config (from object form expression)
+// ---------------------------------------------------------------------------
+
+struct CePropDef {
+    attribute: Option<String>,
+    reflect: bool,
+    prop_type: Option<String>,
+}
+
+struct ParsedCeOptions {
+    tag: Option<String>,
+    shadow: ShadowMode,
+    /// Ordered list of (prop_name, prop_def) pairs, preserving config order.
+    props: Vec<(String, CePropDef)>,
+    /// Source text of the `extend` expression (re-emitted as-is).
+    extend_source: Option<String>,
+}
+
+#[derive(PartialEq)]
+enum ShadowMode {
+    Open,
+    None,
+}
+
+// ---------------------------------------------------------------------------
+// Object form parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a `CustomElementConfig::Expression` span into structured options.
+/// Re-parses the source slice with OXC and walks the ObjectExpression.
+fn parse_ce_expression(source: &str, span: svelte_span::Span) -> ParsedCeOptions {
+    let start = span.start as usize;
+    let end = span.end as usize;
+    let expr_text = &source[start..end];
+
+    let alloc = oxc_allocator::Allocator::default();
+    let arena_text: &str = alloc.alloc_str(expr_text);
+    let parsed = oxc_parser::Parser::new(&alloc, arena_text, oxc_span::SourceType::default())
+        .parse_expression();
+
+    let expr = match parsed {
+        Ok(expr) => expr,
+        Err(_) => return ParsedCeOptions {
+            tag: None,
+            shadow: ShadowMode::Open,
+            props: Vec::new(),
+            extend_source: None,
+        },
+    };
+
+    let mut tag = None;
+    let mut shadow = ShadowMode::Open;
+    let mut props = Vec::new();
+    let mut extend_source = None;
+
+    if let Expression::ObjectExpression(obj) = &expr {
+        for prop_kind in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
+            let key_name = match &prop.key {
+                PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+                _ => continue,
+            };
+
+            match key_name {
+                "tag" => {
+                    if let Expression::StringLiteral(lit) = &prop.value {
+                        tag = Some(lit.value.to_string());
+                    }
+                }
+                "shadow" => {
+                    if let Expression::StringLiteral(lit) = &prop.value {
+                        match lit.value.as_str() {
+                            "none" => shadow = ShadowMode::None,
+                            _ => shadow = ShadowMode::Open,
+                        }
+                    }
+                }
+                "props" => {
+                    if let Expression::ObjectExpression(props_obj) = &prop.value {
+                        for prop_entry in &props_obj.properties {
+                            let ObjectPropertyKind::ObjectProperty(entry) = prop_entry else { continue };
+                            let prop_name = match &entry.key {
+                                PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+                                _ => continue,
+                            };
+                            let mut def = CePropDef {
+                                attribute: None,
+                                reflect: false,
+                                prop_type: None,
+                            };
+                            if let Expression::ObjectExpression(def_obj) = &entry.value {
+                                for def_prop in &def_obj.properties {
+                                    let ObjectPropertyKind::ObjectProperty(dp) = def_prop else { continue };
+                                    let dk = match &dp.key {
+                                        PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+                                        _ => continue,
+                                    };
+                                    match dk {
+                                        "attribute" => {
+                                            if let Expression::StringLiteral(lit) = &dp.value {
+                                                def.attribute = Some(lit.value.to_string());
+                                            }
+                                        }
+                                        "reflect" => {
+                                            if let Expression::BooleanLiteral(lit) = &dp.value {
+                                                def.reflect = lit.value;
+                                            }
+                                        }
+                                        "type" => {
+                                            if let Expression::StringLiteral(lit) = &dp.value {
+                                                def.prop_type = Some(lit.value.to_string());
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            props.push((prop_name, def));
+                        }
+                    }
+                }
+                "extend" => {
+                    let ext_start = prop.value.span().start as usize;
+                    let ext_end = prop.value.span().end as usize;
+                    extend_source = Some(expr_text[ext_start..ext_end].to_string());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    ParsedCeOptions { tag, shadow, props, extend_source }
+}
+
+// ---------------------------------------------------------------------------
+// Codegen
+// ---------------------------------------------------------------------------
+
+/// Generate the `customElements.define(tag, $.create_custom_element(...))` statement(s).
+pub fn gen_custom_element<'a>(
+    ctx: &Ctx<'a>,
+    ce_config: &CustomElementConfig,
+) -> Vec<Statement<'a>> {
+    let b = &ctx.b;
+
+    // Determine tag and parsed options based on config variant
+    let (simple_tag, parsed) = match ce_config {
+        CustomElementConfig::Tag(tag) => (Some(tag.as_str()), None),
+        CustomElementConfig::Expression(span) => {
+            let opts = parse_ce_expression(ctx.source, *span);
+            (None, Some(opts))
+        }
+    };
+
+    // Resolve tag: simple form uses tag directly, object form uses parsed tag
+    let resolved_tag: Option<&str> = match (&simple_tag, &parsed) {
+        (Some(t), _) => Some(t),
+        (None, Some(opts)) => opts.tag.as_deref(),
+        (None, None) => None,
+    };
+
+    let parsed_opts = parsed.as_ref();
+
+    // -- Arg 2: Props metadata object --
+    let props_obj = build_props_metadata(ctx, parsed_opts);
+
+    // -- Arg 3: Slots array (always empty in Svelte 5 runes mode) --
+    let slots = b.array_from_args(std::iter::empty::<Arg<'_, '_>>());
+
+    // -- Arg 4: Accessors array (from exports) --
+    let accessors = b.array_from_args(
+        ctx.analysis.exports.iter().map(|e| {
+            let name = e.alias.as_deref().unwrap_or(e.name.as_str());
+            Arg::Str(name.to_string())
+        })
+    );
+
+    // -- Arg 5: Shadow root config --
+    let is_shadow_none = parsed_opts.is_some_and(|o| o.shadow == ShadowMode::None);
+
+    // -- Arg 6: Extend (optional) --
+    let extend_arg: Option<Expression<'a>> = parsed_opts
+        .and_then(|o| o.extend_source.as_deref())
+        .map(|src| b.parse_expression(src));
+
+    // Build $.create_custom_element() call
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Ident(ctx.name),
+        Arg::Expr(props_obj),
+        Arg::Expr(slots),
+        Arg::Expr(accessors),
+    ];
+
+    if !is_shadow_none {
+        args.push(Arg::Expr(
+            b.object_expr([ObjProp::KeyValue("mode", b.str_expr("open"))]),
+        ));
+    }
+
+    if let Some(extend_expr) = extend_arg {
+        args.push(Arg::Expr(extend_expr));
+    }
+
+    let create_ce = b.call_expr("$.create_custom_element", args);
+
+    // Wrap in customElements.define() if tag is present
+    let mut stmts = Vec::new();
+    if let Some(tag_str) = resolved_tag {
+        let define_callee = b.static_member_expr(
+            b.rid_expr("customElements"),
+            "define",
+        );
+        let define_call = b.call_expr_callee(define_callee, [
+            Arg::Str(tag_str.to_string()),
+            Arg::Expr(create_ce),
+        ]);
+        stmts.push(b.expr_stmt(define_call));
+    } else {
+        stmts.push(b.expr_stmt(create_ce));
+    }
+
+    stmts
+}
+
+/// Build the props metadata object for `$.create_custom_element()`.
+///
+/// For each prop from CE config: build `{ attribute?, reflect?, type? }`.
+/// For remaining component props not in config: add `propName: {}`.
+fn build_props_metadata<'a>(
+    ctx: &Ctx<'a>,
+    parsed_opts: Option<&ParsedCeOptions>,
+) -> Expression<'a> {
+    let b = &ctx.b;
+    let mut obj_props: Vec<ObjProp<'a>> = Vec::new();
+
+    // Collect CE config prop names for dedup check
+    let ce_prop_names: Vec<&str> = parsed_opts
+        .map(|o| o.props.iter().map(|(n, _)| n.as_str()).collect())
+        .unwrap_or_default();
+
+    // First: emit props from CE config (preserving config order)
+    if let Some(opts) = parsed_opts {
+        for (name, def) in &opts.props {
+            let prop_key = resolve_prop_key(ctx, name);
+            let value = build_prop_def_expr(b, def);
+            obj_props.push(ObjProp::KeyValue(b.alloc_str(&prop_key), value));
+        }
+    }
+
+    // Second: emit remaining component props not already in CE config
+    if let Some(ref props_analysis) = ctx.analysis.props {
+        for prop in &props_analysis.props {
+            if prop.is_rest || prop.prop_name.starts_with("$$") {
+                continue;
+            }
+            let key = &prop.prop_name;
+            // Skip if already covered by CE config
+            if ce_prop_names.iter().any(|&n| n == key) {
+                continue;
+            }
+            obj_props.push(ObjProp::KeyValue(
+                b.alloc_str(key),
+                b.object_expr(std::iter::empty::<ObjProp<'_>>()),
+            ));
+        }
+    }
+
+    b.object_expr(obj_props)
+}
+
+/// Resolve the prop key: use prop_alias if the binding has one, otherwise use the name.
+fn resolve_prop_key(ctx: &Ctx<'_>, name: &str) -> String {
+    if let Some(ref props) = ctx.analysis.props {
+        for prop in &props.props {
+            if prop.local_name == name || prop.prop_name == name {
+                return prop.prop_name.clone();
+            }
+        }
+    }
+    name.to_string()
+}
+
+/// Build the value expression for a single prop definition: `{ attribute?, reflect?, type? }`.
+fn build_prop_def_expr<'a>(
+    b: &crate::builder::Builder<'a>,
+    def: &CePropDef,
+) -> Expression<'a> {
+    let mut props: Vec<ObjProp<'a>> = Vec::new();
+
+    if let Some(ref attr) = def.attribute {
+        props.push(ObjProp::KeyValue("attribute", b.str_expr(attr)));
+    }
+    if def.reflect {
+        props.push(ObjProp::KeyValue("reflect", b.bool_expr(true)));
+    }
+    if let Some(ref typ) = def.prop_type {
+        props.push(ObjProp::KeyValue("type", b.str_expr(typ)));
+    }
+
+    b.object_expr(props)
+}

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -1,5 +1,6 @@
 mod builder;
 mod context;
+mod custom_element;
 mod rune_transform;
 mod script;
 mod template;
@@ -9,15 +10,15 @@ use oxc_ast::ast::{ExportDefaultDeclarationKind, Statement};
 use oxc_codegen::Codegen;
 
 use svelte_analyze::{AnalysisData, IdentGen, ParsedExprs};
-use svelte_ast::{Attribute, Component, CustomElementConfig, Node};
+use svelte_ast::{Attribute, Component, Node};
 use svelte_transform::TransformData;
 
 use builder::{Arg, AssignLeft, AssignRight, Builder, ObjProp};
 use context::Ctx;
 
 /// Generate JavaScript client-side code for a compiled Svelte component.
-pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'a AnalysisData, parsed: &'a mut ParsedExprs<'a>, ident_gen: &'a mut IdentGen, transform_data: TransformData, name: &str, dev: bool) -> String {
-    let mut ctx = Ctx::new(alloc, component, analysis, parsed, ident_gen, transform_data, name, dev);
+pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'a AnalysisData, parsed: &'a mut ParsedExprs<'a>, ident_gen: &'a mut IdentGen, transform_data: TransformData, name: &str, dev: bool, source: &'a str) -> String {
+    let mut ctx = Ctx::new(alloc, component, analysis, parsed, ident_gen, transform_data, name, dev, source);
 
     // -----------------------------------------------------------------------
     // 1. Script transformation
@@ -39,11 +40,13 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
     // -----------------------------------------------------------------------
     // 3. Build function body (needs &mut ctx for snippets)
     // -----------------------------------------------------------------------
+    let is_custom_element = ctx.analysis.custom_element;
     let has_exports = !ctx.analysis.exports.is_empty();
     let has_bindable = ctx.analysis.props.as_ref().is_some_and(|p| p.has_bindable);
     let has_stores = !ctx.analysis.scoping.store_symbols().is_empty();
-    let needs_push = has_bindable || has_exports || ctx.analysis.needs_context || ctx.dev;
-    let has_component_exports = has_exports || ctx.dev;
+    let has_ce_props = is_custom_element && ctx.analysis.props.as_ref().is_some_and(|p| !p.props.is_empty());
+    let needs_push = has_bindable || has_exports || has_ce_props || ctx.analysis.needs_context || ctx.dev;
+    let has_component_exports = has_exports || has_ce_props || ctx.dev;
 
     let mut fn_body: Vec<Statement<'_>> = Vec::new();
 
@@ -102,18 +105,48 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
 
     fn_body.extend(script_body);
 
-    // var $$exports = { PI, greet, ... }
-    if has_exports {
-        let props: Vec<ObjProp<'_>> = ctx.analysis.exports.iter().map(|e| {
+    // var $$exports = { ... }
+    if has_exports || has_ce_props {
+        let mut export_props: Vec<ObjProp<'_>> = Vec::new();
+
+        // Regular exports (e.g., `export function reset()`)
+        for e in &ctx.analysis.exports {
             let name: &str = ctx.b.alloc_str(&e.name);
             if let Some(alias) = &e.alias {
                 let alias: &str = ctx.b.alloc_str(alias);
-                ObjProp::KeyValue(alias, ctx.b.rid_expr(name))
+                export_props.push(ObjProp::KeyValue(alias, ctx.b.rid_expr(name)));
             } else {
-                ObjProp::Shorthand(name)
+                export_props.push(ObjProp::Shorthand(name));
             }
-        }).collect();
-        fn_body.push(ctx.b.var_stmt("$$exports", ctx.b.object_expr(props)));
+        }
+
+        // Custom element prop getter/setters
+        if has_ce_props {
+            if let Some(ref props_analysis) = ctx.analysis.props {
+                for prop in &props_analysis.props {
+                    if prop.is_rest || prop.prop_name.starts_with("$$") {
+                        continue;
+                    }
+                    let key: &str = ctx.b.alloc_str(&prop.prop_name);
+                    let local: &str = ctx.b.alloc_str(&prop.local_name);
+
+                    // get name() { return name(); }
+                    let getter_expr = ctx.b.call_expr(local, std::iter::empty::<Arg<'_, '_>>());
+                    export_props.push(ObjProp::Getter(key, getter_expr));
+
+                    // set name($$value = default?) { name($$value); $.flush(); }
+                    let default_expr = prop.default_text.as_deref()
+                        .map(|text| ctx.b.parse_expression(text));
+                    let setter_body = vec![
+                        ctx.b.expr_stmt(ctx.b.call_expr(local, [Arg::Ident("$$value")])),
+                        ctx.b.call_stmt("$.flush", std::iter::empty::<Arg<'_, '_>>()),
+                    ];
+                    export_props.push(ObjProp::Setter(key, "$$value", default_expr, setter_body));
+                }
+            }
+        }
+
+        fn_body.push(ctx.b.var_stmt("$$exports", ctx.b.object_expr(export_props)));
     } else if ctx.dev && needs_push {
         // var $$exports = { ...$.legacy_api() }
         let legacy_call = ctx.b.call_expr("$.legacy_api", std::iter::empty::<Arg<'_, '_>>());
@@ -198,25 +231,9 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
     program_body.extend(delegate_stmts);
 
     // Custom element wrapping: customElements.define(tag, $.create_custom_element(App, ...))
-    if let Some(ce_tag) = component.options.as_ref().and_then(|o| o.custom_element.as_ref()) {
-        if let CustomElementConfig::Tag(tag) = ce_tag {
-            let create_ce = b.call_expr("$.create_custom_element", [
-                Arg::Ident(ctx.name),
-                Arg::Expr(b.object_expr(std::iter::empty::<ObjProp<'_>>())),
-                Arg::Expr(b.array_from_args(std::iter::empty::<Arg<'_, '_>>())),
-                Arg::Expr(b.array_from_args(std::iter::empty::<Arg<'_, '_>>())),
-                Arg::Expr(b.object_expr([ObjProp::KeyValue("mode", b.str_expr("open"))])),
-            ]);
-            let define_callee = b.static_member_expr(
-                b.rid_expr("customElements"),
-                "define",
-            );
-            let define_call = b.call_expr_callee(define_callee, [
-                Arg::Str(tag.clone()),
-                Arg::Expr(create_ce),
-            ]);
-            program_body.push(b.expr_stmt(define_call));
-        }
+    if let Some(ce_config) = component.options.as_ref().and_then(|o| o.custom_element.as_ref()) {
+        let ce_stmts = custom_element::gen_custom_element(&ctx, ce_config);
+        program_body.extend(ce_stmts);
     }
 
     let program = b.program(program_body);

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -40,6 +40,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> (Vec<Statement<'a>>, Vec<
     let props = ctx.analysis.props.as_ref();
     let component_source = &ctx.component.source;
     let script_content_start = ctx.component.script.as_ref().unwrap().content_span.start;
+    let custom_element = ctx.analysis.custom_element;
 
     // Take pre-parsed Program from analysis (avoids double-parsing)
     if let Some(program) = ctx.parsed.script_program.take() {
@@ -51,6 +52,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> (Vec<Statement<'a>>, Vec<
             dev,
             component_source,
             script_content_start,
+            custom_element,
         );
     }
 
@@ -68,6 +70,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> (Vec<Statement<'a>>, Vec<
         dev,
         component_source,
         script_content_start,
+        custom_element,
     )
 }
 
@@ -89,6 +92,7 @@ pub fn transform_module_script<'a>(
         false,
         source,
         0,
+        false,
     );
     (imports, body)
 }
@@ -104,6 +108,7 @@ fn transform_script_text<'a>(
     dev: bool,
     component_source: &str,
     script_content_start: u32,
+    custom_element: bool,
 ) -> (Vec<Statement<'a>>, Vec<Statement<'a>>, bool) {
     let src_type = if is_ts {
         SourceType::default().with_typescript(true).with_module(true)
@@ -129,7 +134,8 @@ fn transform_script_text<'a>(
                 is_prop_source: p.is_prop_source,
                 is_bindable: p.is_bindable,
                 is_rest: p.is_rest,
-                is_mutated: component_scoping.find_binding(root, &p.local_name)
+                // In custom element mode, all props are updatable via CE setters
+                is_mutated: custom_element || component_scoping.find_binding(root, &p.local_name)
                     .is_some_and(|sym| component_scoping.is_mutated(sym)),
                 default_text: p.default_text.clone(),
                 is_lazy_default: p.is_lazy_default,
@@ -193,6 +199,7 @@ fn transform_program<'a>(
     dev: bool,
     component_source: &str,
     script_content_start: u32,
+    custom_element: bool,
 ) -> (Vec<Statement<'a>>, Vec<Statement<'a>>, bool) {
     let b = Builder::new(allocator);
 
@@ -212,7 +219,8 @@ fn transform_program<'a>(
                     is_prop_source: p.is_prop_source,
                     is_bindable: p.is_bindable,
                     is_rest: p.is_rest,
-                    is_mutated: component_scoping.find_binding(root, &p.local_name)
+                    // In custom element mode, all props are updatable via CE setters
+                    is_mutated: custom_element || component_scoping.find_binding(root, &p.local_name)
                         .is_some_and(|sym| component_scoping.is_mutated(sym)),
                     default_text: p.default_text.clone(),
                     is_lazy_default: p.is_lazy_default,

--- a/crates/svelte_compiler/src/lib.rs
+++ b/crates/svelte_compiler/src/lib.rs
@@ -19,9 +19,9 @@ pub fn compile(source: &str, options: &CompileOptions) -> CompileResult {
 
     let codegen_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut ident_gen = svelte_analyze::IdentGen::new();
-        let (analysis, mut parsed, analyze_diags) = svelte_analyze::analyze(&js_alloc, &component);
+        let (analysis, mut parsed, analyze_diags) = svelte_analyze::analyze_with_options(&js_alloc, &component, options.custom_element);
         let transform_data = svelte_transform::transform_component(&js_alloc, &component, &analysis, &mut parsed, &mut ident_gen);
-        let js = svelte_codegen_client::generate(&js_alloc, &component, &analysis, &mut parsed, &mut ident_gen, transform_data, &name, options.dev);
+        let js = svelte_codegen_client::generate(&js_alloc, &component, &analysis, &mut parsed, &mut ident_gen, transform_data, &name, options.dev, source);
         (js, analyze_diags)
     }));
 

--- a/tasks/compiler_tests/cases2/custom_element_boolean_default/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_boolean_default/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let active = $.prop($$props, "active", 7, false);
+	var $$exports = {
+		get active() {
+			return active();
+		},
+		set active($$value = false) {
+			active($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, active()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-toggle", $.create_custom_element(App, { active: {} }, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_boolean_default/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_boolean_default/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let active = $.prop($$props, "active", 7, false);
+	var $$exports = {
+		get active() {
+			return active();
+		},
+		set active($$value = false) {
+			active($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, active()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-toggle", $.create_custom_element(App, { active: {} }, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_boolean_default/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_boolean_default/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement="my-toggle" />
+<script>
+  let { active = false } = $props();
+</script>
+<p>{active}</p>

--- a/tasks/compiler_tests/cases2/custom_element_boolean_default/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_boolean_default/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_exports/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_exports/case-rust.js
@@ -1,0 +1,26 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = $.prop($$props, "value", 7, 0);
+	function reset() {
+		value(0);
+	}
+	var $$exports = {
+		reset,
+		get value() {
+			return value();
+		},
+		set value($$value = 0) {
+			value($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, value()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-widget", $.create_custom_element(App, { value: {} }, [], ["reset"], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_exports/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_exports/case-svelte.js
@@ -1,0 +1,26 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = $.prop($$props, "value", 7, 0);
+	function reset() {
+		value(0);
+	}
+	var $$exports = {
+		reset,
+		get value() {
+			return value();
+		},
+		set value($$value = 0) {
+			value($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, value()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-widget", $.create_custom_element(App, { value: {} }, [], ["reset"], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_exports/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_exports/case.svelte
@@ -1,0 +1,6 @@
+<svelte:options customElement="my-widget" />
+<script>
+  let { value = 0 } = $props();
+  export function reset() { value = 0; }
+</script>
+<p>{value}</p>

--- a/tasks/compiler_tests/cases2/custom_element_exports/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_exports/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_extend/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_extend/case-rust.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import customElementWrapper from "./wrapper.js";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, { name: {} }, [], [], { mode: "open" }, customElementWrapper));

--- a/tasks/compiler_tests/cases2/custom_element_extend/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_extend/case-svelte.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+import customElementWrapper from "./wrapper.js";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, { name: {} }, [], [], { mode: "open" }, customElementWrapper));

--- a/tasks/compiler_tests/cases2/custom_element_extend/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_extend/case.svelte
@@ -1,0 +1,6 @@
+<svelte:options customElement={{ tag: "my-element", extend: customElementWrapper }} />
+<script>
+  import customElementWrapper from './wrapper.js';
+  let { name } = $props();
+</script>
+<p>{name}</p>

--- a/tasks/compiler_tests/cases2/custom_element_extend/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_extend/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_no_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_no_tag/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+$.create_custom_element(App, { name: {} }, [], [], { mode: "open" });

--- a/tasks/compiler_tests/cases2/custom_element_no_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_no_tag/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+$.create_custom_element(App, { name: {} }, [], [], { mode: "open" });

--- a/tasks/compiler_tests/cases2/custom_element_no_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_no_tag/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement={{ shadow: "open" }} />
+<script>
+  let { name } = $props();
+</script>
+<p>{name}</p>

--- a/tasks/compiler_tests/cases2/custom_element_no_tag/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_no_tag/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_object_full/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_object_full/case-rust.js
@@ -1,0 +1,25 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.prop($$props, "count", 7, 0);
+	var $$exports = {
+		get count() {
+			return count();
+		},
+		set count($$value = 0) {
+			count($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, count()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-component", $.create_custom_element(App, { count: {
+	reflect: true,
+	type: "Number"
+} }, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_object_full/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_object_full/case-svelte.js
@@ -1,0 +1,25 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.prop($$props, "count", 7, 0);
+	var $$exports = {
+		get count() {
+			return count();
+		},
+		set count($$value = 0) {
+			count($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, count()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-component", $.create_custom_element(App, { count: {
+	reflect: true,
+	type: "Number"
+} }, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_object_full/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_object_full/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement={{ tag: "my-component", props: { count: { type: 'Number', reflect: true } }, shadow: "open" }} />
+<script>
+  let { count = 0 } = $props();
+</script>
+<p>{count}</p>

--- a/tasks/compiler_tests/cases2/custom_element_object_full/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_object_full/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_props/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_props/case-rust.js
@@ -1,0 +1,32 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.prop($$props, "count", 7), label = $.prop($$props, "label", 7);
+	var $$exports = {
+		get count() {
+			return count();
+		},
+		set count($$value) {
+			count($$value);
+			$.flush();
+		},
+		get label() {
+			return label();
+		},
+		set label($$value) {
+			label($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${label() ?? ""}: ${count() ?? ""}`));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, {
+	count: {},
+	label: {}
+}, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_props/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_props/case-svelte.js
@@ -1,0 +1,32 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.prop($$props, "count", 7), label = $.prop($$props, "label", 7);
+	var $$exports = {
+		get count() {
+			return count();
+		},
+		set count($$value) {
+			count($$value);
+			$.flush();
+		},
+		get label() {
+			return label();
+		},
+		set label($$value) {
+			label($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${label() ?? ""}: ${count() ?? ""}`));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, {
+	count: {},
+	label: {}
+}, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_props/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_props/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement="my-element" />
+<script>
+  let { count, label } = $props();
+</script>
+<p>{label}: {count}</p>

--- a/tasks/compiler_tests/cases2/custom_element_props/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_props/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_props_config/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_props_config/case-rust.js
@@ -1,0 +1,35 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.prop($$props, "count", 7), label = $.prop($$props, "label", 7);
+	var $$exports = {
+		get count() {
+			return count();
+		},
+		set count($$value) {
+			count($$value);
+			$.flush();
+		},
+		get label() {
+			return label();
+		},
+		set label($$value) {
+			label($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${label() ?? ""}: ${count() ?? ""}`));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-counter", $.create_custom_element(App, {
+	count: {
+		reflect: true,
+		type: "Number"
+	},
+	label: { attribute: "data-label" }
+}, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_props_config/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_props_config/case-svelte.js
@@ -1,0 +1,35 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.prop($$props, "count", 7), label = $.prop($$props, "label", 7);
+	var $$exports = {
+		get count() {
+			return count();
+		},
+		set count($$value) {
+			count($$value);
+			$.flush();
+		},
+		get label() {
+			return label();
+		},
+		set label($$value) {
+			label($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${label() ?? ""}: ${count() ?? ""}`));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-counter", $.create_custom_element(App, {
+	count: {
+		reflect: true,
+		type: "Number"
+	},
+	label: { attribute: "data-label" }
+}, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_props_config/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_props_config/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement={{ tag: "my-counter", props: { count: { type: 'Number', reflect: true }, label: { attribute: 'data-label' } } }} />
+<script>
+  let { count, label } = $props();
+</script>
+<p>{label}: {count}</p>

--- a/tasks/compiler_tests/cases2/custom_element_props_config/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_props_config/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_shadow_none/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_none/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, { name: {} }, [], []));

--- a/tasks/compiler_tests/cases2/custom_element_shadow_none/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_none/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, { name: {} }, [], []));

--- a/tasks/compiler_tests/cases2/custom_element_shadow_none/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_none/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement={{ tag: "my-element", shadow: "none" }} />
+<script>
+  let { name } = $props();
+</script>
+<p>{name}</p>

--- a/tasks/compiler_tests/cases2/custom_element_shadow_none/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_none/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/cases2/custom_element_shadow_open/case-rust.js
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_open/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, { name: {} }, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_shadow_open/case-svelte.js
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_open/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let name = $.prop($$props, "name", 7);
+	var $$exports = {
+		get name() {
+			return name();
+		},
+		set name($$value) {
+			name($$value);
+			$.flush();
+		}
+	};
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, name()));
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}
+customElements.define("my-element", $.create_custom_element(App, { name: {} }, [], [], { mode: "open" }));

--- a/tasks/compiler_tests/cases2/custom_element_shadow_open/case.svelte
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_open/case.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement={{ tag: "my-element", shadow: "open" }} />
+<script>
+  let { name } = $props();
+</script>
+<p>{name}</p>

--- a/tasks/compiler_tests/cases2/custom_element_shadow_open/config.json
+++ b/tasks/compiler_tests/cases2/custom_element_shadow_open/config.json
@@ -1,0 +1,1 @@
+{"customElement": true}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -324,6 +324,51 @@ fn host_basic() {
 }
 
 #[rstest]
+fn custom_element_props() {
+    assert_compiler("custom_element_props");
+}
+
+#[rstest]
+fn custom_element_props_config() {
+    assert_compiler("custom_element_props_config");
+}
+
+#[rstest]
+fn custom_element_boolean_default() {
+    assert_compiler("custom_element_boolean_default");
+}
+
+#[rstest]
+fn custom_element_exports() {
+    assert_compiler("custom_element_exports");
+}
+
+#[rstest]
+fn custom_element_shadow_none() {
+    assert_compiler("custom_element_shadow_none");
+}
+
+#[rstest]
+fn custom_element_object_full() {
+    assert_compiler("custom_element_object_full");
+}
+
+#[rstest]
+fn custom_element_shadow_open() {
+    assert_compiler("custom_element_shadow_open");
+}
+
+#[rstest]
+fn custom_element_extend() {
+    assert_compiler("custom_element_extend");
+}
+
+#[rstest]
+fn custom_element_no_tag() {
+    assert_compiler("custom_element_no_tag");
+}
+
+#[rstest]
 fn html_tag() {
     assert_compiler("html_tag");
 }


### PR DESCRIPTION
- Props metadata: auto-populate from $props() destructuring, support
  explicit config (attribute, reflect, type) via object form
- Accessors: exported names populate the accessors array
- Shadow DOM: support "open" (default) and "none" modes
- Object form: parse customElement={{ tag, shadow, props, extend }}
  expression span in codegen via OXC re-parse
- Extend option: pass through extend function as 6th argument
- Tag-less registration: just $.create_custom_element() without define()
- Analysis: custom_element flag forces all props to prop sources with
  getter/setter $$exports and PROPS_IS_UPDATED flag
- Add Setter variant to ObjProp builder for getter/setter exports
- Thread source text through generate() → Ctx for expression re-parsing
- 9 new test cases, all 226 compiler tests pass

https://claude.ai/code/session_017Kxw63XEWanomhQxpSLnzc