### PR TITLE
Port $state/$state.raw destructuring and class field support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,8 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 ### Script codegen
 - [x] `$state` rune (read, assign, update, `$.proxy()`)
 - [x] `$state.raw(val)` → `$.state(val)` (no proxy)
+- [x] `$state` / `$state.raw` destructuring — object, array, defaults, rest, nested patterns
+- [x] `$state` / `$state.raw` class fields — public, private, constructor, multiple fields
 - [x] `$state.snapshot(val)` → `$.snapshot(val)`
 - [x] `$derived` / `$derived.by` — `$.derived(() => expr)` / `$.derived(fn)`
 - [x] `$props` rune (destructure, defaults, `$bindable`, rest, mutated)
@@ -306,8 +308,8 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: emit error if void element has children (requires parser-level check for content between void open tags)
 
 ### Runes (Tier 1)
-- [ ] `$state` / `$state.raw` destructuring support in script codegen
-- [ ] `$state` / `$state.raw` class field support
+- [x] `$state` / `$state.raw` destructuring support in script codegen
+- [x] `$state` / `$state.raw` class field support
 - [ ] `$state.frozen` → `$state.raw` rename validation
 - [ ] `$state.eager(val)` — experimental async, requires `experimental.async` flag
 - [ ] `$effect.pending()` — requires `<svelte:boundary>` (Tier 5)

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -283,6 +283,9 @@ pub struct AnalysisData {
     pub exports: Vec<svelte_js::ExportInfo>,
     /// Component needs runtime context (`$.push`/`$.pop`), e.g. has `$effect` calls.
     pub needs_context: bool,
+    /// Script contains class declarations with `$state`/`$state.raw` fields.
+    /// When true, member access on local bindings is treated as dynamic.
+    pub has_class_state_fields: bool,
 
     /// Per-element flags (spread, class/style directives, needs_var, etc.).
     pub element_flags: ElementFlags,
@@ -326,6 +329,7 @@ impl AnalysisData {
             props_id: None,
             exports: Vec::new(),
             needs_context: false,
+            has_class_state_fields: false,
             element_flags: ElementFlags::new(),
             fragments: FragmentData::new(),
             snippets: SnippetData::new(),

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -27,7 +27,8 @@ pub fn parse_js<'a>(
         ) {
             Ok((mut info, scoping, program)) => {
                 data.exports = std::mem::take(&mut info.exports);
-                data.needs_context = info.has_effects;
+                data.needs_context = info.has_effects || info.has_class_state_fields;
+                data.has_class_state_fields = info.has_class_state_fields;
                 data.script = Some(info);
                 data.scoping = ComponentScoping::from_scoping(scoping);
                 parsed.script_program = Some(program);

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -22,10 +22,19 @@ impl ReactivityVisitor {
                     return true;
                 }
                 if let Some(sym_id) = r.symbol_id {
-                    data.scoping.is_dynamic_by_id(sym_id)
-                } else {
-                    false
+                    if data.scoping.is_dynamic_by_id(sym_id) {
+                        return true;
+                    }
+                    // When class state fields exist, member access on local bindings
+                    // is potentially reactive (getters call $.get internally).
+                    if data.has_class_state_fields
+                        && data.scoping.symbol_scope_id(sym_id) == data.scoping.root_scope_id()
+                        && !data.scoping.is_rune(sym_id)
+                    {
+                        return true;
+                    }
                 }
+                false
             });
         }
         false

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -660,6 +660,20 @@ impl<'a> Builder<'a> {
         Expression::StaticMemberExpression(self.alloc(self.static_member(object, prop)))
     }
 
+    /// Create a computed member expression: `object[property]`.
+    pub fn computed_member_expr(&self, object: Expression<'a>, property: Expression<'a>) -> Expression<'a> {
+        let cme = self.ast.computed_member_expression(SPAN, object, property, false);
+        Expression::ComputedMemberExpression(self.alloc(cme))
+    }
+
+    /// Create an array literal: `[...items]`.
+    pub fn array_expr(&self, items: impl IntoIterator<Item = Expression<'a>>) -> Expression<'a> {
+        let elements = items.into_iter().map(|e| ast::ArrayExpressionElement::from(e));
+        Expression::ArrayExpression(self.alloc(
+            self.ast.array_expression(SPAN, self.ast.vec_from_iter(elements))
+        ))
+    }
+
     /// Convert all member accesses in an expression to optional chaining.
     /// `obj.ref` → `obj?.ref`, `a.b.c` → `a?.b?.c`, `refs[i]` → `refs?.[i]`
     pub fn make_optional_chain(&self, expr: Expression<'a>) -> Expression<'a> {
@@ -1039,6 +1053,151 @@ impl<'a> Builder<'a> {
                 ast::ObjectPropertyKind::ObjectProperty(self.alloc(obj_prop))
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Class member builders
+    // -----------------------------------------------------------------------
+
+    /// Create a `PrivateIdentifier` node (`#name`).
+    pub fn private_identifier(&self, name: &str) -> ast::PrivateIdentifier<'a> {
+        self.ast.private_identifier(SPAN, self.ast.atom(name))
+    }
+
+    /// Create a `PropertyDefinition` class element with a private key: `#name = value;`
+    pub fn class_private_field(
+        &self,
+        name: &str,
+        value: Option<Expression<'a>>,
+    ) -> ast::ClassElement<'a> {
+        let key = ast::PropertyKey::PrivateIdentifier(
+            self.alloc(self.private_identifier(name)),
+        );
+        ast::ClassElement::PropertyDefinition(self.alloc(self.ast.property_definition(
+            SPAN,
+            ast::PropertyDefinitionType::PropertyDefinition,
+            self.ast.vec(),
+            key,
+            NONE,  // type_annotation
+            value,
+            false, // computed
+            false, // r#static
+            false, // declare
+            false, // r#override
+            false, // optional
+            false, // definite
+            false, // readonly
+            None,  // accessibility
+        )))
+    }
+
+    /// Create a getter `MethodDefinition` for a class: `get name() { body }`
+    pub fn class_getter(
+        &self,
+        key: ast::PropertyKey<'a>,
+        body_stmts: Vec<Statement<'a>>,
+    ) -> ast::ClassElement<'a> {
+        let body = self.ast.alloc_function_body(
+            SPAN,
+            self.ast.vec(),
+            self.ast.vec_from_iter(body_stmts),
+        );
+        let func = self.ast.function(
+            SPAN,
+            FunctionType::FunctionExpression,
+            None,
+            false, // generator
+            false, // r#async
+            false, // declare
+            NONE,  // type_parameters
+            NONE,  // this_param
+            self.no_params(),
+            NONE,  // return_type
+            Some(body),
+        );
+        ast::ClassElement::MethodDefinition(self.alloc(self.ast.method_definition(
+            SPAN,
+            ast::MethodDefinitionType::MethodDefinition,
+            self.ast.vec(),
+            key,
+            func,
+            ast::MethodDefinitionKind::Get,
+            false, // computed
+            false, // r#static
+            false, // r#override
+            false, // optional
+            None,  // accessibility
+        )))
+    }
+
+    /// Create a setter `MethodDefinition` for a class: `set name(param) { body }`
+    pub fn class_setter(
+        &self,
+        key: ast::PropertyKey<'a>,
+        param_name: &str,
+        body_stmts: Vec<Statement<'a>>,
+    ) -> ast::ClassElement<'a> {
+        let param_atom = self.ast.atom(param_name);
+        let pattern = self.ast.binding_pattern_binding_identifier(SPAN, param_atom);
+        let param = self.ast.formal_parameter(SPAN, self.ast.vec(), pattern, NONE, NONE, false, None, false, false);
+        let params = self.ast.formal_parameters(
+            SPAN,
+            ast::FormalParameterKind::FormalParameter,
+            self.ast.vec_from_array([param]),
+            NONE,
+        );
+        let body = self.ast.alloc_function_body(
+            SPAN,
+            self.ast.vec(),
+            self.ast.vec_from_iter(body_stmts),
+        );
+        let func = self.ast.function(
+            SPAN,
+            FunctionType::FunctionExpression,
+            None,
+            false, // generator
+            false, // r#async
+            false, // declare
+            NONE,  // type_parameters
+            NONE,  // this_param
+            params,
+            NONE,  // return_type
+            Some(body),
+        );
+        ast::ClassElement::MethodDefinition(self.alloc(self.ast.method_definition(
+            SPAN,
+            ast::MethodDefinitionType::MethodDefinition,
+            self.ast.vec(),
+            key,
+            func,
+            ast::MethodDefinitionKind::Set,
+            false, // computed
+            false, // r#static
+            false, // r#override
+            false, // optional
+            None,  // accessibility
+        )))
+    }
+
+    /// Create a `PropertyKey` from a public identifier name.
+    pub fn public_key(&self, name: &str) -> ast::PropertyKey<'a> {
+        ast::PropertyKey::StaticIdentifier(
+            self.alloc(self.ast.identifier_name(SPAN, self.ast.atom(name))),
+        )
+    }
+
+    /// Create a `PropertyKey` from a private identifier name.
+    pub fn private_key(&self, name: &str) -> ast::PropertyKey<'a> {
+        ast::PropertyKey::PrivateIdentifier(
+            self.alloc(self.private_identifier(name)),
+        )
+    }
+
+    /// Create `this.#name` as an expression.
+    pub fn this_private_member(&self, name: &str) -> Expression<'a> {
+        let this_expr = self.ast.expression_this(SPAN);
+        let field = self.ast.private_field_expression(SPAN, this_expr, self.private_identifier(name), false);
+        Expression::PrivateFieldExpression(self.alloc(field))
     }
 }
 

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -1,9 +1,9 @@
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{
+use oxc_allocator::{Allocator, CloneIn};
+use oxc_ast::{NONE, ast::{
     ArrowFunctionExpression, Expression, FunctionBody, Program, Statement, VariableDeclarator,
-};
+}};
 use oxc_parser::Parser as OxcParser;
 use oxc_semantic::{Scoping, SemanticBuilder};
 use oxc_span::SourceType;
@@ -135,6 +135,8 @@ fn transform_script_text<'a>(
         component_source,
         script_content_start,
         next_arrow_name: None,
+        ident_counter: 0,
+        class_state_stack: Vec::new(),
     };
 
     let empty_scoping = Scoping::default();
@@ -200,6 +202,8 @@ fn transform_program<'a>(
         component_source,
         script_content_start,
         next_arrow_name: None,
+        ident_counter: 0,
+        class_state_stack: Vec::new(),
     };
 
     let empty_scoping = Scoping::default();
@@ -301,6 +305,24 @@ struct ScriptTransformer<'b, 'a> {
     script_content_start: u32,
     /// Captured variable name for arrow functions (from VariableDeclarator).
     next_arrow_name: Option<String>,
+    /// Counter for generating unique variable names (tmp, $$array_0, etc.).
+    ident_counter: u32,
+    /// Stack of class state field info for nested classes. Each entry maps
+    /// the backing private name (e.g. "#count") to its rune kind.
+    class_state_stack: Vec<ClassStateInfo>,
+}
+
+struct ClassStateField {
+    /// Original public field name (e.g. "count") — None for private fields
+    public_name: Option<String>,
+    /// Private backing name (e.g. "#count")
+    private_name: String,
+    /// Whether this is $state (true) or $state.raw (false) — controls the `true` arg in setter
+    is_state: bool,
+}
+
+struct ClassStateInfo {
+    fields: Vec<ClassStateField>,
 }
 
 impl<'b, 'a> ScriptTransformer<'b, 'a> {
@@ -488,6 +510,615 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
 
         vec![self.b.let_multi_stmt(declarators)]
     }
+
+    /// Expand destructured `$state`/`$state.raw` declarations into expanded form.
+    /// Called from `exit_statements` after other transformations.
+    fn expand_state_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
+        let mut i = 0;
+        while i < stmts.len() {
+            let should_expand = if let Statement::VariableDeclaration(decl) = &stmts[i] {
+                decl.declarations.len() == 1
+                    && !matches!(&decl.declarations[0].id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
+                    && decl.declarations[0].init.as_ref().is_some_and(|init| {
+                        Self::detect_state_rune_kind(init).is_some()
+                    })
+            } else {
+                false
+            };
+
+            if !should_expand {
+                i += 1;
+                continue;
+            }
+
+            // Take ownership of the statement
+            let stmt = stmts.remove(i);
+            let Statement::VariableDeclaration(mut decl) = stmt else { unreachable!() };
+            let mut declarator = decl.declarations.remove(0);
+            let init = declarator.init.take().unwrap();
+            let rune_kind = Self::detect_state_rune_kind(&init).unwrap();
+
+            // Extract the rune call argument
+            let value = if let Expression::CallExpression(mut call) = init {
+                if call.arguments.is_empty() {
+                    self.b.ast.expression_object(oxc_span::SPAN, self.b.ast.vec())
+                } else {
+                    let mut dummy = oxc_ast::ast::Argument::from(self.b.cheap_expr());
+                    std::mem::swap(&mut call.arguments[0], &mut dummy);
+                    dummy.into_expression()
+                }
+            } else {
+                unreachable!()
+            };
+
+            // Generate the expanded declaration
+            let replacement = self.gen_state_destructuring(
+                &declarator.id,
+                value,
+                rune_kind,
+                decl.kind,
+            );
+
+            // Insert replacement statement
+            stmts.insert(i, replacement);
+            self.ident_counter += 1;
+            i += 1;
+        }
+    }
+
+    /// Detect if an expression is a `$state(...)` or `$state.raw(...)` call.
+    fn detect_state_rune_kind(expr: &Expression<'_>) -> Option<RuneKind> {
+        if let Expression::CallExpression(call) = expr {
+            match &call.callee {
+                Expression::Identifier(id) if id.name.as_str() == "$state" => {
+                    return Some(RuneKind::State);
+                }
+                Expression::StaticMemberExpression(member) => {
+                    if let Expression::Identifier(obj) = &member.object {
+                        if obj.name.as_str() == "$state" && member.property.name.as_str() == "raw" {
+                            return Some(RuneKind::StateRaw);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// Generate expanded variable declaration for destructured $state/$state.raw.
+    fn gen_state_destructuring(
+        &mut self,
+        pattern: &oxc_ast::ast::BindingPattern<'a>,
+        value: Expression<'a>,
+        rune_kind: RuneKind,
+        decl_kind: oxc_ast::ast::VariableDeclarationKind,
+    ) -> Statement<'a> {
+        let tmp_name = self.gen_unique_name("tmp");
+        let tmp_name_str: &str = self.b.alloc_str(&tmp_name);
+
+        let mut declarators = Vec::new();
+
+        // First declarator: tmp = value
+        let tmp_declarator = self.b.ast.variable_declarator(
+            oxc_span::SPAN,
+            decl_kind,
+            self.b.ast.binding_pattern_binding_identifier(oxc_span::SPAN, self.b.ast.atom(tmp_name_str)),
+            NONE,
+            Some(value),
+            false,
+        );
+        declarators.push(tmp_declarator);
+
+        // Walk pattern and generate remaining declarators
+        let tmp_expr = self.b.rid_expr(tmp_name_str);
+        self.gen_destructure_declarators(pattern, tmp_expr, rune_kind, decl_kind, &mut declarators);
+
+        let decl = self.b.ast.variable_declaration(
+            oxc_span::SPAN,
+            decl_kind,
+            self.b.ast.vec_from_iter(declarators),
+            false,
+        );
+        Statement::VariableDeclaration(self.b.alloc(decl))
+    }
+
+    /// Recursively generate declarators for destructured patterns.
+    fn gen_destructure_declarators(
+        &mut self,
+        pattern: &oxc_ast::ast::BindingPattern<'a>,
+        accessor: Expression<'a>,
+        rune_kind: RuneKind,
+        decl_kind: oxc_ast::ast::VariableDeclarationKind,
+        declarators: &mut Vec<oxc_ast::ast::VariableDeclarator<'a>>,
+    ) {
+        match pattern {
+            oxc_ast::ast::BindingPattern::BindingIdentifier(id) => {
+                let name = id.name.as_str();
+                let sym_id = id.symbol_id.get();
+                let is_mutated = sym_id.is_some_and(|s| self.component_scoping.is_mutated(s));
+
+                let final_value = self.wrap_state_value(accessor, rune_kind, is_mutated);
+
+                let declarator = self.b.ast.variable_declarator(
+                    oxc_span::SPAN,
+                    decl_kind,
+                    self.b.ast.binding_pattern_binding_identifier(oxc_span::SPAN, self.b.ast.atom(name)),
+                    NONE,
+                    Some(final_value),
+                    false,
+                );
+                declarators.push(declarator);
+            }
+            oxc_ast::ast::BindingPattern::ObjectPattern(obj) => {
+                // Collect property key names for rest element
+                let mut key_names: Vec<String> = Vec::new();
+                for prop in &obj.properties {
+                    if let Some(name) = Self::property_key_name(&prop.key) {
+                        key_names.push(name);
+                    }
+                }
+
+                for prop in &obj.properties {
+                    let member = self.build_object_member_access(accessor.clone_in(self.b.ast.allocator), &prop.key, prop.computed);
+                    self.gen_destructure_declarators(&prop.value, member, rune_kind, decl_kind, declarators);
+                }
+
+                if let Some(rest) = &obj.rest {
+                    // $.exclude_from_object(accessor, ["key1", "key2"])
+                    let keys_array = self.b.array_expr(key_names.iter().map(|k| self.b.str_expr(k)));
+                    let exclude_expr = self.b.call_expr("$.exclude_from_object", [
+                        Arg::Expr(accessor),
+                        Arg::Expr(keys_array),
+                    ]);
+                    self.gen_destructure_declarators(&rest.argument, exclude_expr, rune_kind, decl_kind, declarators);
+                }
+            }
+            oxc_ast::ast::BindingPattern::ArrayPattern(arr) => {
+                // Generate intermediate: $$array_N = $.derived(() => $.to_array(accessor, len))
+                let array_name = self.gen_unique_name("$$array");
+                let array_name_str: &str = self.b.alloc_str(&array_name);
+
+                let len_arg = if arr.rest.is_some() {
+                    vec![Arg::Expr(accessor)]
+                } else {
+                    vec![Arg::Expr(accessor), Arg::Num(arr.elements.len() as f64)]
+                };
+
+                let to_array_call = self.b.call_expr("$.to_array", len_arg);
+                let thunk = self.b.arrow_expr(self.b.no_params(), [self.b.expr_stmt(to_array_call)]);
+                let derived_call = self.b.call_expr("$.derived", [Arg::Expr(thunk)]);
+
+                let array_declarator = self.b.ast.variable_declarator(
+                    oxc_span::SPAN,
+                    decl_kind,
+                    self.b.ast.binding_pattern_binding_identifier(oxc_span::SPAN, self.b.ast.atom(array_name_str)),
+                    NONE,
+                    Some(derived_call),
+                    false,
+                );
+                declarators.push(array_declarator);
+
+                // Generate element declarators
+                for (idx, elem) in arr.elements.iter().enumerate() {
+                    let Some(elem) = elem else { continue };
+                    // $.get($$array)[idx]
+                    let get_array = self.b.call_expr("$.get", [Arg::Ident(array_name_str)]);
+                    let elem_access = self.b.computed_member_expr(get_array, self.b.num_expr(idx as f64));
+                    self.gen_destructure_declarators(elem, elem_access, rune_kind, decl_kind, declarators);
+                }
+
+                if let Some(rest) = &arr.rest {
+                    // $.get($$array).slice(idx)
+                    let get_array = self.b.call_expr("$.get", [Arg::Ident(array_name_str)]);
+                    let slice = self.b.static_member_expr(get_array, "slice");
+                    let slice_call = self.b.ast.expression_call(
+                        oxc_span::SPAN,
+                        slice,
+                        NONE,
+                        self.b.ast.vec_from_array([oxc_ast::ast::Argument::from(self.b.num_expr(arr.elements.len() as f64))]),
+                        false,
+                    );
+                    self.gen_destructure_declarators(&rest.argument, slice_call, rune_kind, decl_kind, declarators);
+                }
+            }
+            oxc_ast::ast::BindingPattern::AssignmentPattern(assign) => {
+                // Default value: $.fallback(accessor, default)
+                let default_expr = assign.right.clone_in(self.b.ast.allocator);
+                let fallback = self.b.call_expr("$.fallback", [
+                    Arg::Expr(accessor),
+                    Arg::Expr(default_expr),
+                ]);
+                self.gen_destructure_declarators(&assign.left, fallback, rune_kind, decl_kind, declarators);
+            }
+        }
+    }
+
+    /// Wrap a value based on rune kind and mutation status.
+    fn wrap_state_value(
+        &self,
+        value: Expression<'a>,
+        rune_kind: RuneKind,
+        is_mutated: bool,
+    ) -> Expression<'a> {
+        match rune_kind {
+            RuneKind::State => {
+                let proxied = if Self::should_proxy(&value) {
+                    self.b.call_expr("$.proxy", [Arg::Expr(value)])
+                } else {
+                    value
+                };
+                if is_mutated {
+                    self.b.call_expr("$.state", [Arg::Expr(proxied)])
+                } else {
+                    proxied
+                }
+            }
+            RuneKind::StateRaw => {
+                if is_mutated {
+                    self.b.call_expr("$.state", [Arg::Expr(value)])
+                } else {
+                    value
+                }
+            }
+            _ => value,
+        }
+    }
+
+    /// Generate a unique name with a given prefix.
+    /// Each prefix has its own counter so `tmp` and `$$array` don't conflict.
+    fn gen_unique_name(&mut self, prefix: &str) -> String {
+        // Use a simple scheme: first call for any prefix gets no suffix,
+        // subsequent calls get _1, _2, etc. Track via ident_counter globally
+        // but offset per-prefix using a simple convention.
+        // For simplicity, just track the count of destructured statements.
+        // The first destructuring gets tmp/$$array, second gets tmp_1/$$array_1.
+        // We use ident_counter to count destructuring invocations.
+        // gen_state_destructuring increments once, both tmp and $$array use same number.
+        let n = self.ident_counter;
+        if n == 0 {
+            prefix.to_string()
+        } else {
+            format!("{}_{}", prefix, n)
+        }
+    }
+
+    /// Extract property key name as a string.
+    fn property_key_name(key: &oxc_ast::ast::PropertyKey<'_>) -> Option<String> {
+        match key {
+            oxc_ast::ast::PropertyKey::StaticIdentifier(id) => Some(id.name.to_string()),
+            oxc_ast::ast::PropertyKey::StringLiteral(s) => Some(s.value.to_string()),
+            _ => None,
+        }
+    }
+
+    /// Build a member access expression for an object property key.
+    fn build_object_member_access(
+        &self,
+        object: Expression<'a>,
+        key: &oxc_ast::ast::PropertyKey<'a>,
+        computed: bool,
+    ) -> Expression<'a> {
+        if computed {
+            if let Some(expr) = Self::property_key_to_expr(self.b, key) {
+                self.b.computed_member_expr(object, expr)
+            } else {
+                object
+            }
+        } else {
+            match key {
+                oxc_ast::ast::PropertyKey::StaticIdentifier(id) => {
+                    self.b.static_member_expr(object, self.b.alloc_str(id.name.as_str()))
+                }
+                oxc_ast::ast::PropertyKey::StringLiteral(s) => {
+                    self.b.static_member_expr(object, self.b.alloc_str(s.value.as_str()))
+                }
+                _ => object,
+            }
+        }
+    }
+
+    fn property_key_to_expr<'c>(b: &'c Builder<'a>, key: &oxc_ast::ast::PropertyKey<'a>) -> Option<Expression<'a>> {
+        match key {
+            oxc_ast::ast::PropertyKey::StringLiteral(s) => Some(b.str_expr(s.value.as_str())),
+            oxc_ast::ast::PropertyKey::NumericLiteral(n) => Some(b.num_expr(n.value)),
+            _ => None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Class state field helpers
+    // -----------------------------------------------------------------------
+
+    /// Scan a class body for state fields and return info about them.
+    fn scan_class_state_fields(&self, body: &oxc_ast::ast::ClassBody<'a>) -> ClassStateInfo {
+        let mut fields = Vec::new();
+
+        // Collect existing private names to avoid conflicts when generating backing fields
+        let mut existing_private: FxHashSet<String> = FxHashSet::default();
+        for element in &body.body {
+            if let oxc_ast::ast::ClassElement::PropertyDefinition(prop) = element {
+                if let oxc_ast::ast::PropertyKey::PrivateIdentifier(id) = &prop.key {
+                    existing_private.insert(id.name.to_string());
+                }
+            }
+        }
+
+        // Scan PropertyDefinitions for $state/$state.raw
+        for element in &body.body {
+            if let oxc_ast::ast::ClassElement::PropertyDefinition(prop) = element {
+                let Some(value) = &prop.value else { continue };
+                let Some(rune_kind) = Self::detect_state_rune_kind(value) else { continue };
+                let is_state = rune_kind == RuneKind::State;
+
+                match &prop.key {
+                    oxc_ast::ast::PropertyKey::PrivateIdentifier(id) => {
+                        // Private field: #name = $state(...) → just rewrite callee
+                        fields.push(ClassStateField {
+                            public_name: None,
+                            private_name: id.name.to_string(),
+                            is_state,
+                        });
+                    }
+                    oxc_ast::ast::PropertyKey::StaticIdentifier(id) if !prop.computed => {
+                        // Public field: name = $state(...) → private backing + getter/setter
+                        let name = id.name.to_string();
+                        let mut backing = format!("#{}", name);
+                        // Deconflict if private name already exists
+                        while existing_private.contains(backing.trim_start_matches('#')) {
+                            backing = format!("#_{}", backing.trim_start_matches('#'));
+                        }
+                        existing_private.insert(backing.trim_start_matches('#').to_string());
+                        fields.push(ClassStateField {
+                            public_name: Some(name),
+                            private_name: backing.trim_start_matches('#').to_string(),
+                            is_state,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Scan constructor for `this.name = $state(...)` assignments
+        for element in &body.body {
+            if let oxc_ast::ast::ClassElement::MethodDefinition(method) = element {
+                if method.kind == oxc_ast::ast::MethodDefinitionKind::Constructor {
+                    if let Some(func_body) = &method.value.body {
+                        for stmt in &func_body.statements {
+                            if let Statement::ExpressionStatement(es) = stmt {
+                                if let Expression::AssignmentExpression(assign) = &es.expression {
+                                    if assign.operator == oxc_ast::ast::AssignmentOperator::Assign {
+                                        if let oxc_ast::ast::AssignmentTarget::StaticMemberExpression(member) = &assign.left {
+                                            if let Expression::ThisExpression(_) = &member.object {
+                                                if let Some(rune_kind) = Self::detect_state_rune_kind(&assign.right) {
+                                                    let name = member.property.name.to_string();
+                                                    let is_state = rune_kind == RuneKind::State;
+                                                    let mut backing = format!("#{}", name);
+                                                    while existing_private.contains(backing.trim_start_matches('#')) {
+                                                        backing = format!("#_{}", backing.trim_start_matches('#'));
+                                                    }
+                                                    existing_private.insert(backing.trim_start_matches('#').to_string());
+                                                    fields.push(ClassStateField {
+                                                        public_name: Some(name),
+                                                        private_name: backing.trim_start_matches('#').to_string(),
+                                                        is_state,
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ClassStateInfo { fields }
+    }
+
+    /// Rewrite class body: replace state fields with private backing + getter/setter.
+    fn rewrite_class_body(
+        &self,
+        body: &mut oxc_ast::ast::ClassBody<'a>,
+        info: &ClassStateInfo,
+    ) {
+        use oxc_ast::ast::ClassElement;
+
+        // Build a lookup: field name → ClassStateField for quick matching
+        let public_fields: std::collections::HashMap<&str, &ClassStateField> = info.fields.iter()
+            .filter_map(|f| f.public_name.as_deref().map(|n| (n, f)))
+            .collect();
+        let private_fields: FxHashSet<&str> = info.fields.iter()
+            .filter(|f| f.public_name.is_none())
+            .map(|f| f.private_name.as_str())
+            .collect();
+
+        let mut new_body: Vec<ClassElement<'a>> = Vec::new();
+        // Track which public field names were handled from PropertyDefinition
+        let mut handled_public: FxHashSet<String> = FxHashSet::default();
+
+        // Take ownership of old body elements
+        let old_elements: Vec<ClassElement<'a>> = {
+            let mut temp = self.b.ast.vec();
+            std::mem::swap(&mut body.body, &mut temp);
+            temp.into_iter().collect()
+        };
+
+        for element in old_elements {
+            match element {
+                ClassElement::PropertyDefinition(mut prop) => {
+                    // Check if it's a state field
+                    let is_state_prop = prop.value.as_ref().is_some_and(|v| Self::detect_state_rune_kind(v).is_some());
+                    if !is_state_prop {
+                        new_body.push(ClassElement::PropertyDefinition(prop));
+                        continue;
+                    }
+
+                    match &prop.key {
+                        oxc_ast::ast::PropertyKey::PrivateIdentifier(id) => {
+                            let name = id.name.to_string();
+                            if private_fields.contains(name.as_str()) {
+                                // Private field: just rewrite $state(arg) → $.state(arg)
+                                if let Some(Expression::CallExpression(call)) = &mut prop.value {
+                                    call.callee = self.b.rid_expr("$.state");
+                                }
+                                new_body.push(ClassElement::PropertyDefinition(prop));
+                            } else {
+                                new_body.push(ClassElement::PropertyDefinition(prop));
+                            }
+                        }
+                        oxc_ast::ast::PropertyKey::StaticIdentifier(id) if !prop.computed => {
+                            let name = id.name.to_string();
+                            if let Some(field_info) = public_fields.get(name.as_str()) {
+                                handled_public.insert(name.clone());
+                                // Extract the rune argument
+                                let arg = if let Some(Expression::CallExpression(mut call)) = prop.value.take() {
+                                    if call.arguments.is_empty() {
+                                        None
+                                    } else {
+                                        let mut dummy = oxc_ast::ast::Argument::from(self.b.cheap_expr());
+                                        std::mem::swap(&mut call.arguments[0], &mut dummy);
+                                        Some(dummy.into_expression())
+                                    }
+                                } else {
+                                    None
+                                };
+
+                                // Generate: #backing = $.state(arg)
+                                let state_call = if let Some(arg) = arg {
+                                    self.b.call_expr("$.state", [Arg::Expr(arg)])
+                                } else {
+                                    self.b.call_expr("$.state", std::iter::empty::<Arg<'a, '_>>())
+                                };
+                                new_body.push(self.b.class_private_field(
+                                    &field_info.private_name,
+                                    Some(state_call),
+                                ));
+
+                                // Generate getter: get name() { return $.get(this.#backing); }
+                                let get_call = self.b.call_expr("$.get", [Arg::Expr(
+                                    self.b.this_private_member(&field_info.private_name),
+                                )]);
+                                let return_stmt = self.b.return_stmt(get_call);
+                                new_body.push(self.b.class_getter(
+                                    self.b.public_key(&name),
+                                    vec![return_stmt],
+                                ));
+
+                                // Generate setter: set name(value) { $.set(this.#backing, value, true?); }
+                                let mut set_args: Vec<Arg<'a, '_>> = vec![
+                                    Arg::Expr(self.b.this_private_member(&field_info.private_name)),
+                                    Arg::Ident("value"),
+                                ];
+                                if field_info.is_state {
+                                    set_args.push(Arg::Bool(true));
+                                }
+                                let set_call = self.b.call_stmt("$.set", set_args);
+                                new_body.push(self.b.class_setter(
+                                    self.b.public_key(&name),
+                                    "value",
+                                    vec![set_call],
+                                ));
+                            } else {
+                                new_body.push(ClassElement::PropertyDefinition(prop));
+                            }
+                        }
+                        _ => {
+                            new_body.push(ClassElement::PropertyDefinition(prop));
+                        }
+                    }
+                }
+                ClassElement::MethodDefinition(mut method) => {
+                    if method.kind == oxc_ast::ast::MethodDefinitionKind::Constructor {
+                        // Insert #backing; + getter + setter for constructor-originating state fields
+                        let ctor_fields: Vec<&ClassStateField> = info.fields.iter()
+                            .filter(|f| f.public_name.is_some() && !handled_public.contains(f.public_name.as_deref().unwrap()))
+                            .collect();
+                        for field_info in &ctor_fields {
+                            let name = field_info.public_name.as_deref().unwrap();
+                            // #backing; (no init)
+                            new_body.push(self.b.class_private_field(&field_info.private_name, None));
+                            // getter
+                            let get_call = self.b.call_expr("$.get", [Arg::Expr(
+                                self.b.this_private_member(&field_info.private_name),
+                            )]);
+                            let return_stmt = self.b.return_stmt(get_call);
+                            new_body.push(self.b.class_getter(self.b.public_key(name), vec![return_stmt]));
+                            // setter
+                            let mut set_args: Vec<Arg<'a, '_>> = vec![
+                                Arg::Expr(self.b.this_private_member(&field_info.private_name)),
+                                Arg::Ident("value"),
+                            ];
+                            if field_info.is_state {
+                                set_args.push(Arg::Bool(true));
+                            }
+                            let set_call = self.b.call_stmt("$.set", set_args);
+                            new_body.push(self.b.class_setter(self.b.public_key(name), "value", vec![set_call]));
+                        }
+                        self.rewrite_constructor(&mut method, info);
+                    }
+                    new_body.push(ClassElement::MethodDefinition(method));
+                }
+                other => {
+                    new_body.push(other);
+                }
+            }
+        }
+
+        body.body = self.b.ast.vec_from_iter(new_body);
+    }
+
+    /// Rewrite constructor: replace `this.name = $state(...)` with `this.#backing = $.state(...)`.
+    /// Also insert `#backing;` property definitions and getter/setter before the constructor.
+    fn rewrite_constructor(
+        &self,
+        method: &mut oxc_allocator::Box<'a, oxc_ast::ast::MethodDefinition<'a>>,
+        info: &ClassStateInfo,
+    ) {
+        let Some(func_body) = &mut method.value.body else { return };
+
+        // Build lookup for constructor-originating fields
+        let ctor_fields: std::collections::HashMap<&str, &ClassStateField> = info.fields.iter()
+            .filter_map(|f| f.public_name.as_deref().map(|n| (n, f)))
+            .collect();
+
+        for stmt in func_body.statements.iter_mut() {
+            if let Statement::ExpressionStatement(es) = stmt {
+                if let Expression::AssignmentExpression(assign) = &mut es.expression {
+                    if assign.operator == oxc_ast::ast::AssignmentOperator::Assign {
+                        if let oxc_ast::ast::AssignmentTarget::StaticMemberExpression(member) = &assign.left {
+                            if let Expression::ThisExpression(_) = &member.object {
+                                let name = member.property.name.to_string();
+                                if let Some(field_info) = ctor_fields.get(name.as_str()) {
+                                    // Rewrite: this.name = $state(arg) → this.#backing = $.state(arg)
+                                    if let Expression::CallExpression(call) = &mut assign.right {
+                                        call.callee = self.b.rid_expr("$.state");
+                                    }
+                                    // Change left side to this.#backing
+                                    let new_left = self.b.this_private_member(&field_info.private_name);
+                                    // We need to convert Expression to AssignmentTarget
+                                    // For private field: use PrivateFieldExpression
+                                    if let Expression::PrivateFieldExpression(pfe) = new_left {
+                                        assign.left = oxc_ast::ast::AssignmentTarget::PrivateFieldExpression(pfe);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Check if we're inside a class body that has a private state field with given name.
+    fn is_private_state_field(&self, name: &str) -> bool {
+        self.class_state_stack.last().is_some_and(|info| {
+            info.fields.iter().any(|f| f.public_name.is_none() && f.private_name == name)
+        })
+    }
 }
 
 /// Post-traverse: wrap `$.derived(expr)` → `$.derived(() => expr)` for $derived runes.
@@ -617,6 +1248,27 @@ fn compute_line_col(source: &str, offset: u32) -> (usize, usize) {
 }
 
 impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
+    fn enter_class_body(
+        &mut self,
+        node: &mut oxc_ast::ast::ClassBody<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        let info = self.scan_class_state_fields(node);
+        self.class_state_stack.push(info);
+    }
+
+    fn exit_class_body(
+        &mut self,
+        node: &mut oxc_ast::ast::ClassBody<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        let Some(info) = self.class_state_stack.pop() else { return };
+        if info.fields.is_empty() {
+            return;
+        }
+        self.rewrite_class_body(node, &info);
+    }
+
     fn enter_function(
         &mut self,
         node: &mut oxc_ast::ast::Function<'a>,
@@ -777,6 +1429,9 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
             }
             true
         });
+
+        // Expand destructured $state/$state.raw declarations
+        self.expand_state_destructuring(stmts);
 
         // Replace $props() destructuring
         if self.props_gen.is_none() {
@@ -984,11 +1639,24 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
                     *node = svelte_transform::rune_refs::make_rune_get(self.b.ast.allocator, &name);
                 }
             }
+            // Private field read wrapping handled in exit_expression to avoid infinite re-entry
             _ => {}
         }
     }
 
     fn exit_expression(&mut self, node: &mut Expression<'a>, _ctx: &mut TraverseCtx<'a, ()>) {
+        // Private state field read: this.#field → $.get(this.#field)
+        // Done in exit to avoid infinite re-entry (enter would re-visit the created node).
+        if let Expression::PrivateFieldExpression(pfe) = node {
+            if matches!(&pfe.object, Expression::ThisExpression(_))
+                && self.is_private_state_field(pfe.field.name.as_str())
+            {
+                let field_expr = self.b.move_expr(node);
+                *node = self.b.call_expr("$.get", [Arg::Expr(field_expr)]);
+                return;
+            }
+        }
+
         if self.dev {
             if let Some(replacement) = self.transform_inspect(node) {
                 *node = replacement;

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -94,6 +94,8 @@ pub struct ScriptInfo {
     pub exports: Vec<ExportInfo>,
     /// True when the script contains `$effect(...)` or `$effect.pre(...)` calls.
     pub has_effects: bool,
+    /// True when the script contains class fields with `$state()`/`$state.raw()` initializers.
+    pub has_class_state_fields: bool,
     /// Base names of `$`-prefixed identifiers found in the script body
     /// (e.g. `"count"` for `$count`). Used to detect store subscriptions.
     pub store_candidates: Vec<CompactString>,
@@ -286,6 +288,7 @@ fn extract_script_info(program: &oxc_ast::ast::Program<'_>, offset: u32, source:
     let mut props_declaration = None;
     let mut exports = Vec::new();
     let mut has_effects = false;
+    let mut has_class_state_fields = false;
 
     for stmt in &program.body {
         use oxc_ast::ast::Statement;
@@ -318,11 +321,16 @@ fn extract_script_info(program: &oxc_ast::ast::Program<'_>, offset: u32, source:
                     has_effects = true;
                 }
             }
+            Statement::ClassDeclaration(class) => {
+                if has_class_state_runes(&class.body) {
+                    has_class_state_fields = true;
+                }
+            }
             _ => {}
         }
     }
 
-    ScriptInfo { declarations, props_declaration, exports, has_effects, store_candidates: Vec::new() }
+    ScriptInfo { declarations, props_declaration, exports, has_effects, has_class_state_fields, store_candidates: Vec::new() }
 }
 
 /// Enrich ScriptInfo from OXC's unresolved references in one pass.
@@ -446,12 +454,9 @@ fn collect_var_declarations(
                 });
             }
             oxc_ast::ast::BindingPattern::ObjectPattern(obj_pat) => {
-                let is_props = declarator.init.as_ref()
-                    .and_then(|init| detect_rune(init))
-                    .map(|r| r == RuneKind::Props)
-                    .unwrap_or(false);
+                let rune = declarator.init.as_ref().and_then(|init| detect_rune(init));
 
-                if is_props {
+                if rune == Some(RuneKind::Props) {
                     let mut props = Vec::new();
 
                     for prop in &obj_pat.properties {
@@ -514,6 +519,51 @@ fn collect_var_declarations(
                     }
 
                     *props_declaration = Some(PropsDeclaration { props });
+                } else if matches!(rune, Some(RuneKind::State | RuneKind::StateRaw)) {
+                    // Destructured $state/$state.raw: register each leaf binding.
+                    // Use StateRaw for analysis so all bindings are considered dynamic
+                    // (proxied values are always reactive, even if the binding isn't mutated).
+                    let mut names = Vec::new();
+                    extract_all_binding_names(&declarator.id, &mut names);
+                    for name in names {
+                        let decl_span = Span::new(
+                            declarator.span.start + offset,
+                            declarator.span.end + offset,
+                        );
+                        declarations.push(DeclarationInfo {
+                            name,
+                            span: decl_span,
+                            kind,
+                            init_span: None,
+                            is_rune: Some(RuneKind::StateRaw),
+                            rune_init_refs: vec![],
+                        });
+                    }
+                }
+            }
+            oxc_ast::ast::BindingPattern::ArrayPattern(_) => {
+                // Destructured $state/$state.raw: register each leaf binding.
+                // Use StateRaw so all bindings are considered dynamic in analysis.
+                let rune = declarator.init.as_ref().and_then(|init| detect_rune(init));
+                if let Some(rune_kind) = rune {
+                    if matches!(rune_kind, RuneKind::State | RuneKind::StateRaw) {
+                        let mut names = Vec::new();
+                        extract_all_binding_names(&declarator.id, &mut names);
+                        for name in names {
+                            let decl_span = Span::new(
+                                declarator.span.start + offset,
+                                declarator.span.end + offset,
+                            );
+                            declarations.push(DeclarationInfo {
+                                name,
+                                span: decl_span,
+                                kind,
+                                init_span: None,
+                                is_rune: Some(RuneKind::StateRaw),
+                                rune_init_refs: vec![],
+                            });
+                        }
+                    }
                 }
             }
             _ => {}
@@ -976,6 +1026,43 @@ fn is_effect_call(expr: &Expression<'_>) -> bool {
                 if let Expression::Identifier(obj) = &member.object {
                     if obj.name.as_str() == "$effect" && member.property.name.as_str() == "pre" {
                         return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Check if a class body contains any PropertyDefinition with $state/$state.raw initializer,
+/// or constructor assignments like `this.x = $state(...)`.
+fn has_class_state_runes(body: &oxc_ast::ast::ClassBody<'_>) -> bool {
+    for element in &body.body {
+        match element {
+            oxc_ast::ast::ClassElement::PropertyDefinition(prop) => {
+                if let Some(value) = &prop.value {
+                    if let Some(kind) = detect_rune(value) {
+                        if matches!(kind, RuneKind::State | RuneKind::StateRaw) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            oxc_ast::ast::ClassElement::MethodDefinition(method) => {
+                if method.kind == oxc_ast::ast::MethodDefinitionKind::Constructor {
+                    if let Some(body) = &method.value.body {
+                        for stmt in &body.statements {
+                            if let oxc_ast::ast::Statement::ExpressionStatement(es) = stmt {
+                                if let Expression::AssignmentExpression(assign) = &es.expression {
+                                    if let Some(kind) = detect_rune(&assign.right) {
+                                        if matches!(kind, RuneKind::State | RuneKind::StateRaw) {
+                                            return true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tasks/compiler_tests/cases2/state_class_constructor/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_class_constructor/case-rust.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count;
+		get count() {
+			return $.get(this.#count);
+		}
+		set count(value) {
+			$.set(this.#count, value, true);
+		}
+		constructor() {
+			this.#count = $.state(0);
+		}
+	}
+	let c = new Counter();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.count));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_constructor/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_class_constructor/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count;
+		get count() {
+			return $.get(this.#count);
+		}
+		set count(value) {
+			$.set(this.#count, value, true);
+		}
+		constructor() {
+			this.#count = $.state(0);
+		}
+	}
+	let c = new Counter();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.count));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_constructor/case.svelte
+++ b/tasks/compiler_tests/cases2/state_class_constructor/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	class Counter {
+		constructor() {
+			this.count = $state(0);
+		}
+	}
+	let c = new Counter();
+</script>
+
+<p>{c.count}</p>

--- a/tasks/compiler_tests/cases2/state_class_field/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_class_field/case-rust.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count = $.state(0);
+		get count() {
+			return $.get(this.#count);
+		}
+		set count(value) {
+			$.set(this.#count, value, true);
+		}
+		increment() {
+			this.count += 1;
+		}
+	}
+	let c = new Counter();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.count));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_field/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_class_field/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count = $.state(0);
+		get count() {
+			return $.get(this.#count);
+		}
+		set count(value) {
+			$.set(this.#count, value, true);
+		}
+		increment() {
+			this.count += 1;
+		}
+	}
+	let c = new Counter();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.count));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_field/case.svelte
+++ b/tasks/compiler_tests/cases2/state_class_field/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	class Counter {
+		count = $state(0);
+		increment() {
+			this.count += 1;
+		}
+	}
+	let c = new Counter();
+</script>
+
+<p>{c.count}</p>

--- a/tasks/compiler_tests/cases2/state_class_multiple/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_class_multiple/case-rust.js
@@ -1,0 +1,35 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Form {
+		#name = $.state("");
+		get name() {
+			return $.get(this.#name);
+		}
+		set name(value) {
+			$.set(this.#name, value, true);
+		}
+		#email = $.state("");
+		get email() {
+			return $.get(this.#email);
+		}
+		set email(value) {
+			$.set(this.#email, value, true);
+		}
+		#data = $.state({});
+		get data() {
+			return $.get(this.#data);
+		}
+		set data(value) {
+			$.set(this.#data, value);
+		}
+	}
+	let f = new Form();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, f.name));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_multiple/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_class_multiple/case-svelte.js
@@ -1,0 +1,35 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Form {
+		#name = $.state("");
+		get name() {
+			return $.get(this.#name);
+		}
+		set name(value) {
+			$.set(this.#name, value, true);
+		}
+		#email = $.state("");
+		get email() {
+			return $.get(this.#email);
+		}
+		set email(value) {
+			$.set(this.#email, value, true);
+		}
+		#data = $.state({});
+		get data() {
+			return $.get(this.#data);
+		}
+		set data(value) {
+			$.set(this.#data, value);
+		}
+	}
+	let f = new Form();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, f.name));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_multiple/case.svelte
+++ b/tasks/compiler_tests/cases2/state_class_multiple/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	class Form {
+		name = $state('');
+		email = $state('');
+		data = $state.raw({});
+	}
+	let f = new Form();
+</script>
+
+<p>{f.name}</p>

--- a/tasks/compiler_tests/cases2/state_destructure_array/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_destructure_array/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = [1, 2], $$array = $.derived(() => $.to_array(tmp, 2)), x = $.state($.proxy($.get($$array)[0])), y = $.proxy($.get($$array)[1]);
+	$.set(x, $.get(x) + 1);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(x) ?? ""} ${y ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_array/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_destructure_array/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = [1, 2], $$array = $.derived(() => $.to_array(tmp, 2)), x = $.state($.proxy($.get($$array)[0])), y = $.proxy($.get($$array)[1]);
+	$.set(x, $.get(x) + 1);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(x) ?? ""} ${y ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_array/case.svelte
+++ b/tasks/compiler_tests/cases2/state_destructure_array/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let [x, y] = $state([1, 2]);
+	x += 1;
+</script>
+
+<p>{x} {y}</p>

--- a/tasks/compiler_tests/cases2/state_destructure_defaults/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_destructure_defaults/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {}, a = $.state($.proxy($.fallback(tmp.a, 10))), b = $.proxy($.fallback(tmp.b, 20));
+	$.set(a, $.get(a) + 1);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(a) ?? ""} ${b ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_defaults/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_destructure_defaults/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {}, a = $.state($.proxy($.fallback(tmp.a, 10))), b = $.proxy($.fallback(tmp.b, 20));
+	$.set(a, $.get(a) + 1);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(a) ?? ""} ${b ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_defaults/case.svelte
+++ b/tasks/compiler_tests/cases2/state_destructure_defaults/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { a = 10, b = 20 } = $state({});
+	a += 1;
+</script>
+
+<p>{a} {b}</p>

--- a/tasks/compiler_tests/cases2/state_destructure_nested/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_destructure_nested/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = { a: { b: 1 } }, b = $.proxy(tmp.a.b);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, b));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_nested/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_destructure_nested/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = { a: { b: 1 } }, b = $.proxy(tmp.a.b);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, b));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_nested/case.svelte
+++ b/tasks/compiler_tests/cases2/state_destructure_nested/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { a: { b } } = $state({ a: { b: 1 } });
+</script>
+
+<p>{b}</p>

--- a/tasks/compiler_tests/cases2/state_destructure_object/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_destructure_object/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {
+		a: 1,
+		b: 2
+	}, a = $.state($.proxy(tmp.a)), b = $.proxy(tmp.b);
+	$.set(a, $.get(a) + 1);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(a) ?? ""} ${b ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_object/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_destructure_object/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {
+		a: 1,
+		b: 2
+	}, a = $.state($.proxy(tmp.a)), b = $.proxy(tmp.b);
+	$.set(a, $.get(a) + 1);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(a) ?? ""} ${b ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_object/case.svelte
+++ b/tasks/compiler_tests/cases2/state_destructure_object/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { a, b } = $state({ a: 1, b: 2 });
+	a += 1;
+</script>
+
+<p>{a} {b}</p>

--- a/tasks/compiler_tests/cases2/state_destructure_rest/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_destructure_rest/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {
+		a: 1,
+		b: 2,
+		c: 3
+	}, a = $.proxy(tmp.a), rest = $.proxy($.exclude_from_object(tmp, ["a"]));
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, a));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_rest/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_destructure_rest/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {
+		a: 1,
+		b: 2,
+		c: 3
+	}, a = $.proxy(tmp.a), rest = $.proxy($.exclude_from_object(tmp, ["a"]));
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, a));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_destructure_rest/case.svelte
+++ b/tasks/compiler_tests/cases2/state_destructure_rest/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { a, ...rest } = $state({ a: 1, b: 2, c: 3 });
+</script>
+
+<p>{a}</p>

--- a/tasks/compiler_tests/cases2/state_private_class_field/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_private_class_field/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count = $.state(0);
+		get value() {
+			return $.get(this.#count);
+		}
+	}
+	let c = new Counter();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.value));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_private_class_field/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_private_class_field/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count = $.state(0);
+		get value() {
+			return $.get(this.#count);
+		}
+	}
+	let c = new Counter();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.value));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_private_class_field/case.svelte
+++ b/tasks/compiler_tests/cases2/state_private_class_field/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	class Counter {
+		#count = $state(0);
+		get value() {
+			return this.#count;
+		}
+	}
+	let c = new Counter();
+</script>
+
+<p>{c.value}</p>

--- a/tasks/compiler_tests/cases2/state_raw_class_field/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_raw_class_field/case-rust.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Store {
+		#items = $.state([]);
+		get items() {
+			return $.get(this.#items);
+		}
+		set items(value) {
+			$.set(this.#items, value);
+		}
+	}
+	let s = new Store();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, s.items));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_raw_class_field/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_raw_class_field/case-svelte.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Store {
+		#items = $.state([]);
+		get items() {
+			return $.get(this.#items);
+		}
+		set items(value) {
+			$.set(this.#items, value);
+		}
+	}
+	let s = new Store();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, s.items));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_raw_class_field/case.svelte
+++ b/tasks/compiler_tests/cases2/state_raw_class_field/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	class Store {
+		items = $state.raw([]);
+	}
+	let s = new Store();
+</script>
+
+<p>{s.items}</p>

--- a/tasks/compiler_tests/cases2/state_raw_destructure_array/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_raw_destructure_array/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = [1, 2], $$array = $.derived(() => $.to_array(tmp, 2)), x = $.get($$array)[0], y = $.get($$array)[1];
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${x ?? ""} ${y ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_raw_destructure_array/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_raw_destructure_array/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = [1, 2], $$array = $.derived(() => $.to_array(tmp, 2)), x = $.get($$array)[0], y = $.get($$array)[1];
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${x ?? ""} ${y ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_raw_destructure_array/case.svelte
+++ b/tasks/compiler_tests/cases2/state_raw_destructure_array/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let [x, y] = $state.raw([1, 2]);
+</script>
+
+<p>{x} {y}</p>

--- a/tasks/compiler_tests/cases2/state_raw_destructure_object/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_raw_destructure_object/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {
+		items: [],
+		count: 0
+	}, items = tmp.items, count = tmp.count;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, count));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_raw_destructure_object/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_raw_destructure_object/case-svelte.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let tmp = {
+		items: [],
+		count: 0
+	}, items = tmp.items, count = tmp.count;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, count));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_raw_destructure_object/case.svelte
+++ b/tasks/compiler_tests/cases2/state_raw_destructure_object/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { items, count } = $state.raw({ items: [], count: 0 });
+</script>
+
+<p>{count}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -711,6 +711,74 @@ fn attach_in_each() {
 }
 
 // ---------------------------------------------------------------------------
+// $state/$state.raw destructuring
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn state_destructure_object() {
+    assert_compiler("state_destructure_object");
+}
+
+#[rstest]
+fn state_destructure_array() {
+    assert_compiler("state_destructure_array");
+}
+
+#[rstest]
+fn state_raw_destructure_object() {
+    assert_compiler("state_raw_destructure_object");
+}
+
+#[rstest]
+fn state_raw_destructure_array() {
+    assert_compiler("state_raw_destructure_array");
+}
+
+#[rstest]
+fn state_destructure_defaults() {
+    assert_compiler("state_destructure_defaults");
+}
+
+#[rstest]
+fn state_destructure_rest() {
+    assert_compiler("state_destructure_rest");
+}
+
+#[rstest]
+fn state_destructure_nested() {
+    assert_compiler("state_destructure_nested");
+}
+
+// ---------------------------------------------------------------------------
+// $state/$state.raw class fields
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn state_class_field() {
+    assert_compiler("state_class_field");
+}
+
+#[rstest]
+fn state_raw_class_field() {
+    assert_compiler("state_raw_class_field");
+}
+
+#[rstest]
+fn state_private_class_field() {
+    assert_compiler("state_private_class_field");
+}
+
+#[rstest]
+fn state_class_constructor() {
+    assert_compiler("state_class_constructor");
+}
+
+#[rstest]
+fn state_class_multiple() {
+    assert_compiler("state_class_multiple");
+}
+
+// ---------------------------------------------------------------------------
 // Module compilation tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implement two deferred Runes (Tier 1) features:

1. **Destructuring**: Object/array destructuring of $state/$state.raw with
   support for defaults ($.fallback), rest ($.exclude_from_object), nested
   patterns, and array intermediates ($.derived(() => $.to_array(...))).
   Mutated bindings get $.state() wrapper, unmutated get $.proxy() only.

2. **Class fields**: Public fields → private backing + getter/setter,
   private fields → $.state() callee rewrite + $.get() read transform,
   constructor assignments → private backing declaration + rewritten body.
   $state uses true in setter, $state.raw omits it.

Analysis changes: mark destructured state bindings as StateRaw for
reactivity (proxied values are always dynamic). Add has_class_state_fields
flag to treat member access on local bindings as dynamic when classes
with state fields are present.

12 new test cases, all 238 compiler tests pass.

https://claude.ai/code/session_011dSYXcz1sRcGcK76nyoc7R