### PR TITLE
Reduce code duplication in template codegen and fix std::HashSet usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "pretty_assertions",
+ "rustc-hash",
  "svelte_diagnostics",
  "svelte_span",
 ]

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -409,6 +409,47 @@ fn build_style_concat<'a>(
     ctx.b.template_parts_expr(tpl_parts)
 }
 
+/// Build binding getter: `() => $.get(x)` for runes, `() => x` for plain vars.
+pub(crate) fn build_binding_getter<'a>(ctx: &mut Ctx<'a>, var: &str, is_rune: bool) -> Expression<'a> {
+    let body = if is_rune {
+        ctx.b.call_expr("$.get", [Arg::Ident(var)])
+    } else {
+        ctx.b.rid_expr(var)
+    };
+    ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
+}
+
+/// Build binding setter: `($$value) => $.set(x, $$value)` for runes, `($$value) => x = $$value` for plain.
+pub(crate) fn build_binding_setter<'a>(ctx: &mut Ctx<'a>, var: String, is_rune: bool) -> Expression<'a> {
+    let body = if is_rune {
+        ctx.b.call_expr("$.set", [Arg::Ident(&var), Arg::Ident("$$value")])
+    } else {
+        ctx.b.assign_expr(
+            AssignLeft::Ident(var),
+            AssignRight::Expr(ctx.b.rid_expr("$$value")),
+        )
+    };
+    ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+}
+
+/// Build binding setter with `true` flag: `($$value) => $.set(x, $$value, true)`.
+/// Used by window/document bindings to prevent re-triggering reactivity.
+pub(crate) fn build_binding_setter_silent<'a>(ctx: &mut Ctx<'a>, var: String, is_rune: bool) -> Expression<'a> {
+    let body = if is_rune {
+        ctx.b.call_expr("$.set", [
+            Arg::Ident(&var),
+            Arg::Ident("$$value"),
+            Arg::Bool(true),
+        ])
+    } else {
+        ctx.b.assign_expr(
+            AssignLeft::Ident(var),
+            AssignRight::Expr(ctx.b.rid_expr("$$value")),
+        )
+    };
+    ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
+}
+
 /// Where to place a bind directive statement.
 enum BindPlacement<'a> {
     /// Most bindings: placed after attribute updates.
@@ -435,56 +476,33 @@ fn gen_bind_directive<'a>(
         return None;
     };
 
-    // Build getter: () => $.get(x) for runes, () => x for plain vars
-    let build_getter = |ctx: &mut Ctx<'a>, var: &str, is_rune: bool| -> Expression<'a> {
-        let body = if is_rune {
-            ctx.b.call_expr("$.get", [Arg::Ident(var)])
-        } else {
-            ctx.b.rid_expr(var)
-        };
-        ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
-    };
-
-    // Build setter: ($$value) => $.set(x, $$value) for runes, ($$value) => x = $$value for plain
-    let build_setter = |ctx: &mut Ctx<'a>, var: String, is_rune: bool| -> Expression<'a> {
-        let body = if is_rune {
-            ctx.b.call_expr("$.set", [Arg::Ident(&var), Arg::Ident("$$value")])
-        } else {
-            ctx.b.assign_expr(
-                AssignLeft::Ident(var),
-                AssignRight::Expr(ctx.b.rid_expr("$$value")),
-            )
-        };
-        ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
-    };
-
     let stmt = match bind.name.as_str() {
         // --- Input/Form ---
         "value" if tag_name == "select" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_select_value", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "value" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_value", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "checked" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_checked", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "group" => {
             ctx.needs_binding_group = true;
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_group", [
                 Arg::Ident("binding_group"),
                 Arg::Expr(ctx.b.empty_array_expr()),
@@ -494,8 +512,8 @@ fn gen_bind_directive<'a>(
             ])
         }
         "files" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_files", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
@@ -503,16 +521,16 @@ fn gen_bind_directive<'a>(
 
         // --- Generic event-based bindings (bidirectional) ---
         "indeterminate" => {
-            let setter = build_setter(ctx, var_name.clone(), is_rune);
-            let getter = build_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name.clone(), is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("indeterminate".into()), Arg::Str("change".into()),
                 Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
             ])
         }
         "open" => {
-            let setter = build_setter(ctx, var_name.clone(), is_rune);
-            let getter = build_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name.clone(), is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("open".into()), Arg::Str("toggle".into()),
                 Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
@@ -521,8 +539,8 @@ fn gen_bind_directive<'a>(
 
         // --- Contenteditable ---
         "innerHTML" | "innerText" | "textContent" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_content_editable", [
                 Arg::Str(bind.name.clone()), Arg::Ident(el_name),
                 Arg::Expr(getter), Arg::Expr(setter),
@@ -531,7 +549,7 @@ fn gen_bind_directive<'a>(
 
         // --- Dimension bindings (element size, readonly) ---
         "clientWidth" | "clientHeight" | "offsetWidth" | "offsetHeight" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_element_size", [
                 Arg::Ident(el_name), Arg::Str(bind.name.clone()), Arg::Expr(setter),
             ])
@@ -539,7 +557,7 @@ fn gen_bind_directive<'a>(
 
         // --- Dimension bindings (resize observer, readonly) ---
         "contentRect" | "contentBoxSize" | "borderBoxSize" | "devicePixelContentBoxSize" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_resize_observer", [
                 Arg::Ident(el_name), Arg::Str(bind.name.clone()), Arg::Expr(setter),
             ])
@@ -547,36 +565,36 @@ fn gen_bind_directive<'a>(
 
         // --- Media R/W bindings ---
         "currentTime" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_current_time", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "playbackRate" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_playback_rate", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "paused" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_paused", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "volume" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_volume", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
         "muted" => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_muted", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
@@ -584,61 +602,61 @@ fn gen_bind_directive<'a>(
 
         // --- Media RO bindings (setter only) ---
         "buffered" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_buffered", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
         "seekable" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_seekable", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
         "seeking" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_seeking", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
         "ended" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_ended", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
         "readyState" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_ready_state", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
         "played" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_played", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
 
         // --- Media/Image RO event-based bindings (bind_property, no bidirectional) ---
         "duration" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("duration".into()), Arg::Str("durationchange".into()),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "videoWidth" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("videoWidth".into()), Arg::Str("resize".into()),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "videoHeight" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("videoHeight".into()), Arg::Str("resize".into()),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "naturalWidth" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("naturalWidth".into()), Arg::Str("load".into()),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "naturalHeight" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("naturalHeight".into()), Arg::Str("load".into()),
                 Arg::Ident(el_name), Arg::Expr(setter),
@@ -647,7 +665,7 @@ fn gen_bind_directive<'a>(
 
         // --- Misc ---
         "focused" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_focused", [Arg::Ident(el_name), Arg::Expr(setter)])
         }
 
@@ -660,9 +678,9 @@ fn gen_bind_directive<'a>(
                 ]);
                 ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
             } else {
-                build_setter(ctx, var_name.clone(), is_rune)
+                build_binding_setter(ctx, var_name.clone(), is_rune)
             };
-            let getter = build_getter(ctx, &var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
             let stmt = ctx.b.call_stmt("$.bind_this", [
                 Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
             ]);
@@ -671,8 +689,8 @@ fn gen_bind_directive<'a>(
 
         // Fallback for unknown bindings
         _ => {
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_value", [
                 Arg::Ident(el_name), Arg::Expr(getter), Arg::Expr(setter),
             ])
@@ -1040,7 +1058,7 @@ pub(crate) fn build_event_handler_s5<'a>(
 
 /// Build event handler for legacy on:directive (non-dev mode).
 /// Reference: `events.js` `build_event_handler()`.
-fn build_legacy_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
+pub(crate) fn build_legacy_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
     match &handler {
         // Inline arrow/function — pass through
         Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
@@ -1056,4 +1074,101 @@ fn build_legacy_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) ->
             ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
         }
     }
+}
+
+/// LEGACY(svelte4): Generate `$.event()` for legacy `on:directive` on a global element
+/// (svelte:body, svelte:document, svelte:window). `target` is the element expression
+/// (e.g. `"$.document.body"`, `"$.document"`, `"$.window"`).
+pub(crate) fn gen_legacy_event_on<'a>(
+    ctx: &mut Ctx<'a>,
+    od: &svelte_ast::OnDirectiveLegacy,
+    attr_id: NodeId,
+    target: &str,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let handler = if od.expression_span.is_none() {
+        let bubble_call = ctx.b.static_member_expr(
+            ctx.b.rid_expr("$.bubble_event"),
+            "call",
+        );
+        let call = ctx.b.call_expr_callee(bubble_call, [
+            Arg::Expr(ctx.b.this_expr()),
+            Arg::Ident("$$props"),
+            Arg::Ident("$$arg"),
+        ]);
+        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
+    } else {
+        let expr = super::expression::get_attr_expr(ctx, attr_id);
+        build_legacy_event_handler(ctx, expr)
+    };
+
+    let mut wrapped = handler;
+    for modifier in &[
+        "stopPropagation",
+        "stopImmediatePropagation",
+        "preventDefault",
+        "self",
+        "trusted",
+        "once",
+    ] {
+        if od.modifiers.iter().any(|m| m == modifier) {
+            let fn_name = format!("$.{}", modifier);
+            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
+        }
+    }
+
+    let capture = od.modifiers.iter().any(|m| m == "capture");
+    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
+        "passive" => Some(true),
+        "nonpassive" => Some(false),
+        _ => None,
+    });
+
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Str(od.name.clone()),
+        Arg::Ident(target),
+        Arg::Expr(wrapped),
+    ];
+    if capture || passive.is_some() {
+        args.push(Arg::Bool(capture));
+    }
+    if let Some(p) = passive {
+        args.push(Arg::Bool(p));
+    }
+
+    stmts.push(ctx.b.call_stmt("$.event", args));
+}
+
+/// Generate Svelte 5 event attribute `$.event()` on a global element.
+/// `target` is the element expression (e.g. `"$.document.body"`, `"$.window"`).
+pub(crate) fn gen_event_attr_on<'a>(
+    ctx: &mut Ctx<'a>,
+    attr_id: NodeId,
+    raw_event_name: &str,
+    target: &str,
+    stmts: &mut Vec<Statement<'a>>,
+) {
+    let (event_name, capture) = if let Some(base) = svelte_js::strip_capture_event(raw_event_name) {
+        (base.to_string(), true)
+    } else {
+        (raw_event_name.to_string(), false)
+    };
+
+    let has_call = ctx.analysis.attr_expression(attr_id).map_or(false, |e| e.has_call);
+    let handler_expr = super::expression::get_attr_expr(ctx, attr_id);
+    let handler = build_event_handler_s5(ctx, handler_expr, has_call, stmts);
+
+    let passive = svelte_js::is_passive_event(&event_name);
+    let mut args: Vec<Arg<'a, '_>> = vec![
+        Arg::Str(event_name),
+        Arg::Ident(target),
+        Arg::Expr(handler),
+    ];
+    if capture || passive {
+        args.push(if capture { Arg::Bool(true) } else { Arg::Expr(ctx.b.void_zero_expr()) });
+    }
+    if passive {
+        args.push(Arg::Bool(true));
+    }
+    stmts.push(ctx.b.call_stmt("$.event", args));
 }

--- a/crates/svelte_codegen_client/src/template/svelte_body.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_body.rs
@@ -1,14 +1,12 @@
 //! SvelteBody code generation — `<svelte:body onclick={handler} use:action />`.
 
-use oxc_ast::ast::{Expression, Statement};
+use oxc_ast::ast::Statement;
 
 use svelte_ast::{Attribute, NodeId};
 
-use crate::builder::Arg;
 use crate::context::Ctx;
 
-use super::attributes::gen_use_directive_on;
-use super::expression::get_attr_expr;
+use super::attributes::{gen_event_attr_on, gen_legacy_event_on, gen_use_directive_on};
 
 /// Generate event listeners and actions for `<svelte:body>`.
 ///
@@ -26,12 +24,12 @@ pub(crate) fn gen_svelte_body<'a>(
         match attr {
             Attribute::OnDirectiveLegacy(od) => {
                 let attr_id = attr.id();
-                gen_legacy_event(ctx, od, attr_id, stmts);
+                gen_legacy_event_on(ctx, od, attr_id, "$.document.body", stmts);
             }
             Attribute::ExpressionAttribute(ea) => {
                 if let Some(event_name) = ea.name.strip_prefix("on") {
                     let attr_id = attr.id();
-                    gen_event_attr(ctx, attr_id, event_name, stmts);
+                    gen_event_attr_on(ctx, attr_id, event_name, "$.document.body", stmts);
                 }
             }
             Attribute::UseDirective(ud) => {
@@ -39,115 +37,6 @@ pub(crate) fn gen_svelte_body<'a>(
                 gen_use_directive_on(ctx, ud, attr_id, "$.document.body", stmts);
             }
             _ => {}
-        }
-    }
-}
-
-/// Legacy `on:event` → `$.event("name", $.document.body, handler)`.
-fn gen_legacy_event<'a>(
-    ctx: &mut Ctx<'a>,
-    od: &svelte_ast::OnDirectiveLegacy,
-    attr_id: NodeId,
-    stmts: &mut Vec<Statement<'a>>,
-) {
-    let handler = if od.expression_span.is_none() {
-        // Bubble event
-        let bubble_call = ctx.b.static_member_expr(
-            ctx.b.rid_expr("$.bubble_event"),
-            "call",
-        );
-        let call = ctx.b.call_expr_callee(bubble_call, [
-            Arg::Expr(ctx.b.this_expr()),
-            Arg::Ident("$$props"),
-            Arg::Ident("$$arg"),
-        ]);
-        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
-    } else {
-        let expr = get_attr_expr(ctx, attr_id);
-        build_event_handler(ctx, expr)
-    };
-
-    let mut wrapped = handler;
-    for modifier in &[
-        "stopPropagation",
-        "stopImmediatePropagation",
-        "preventDefault",
-        "self",
-        "trusted",
-        "once",
-    ] {
-        if od.modifiers.iter().any(|m| m == modifier) {
-            let fn_name = format!("$.{}", modifier);
-            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
-        }
-    }
-
-    let capture = od.modifiers.iter().any(|m| m == "capture");
-    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
-        "passive" => Some(true),
-        "nonpassive" => Some(false),
-        _ => None,
-    });
-
-    let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(od.name.clone()),
-        Arg::Ident("$.document.body"),
-        Arg::Expr(wrapped),
-    ];
-    if capture || passive.is_some() {
-        args.push(Arg::Bool(capture));
-    }
-    if let Some(p) = passive {
-        args.push(Arg::Bool(p));
-    }
-
-    stmts.push(ctx.b.call_stmt("$.event", args));
-}
-
-/// Svelte 5 event attribute → `$.event(name, $.document.body, handler [, capture] [, passive])`.
-fn gen_event_attr<'a>(
-    ctx: &mut Ctx<'a>,
-    attr_id: NodeId,
-    raw_event_name: &str,
-    stmts: &mut Vec<Statement<'a>>,
-) {
-    let (event_name, capture) = if let Some(base) = svelte_js::strip_capture_event(raw_event_name) {
-        (base.to_string(), true)
-    } else {
-        (raw_event_name.to_string(), false)
-    };
-
-    let has_call = ctx.analysis.attr_expression(attr_id).map_or(false, |e| e.has_call);
-    let handler_expr = get_attr_expr(ctx, attr_id);
-    let handler = super::attributes::build_event_handler_s5(ctx, handler_expr, has_call, stmts);
-
-    let passive = svelte_js::is_passive_event(&event_name);
-    let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(event_name),
-        Arg::Ident("$.document.body"),
-        Arg::Expr(handler),
-    ];
-    if capture || passive {
-        args.push(if capture { Arg::Bool(true) } else { Arg::Expr(ctx.b.void_zero_expr()) });
-    }
-    if passive {
-        args.push(Arg::Bool(true));
-    }
-    stmts.push(ctx.b.call_stmt("$.event", args));
-}
-
-/// Build event handler for legacy on:directive (non-dev mode).
-fn build_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
-    match &handler {
-        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
-        Expression::Identifier(_) => handler,
-        _ => {
-            let apply = ctx.b.static_member_expr(handler, "apply");
-            let call = ctx.b.call_expr_callee(apply, [
-                Arg::Expr(ctx.b.this_expr()),
-                Arg::Ident("$$args"),
-            ]);
-            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
         }
     }
 }

--- a/crates/svelte_codegen_client/src/template/svelte_document.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_document.rs
@@ -1,13 +1,15 @@
 //! SvelteDocument code generation — `<svelte:document on:event bind:prop />`.
 
-use oxc_ast::ast::{Expression, Statement};
+use oxc_ast::ast::Statement;
 
 use svelte_ast::{Attribute, NodeId};
 
 use crate::builder::Arg;
 use crate::context::Ctx;
 
-use super::expression::get_attr_expr;
+use super::attributes::{
+    build_binding_setter_silent, gen_event_attr_on, gen_legacy_event_on,
+};
 
 /// Generate event listeners and bindings for `<svelte:document>`.
 ///
@@ -25,12 +27,12 @@ pub(crate) fn gen_svelte_document<'a>(
         match attr {
             Attribute::OnDirectiveLegacy(od) => {
                 let attr_id = attr.id();
-                gen_legacy_event(ctx, od, attr_id, stmts);
+                gen_legacy_event_on(ctx, od, attr_id, "$.document", stmts);
             }
             Attribute::ExpressionAttribute(ea) => {
                 if let Some(event_name) = ea.name.strip_prefix("on") {
                     let attr_id = attr.id();
-                    gen_event_attr(ctx, attr_id, event_name, stmts);
+                    gen_event_attr_on(ctx, attr_id, event_name, "$.document", stmts);
                 }
             }
             Attribute::BindDirective(bind) => {
@@ -41,122 +43,12 @@ pub(crate) fn gen_svelte_document<'a>(
     }
 }
 
-/// Legacy `on:event` → `$.event("name", $.document, handler)`.
-fn gen_legacy_event<'a>(
-    ctx: &mut Ctx<'a>,
-    od: &svelte_ast::OnDirectiveLegacy,
-    attr_id: NodeId,
-    stmts: &mut Vec<Statement<'a>>,
-) {
-    let handler = if od.expression_span.is_none() {
-        // Bubble event
-        let bubble_call = ctx.b.static_member_expr(
-            ctx.b.rid_expr("$.bubble_event"),
-            "call",
-        );
-        let call = ctx.b.call_expr_callee(bubble_call, [
-            Arg::Expr(ctx.b.this_expr()),
-            Arg::Ident("$$props"),
-            Arg::Ident("$$arg"),
-        ]);
-        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
-    } else {
-        let expr = get_attr_expr(ctx, attr_id);
-        build_event_handler(ctx, expr)
-    };
-
-    let mut wrapped = handler;
-    for modifier in &[
-        "stopPropagation",
-        "stopImmediatePropagation",
-        "preventDefault",
-        "self",
-        "trusted",
-        "once",
-    ] {
-        if od.modifiers.iter().any(|m| m == modifier) {
-            let fn_name = format!("$.{}", modifier);
-            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
-        }
-    }
-
-    let capture = od.modifiers.iter().any(|m| m == "capture");
-    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
-        "passive" => Some(true),
-        "nonpassive" => Some(false),
-        _ => None,
-    });
-
-    let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(od.name.clone()),
-        Arg::Ident("$.document"),
-        Arg::Expr(wrapped),
-    ];
-    if capture || passive.is_some() {
-        args.push(Arg::Bool(capture));
-    }
-    if let Some(p) = passive {
-        args.push(Arg::Bool(p));
-    }
-
-    stmts.push(ctx.b.call_stmt("$.event", args));
-}
-
-/// Svelte 5 event attribute → `$.event(name, $.document, handler [, capture] [, passive])`.
-fn gen_event_attr<'a>(
-    ctx: &mut Ctx<'a>,
-    attr_id: NodeId,
-    raw_event_name: &str,
-    stmts: &mut Vec<Statement<'a>>,
-) {
-    let (event_name, capture) = if let Some(base) = svelte_js::strip_capture_event(raw_event_name) {
-        (base.to_string(), true)
-    } else {
-        (raw_event_name.to_string(), false)
-    };
-
-    let has_call = ctx.analysis.attr_expression(attr_id).map_or(false, |e| e.has_call);
-    let handler_expr = get_attr_expr(ctx, attr_id);
-    let handler = super::attributes::build_event_handler_s5(ctx, handler_expr, has_call, stmts);
-
-    let passive = svelte_js::is_passive_event(&event_name);
-    let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(event_name),
-        Arg::Ident("$.document"),
-        Arg::Expr(handler),
-    ];
-    if capture || passive {
-        args.push(if capture { Arg::Bool(true) } else { Arg::Expr(ctx.b.void_zero_expr()) });
-    }
-    if passive {
-        args.push(Arg::Bool(true));
-    }
-    stmts.push(ctx.b.call_stmt("$.event", args));
-}
-
-/// Build event handler for legacy on:directive (non-dev mode).
-fn build_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
-    match &handler {
-        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
-        Expression::Identifier(_) => handler,
-        _ => {
-            let apply = ctx.b.static_member_expr(handler, "apply");
-            let call = ctx.b.call_expr_callee(apply, [
-                Arg::Expr(ctx.b.this_expr()),
-                Arg::Ident("$$args"),
-            ]);
-            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
-        }
-    }
-}
-
 /// Generate document-specific bind directives.
 fn gen_document_binding<'a>(
     ctx: &mut Ctx<'a>,
     bind: &svelte_ast::BindDirective,
     stmts: &mut Vec<Statement<'a>>,
 ) {
-    // Pre-computed by analysis — no string-based symbol re-resolution needed.
     let is_rune = ctx.is_mutable_rune_target(bind.id);
 
     let var_name = if bind.shorthand {
@@ -167,31 +59,13 @@ fn gen_document_binding<'a>(
         return;
     };
 
-    // Document binding setters use `$.set(var, $$value, true)` — the `true` prevents
-    // re-triggering reactivity within the binding's own effect.
-    let build_setter = |ctx: &mut Ctx<'a>, var: String, is_rune: bool| -> Expression<'a> {
-        let body = if is_rune {
-            ctx.b.call_expr("$.set", [
-                Arg::Ident(&var),
-                Arg::Ident("$$value"),
-                Arg::Bool(true),
-            ])
-        } else {
-            ctx.b.assign_expr(
-                crate::builder::AssignLeft::Ident(var),
-                crate::builder::AssignRight::Expr(ctx.b.rid_expr("$$value")),
-            )
-        };
-        ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
-    };
-
     let stmt = match bind.name.as_str() {
         "activeElement" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_active_element", [Arg::Expr(setter)])
         }
         "fullscreenElement" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("fullscreenElement".to_string()),
                 Arg::Str("fullscreenchange".to_string()),
@@ -200,7 +74,7 @@ fn gen_document_binding<'a>(
             ])
         }
         "pointerLockElement" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("pointerLockElement".to_string()),
                 Arg::Str("pointerlockchange".to_string()),
@@ -209,7 +83,7 @@ fn gen_document_binding<'a>(
             ])
         }
         "visibilityState" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("visibilityState".to_string()),
                 Arg::Str("visibilitychange".to_string()),

--- a/crates/svelte_codegen_client/src/template/svelte_window.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_window.rs
@@ -1,13 +1,15 @@
 //! SvelteWindow code generation — `<svelte:window on:event bind:prop />`.
 
-use oxc_ast::ast::{Expression, Statement};
+use oxc_ast::ast::Statement;
 
 use svelte_ast::{Attribute, NodeId};
 
 use crate::builder::Arg;
 use crate::context::Ctx;
 
-use super::expression::get_attr_expr;
+use super::attributes::{
+    build_binding_getter, build_binding_setter_silent, gen_event_attr_on, gen_legacy_event_on,
+};
 
 /// Generate event listeners and bindings for `<svelte:window>`.
 ///
@@ -25,12 +27,12 @@ pub(crate) fn gen_svelte_window<'a>(
         match attr {
             Attribute::OnDirectiveLegacy(od) => {
                 let attr_id = attr.id();
-                gen_legacy_event(ctx, od, attr_id, stmts);
+                gen_legacy_event_on(ctx, od, attr_id, "$.window", stmts);
             }
             Attribute::ExpressionAttribute(ea) => {
                 if let Some(event_name) = ea.name.strip_prefix("on") {
                     let attr_id = attr.id();
-                    gen_event_attr(ctx, attr_id, event_name, stmts);
+                    gen_event_attr_on(ctx, attr_id, event_name, "$.window", stmts);
                 }
             }
             Attribute::BindDirective(bind) => {
@@ -41,122 +43,12 @@ pub(crate) fn gen_svelte_window<'a>(
     }
 }
 
-/// Legacy `on:event` → `$.event("name", $.window, handler)`.
-fn gen_legacy_event<'a>(
-    ctx: &mut Ctx<'a>,
-    od: &svelte_ast::OnDirectiveLegacy,
-    attr_id: NodeId,
-    stmts: &mut Vec<Statement<'a>>,
-) {
-    let handler = if od.expression_span.is_none() {
-        // Bubble event
-        let bubble_call = ctx.b.static_member_expr(
-            ctx.b.rid_expr("$.bubble_event"),
-            "call",
-        );
-        let call = ctx.b.call_expr_callee(bubble_call, [
-            Arg::Expr(ctx.b.this_expr()),
-            Arg::Ident("$$props"),
-            Arg::Ident("$$arg"),
-        ]);
-        ctx.b.function_expr(ctx.b.params(["$$arg"]), vec![ctx.b.expr_stmt(call)])
-    } else {
-        let expr = get_attr_expr(ctx, attr_id);
-        build_event_handler(ctx, expr)
-    };
-
-    let mut wrapped = handler;
-    for modifier in &[
-        "stopPropagation",
-        "stopImmediatePropagation",
-        "preventDefault",
-        "self",
-        "trusted",
-        "once",
-    ] {
-        if od.modifiers.iter().any(|m| m == modifier) {
-            let fn_name = format!("$.{}", modifier);
-            wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
-        }
-    }
-
-    let capture = od.modifiers.iter().any(|m| m == "capture");
-    let passive = od.modifiers.iter().find_map(|m| match m.as_str() {
-        "passive" => Some(true),
-        "nonpassive" => Some(false),
-        _ => None,
-    });
-
-    let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(od.name.clone()),
-        Arg::Ident("$.window"),
-        Arg::Expr(wrapped),
-    ];
-    if capture || passive.is_some() {
-        args.push(Arg::Bool(capture));
-    }
-    if let Some(p) = passive {
-        args.push(Arg::Bool(p));
-    }
-
-    stmts.push(ctx.b.call_stmt("$.event", args));
-}
-
-/// Svelte 5 event attribute → `$.event(name, $.window, handler [, capture] [, passive])`.
-fn gen_event_attr<'a>(
-    ctx: &mut Ctx<'a>,
-    attr_id: NodeId,
-    raw_event_name: &str,
-    stmts: &mut Vec<Statement<'a>>,
-) {
-    let (event_name, capture) = if let Some(base) = svelte_js::strip_capture_event(raw_event_name) {
-        (base.to_string(), true)
-    } else {
-        (raw_event_name.to_string(), false)
-    };
-
-    let has_call = ctx.analysis.attr_expression(attr_id).map_or(false, |e| e.has_call);
-    let handler_expr = get_attr_expr(ctx, attr_id);
-    let handler = super::attributes::build_event_handler_s5(ctx, handler_expr, has_call, stmts);
-
-    let passive = svelte_js::is_passive_event(&event_name);
-    let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(event_name),
-        Arg::Ident("$.window"),
-        Arg::Expr(handler),
-    ];
-    if capture || passive {
-        args.push(if capture { Arg::Bool(true) } else { Arg::Expr(ctx.b.void_zero_expr()) });
-    }
-    if passive {
-        args.push(Arg::Bool(true));
-    }
-    stmts.push(ctx.b.call_stmt("$.event", args));
-}
-
-/// Build event handler for legacy on:directive (non-dev mode).
-fn build_event_handler<'a>(ctx: &mut Ctx<'a>, handler: Expression<'a>) -> Expression<'a> {
-    match &handler {
-        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => handler,
-        Expression::Identifier(_) => handler,
-        _ => {
-            let apply = ctx.b.static_member_expr(handler, "apply");
-            let call = ctx.b.call_expr_callee(apply, [
-                Arg::Expr(ctx.b.this_expr()),
-                Arg::Ident("$$args"),
-            ]);
-            ctx.b.function_expr(ctx.b.rest_params("$$args"), vec![ctx.b.expr_stmt(call)])
-        }
-    }
-}
-
 /// Generate window-specific bind directives.
 fn gen_window_binding<'a>(
     ctx: &mut Ctx<'a>,
     bind: &svelte_ast::BindDirective,
     stmts: &mut Vec<Statement<'a>>,
 ) {
-    // Pre-computed by analysis — no string-based symbol re-resolution needed.
     let is_rune = ctx.is_mutable_rune_target(bind.id);
 
     let var_name = if bind.shorthand {
@@ -167,38 +59,11 @@ fn gen_window_binding<'a>(
         return;
     };
 
-    let build_getter = |ctx: &mut Ctx<'a>, var: &str, is_rune: bool| -> Expression<'a> {
-        let body = if is_rune {
-            ctx.b.call_expr("$.get", [Arg::Ident(var)])
-        } else {
-            ctx.b.rid_expr(var)
-        };
-        ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(body)])
-    };
-
-    // Window binding setters use `$.set(var, $$value, true)` — the `true` prevents
-    // re-triggering reactivity within the binding's own effect.
-    let build_setter = |ctx: &mut Ctx<'a>, var: String, is_rune: bool| -> Expression<'a> {
-        let body = if is_rune {
-            ctx.b.call_expr("$.set", [
-                Arg::Ident(&var),
-                Arg::Ident("$$value"),
-                Arg::Bool(true),
-            ])
-        } else {
-            ctx.b.assign_expr(
-                crate::builder::AssignLeft::Ident(var),
-                crate::builder::AssignRight::Expr(ctx.b.rid_expr("$$value")),
-            )
-        };
-        ctx.b.arrow_expr(ctx.b.params(["$$value"]), [ctx.b.expr_stmt(body)])
-    };
-
     let stmt = match bind.name.as_str() {
         "scrollX" | "scrollY" => {
             let axis = if bind.name == "scrollX" { "x" } else { "y" };
-            let getter = build_getter(ctx, &var_name, is_rune);
-            let setter = build_setter(ctx, var_name, is_rune);
+            let getter = build_binding_getter(ctx, &var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_window_scroll", [
                 Arg::Str(axis.to_string()),
                 Arg::Expr(getter),
@@ -206,18 +71,18 @@ fn gen_window_binding<'a>(
             ])
         }
         "innerWidth" | "innerHeight" | "outerWidth" | "outerHeight" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_window_size", [
                 Arg::Str(bind.name.clone()),
                 Arg::Expr(setter),
             ])
         }
         "online" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_online", [Arg::Expr(setter)])
         }
         "devicePixelRatio" => {
-            let setter = build_setter(ctx, var_name, is_rune);
+            let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
                 Arg::Str("devicePixelRatio".to_string()),
                 Arg::Str("resize".to_string()),

--- a/crates/svelte_js/Cargo.toml
+++ b/crates/svelte_js/Cargo.toml
@@ -13,6 +13,7 @@ oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 compact_str = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -10,6 +10,7 @@ use oxc_span::{GetSpan as _, SourceType};
 
 use compact_str::CompactString;
 use oxc_semantic::SymbolId;
+use rustc_hash::FxHashSet;
 use svelte_span::Span;
 use svelte_diagnostics::Diagnostic;
 
@@ -1023,7 +1024,7 @@ fn collect_derived_refs(expr: &Expression<'_>) -> Vec<CompactString> {
     };
     let mut refs = Vec::new();
     collect_idents_recursive(arg_expr, &mut refs);
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = FxHashSet::default();
     refs.retain(|r| seen.insert(r.clone()));
     refs
 }


### PR DESCRIPTION
- Extract shared event handler functions (build_legacy_event_handler,
  gen_legacy_event_on, gen_event_attr_on) into attributes.rs, eliminating
  identical implementations from svelte_body.rs, svelte_document.rs, and
  svelte_window.rs
- Extract binding getter/setter builders (build_binding_getter,
  build_binding_setter, build_binding_setter_silent) as pub(crate)
  functions, replacing duplicated closures across 3 files
- Replace std::collections::HashSet with FxHashSet in svelte_js

Net reduction: ~250 lines of duplicated code.

https://claude.ai/code/session_01BvtpXucaPKNJmq1gRMNwak