### PR TITLE
feat: Tier 1c — Strip TypeScript from compiled output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,8 +145,8 @@ Theme: remove TypeScript type annotations from compiled output.
 
 | # | Feature | Phases | Description |
 |---|---------|--------|-------------|
-| 1 | Strip type annotations | S | Remove type annotations, interfaces, type aliases from `<script>` output |
-| 2 | Strip from expressions | T | Remove type assertions, `as` casts, generics from template expressions |
+| 1 | ~~Strip type annotations~~ | S | ~~Remove type annotations, interfaces, type aliases from `<script>` output~~ |
+| 2 | ~~Strip from expressions~~ | T | ~~Remove type assertions, `as` casts, generics from template expressions~~ |
 
 ---
 

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -15,9 +15,11 @@ pub fn parse_js<'a>(
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
 ) {
+    let typescript = component.script.as_ref()
+        .is_some_and(|s| matches!(s.language, ScriptLanguage::TypeScript));
+
     if let Some(script) = &component.script {
         let source = component.source_text(script.content_span);
-        let typescript = matches!(script.language, ScriptLanguage::TypeScript);
         let arena_source: &'a str = alloc.alloc_str(source);
         match svelte_js::analyze_script_with_alloc(
             alloc,
@@ -37,7 +39,7 @@ pub fn parse_js<'a>(
         }
     }
 
-    walk_fragment(alloc, &component.fragment, component, data, parsed, diags);
+    walk_fragment(alloc, &component.fragment, component, typescript, data, parsed, diags);
 }
 
 /// Parse an expression into the shared allocator, storing both metadata and AST.
@@ -46,13 +48,14 @@ fn parse_expr<'a>(
     source: &str,
     offset: u32,
     node_id: NodeId,
+    typescript: bool,
     data: &mut AnalysisData,
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
 ) {
     // Copy source into arena so Expression AST can reference it with lifetime 'a
     let arena_source: &'a str = alloc.alloc_str(source);
-    match svelte_js::analyze_expression_with_alloc(alloc, arena_source, offset) {
+    match svelte_js::analyze_expression_with_alloc(alloc, arena_source, offset, typescript) {
         Ok((info, expr)) => {
             data.expressions.insert(node_id, info);
             parsed.exprs.insert(node_id, expr);
@@ -67,12 +70,13 @@ fn parse_attr_expr<'a>(
     source: &str,
     offset: u32,
     attr_id: NodeId,
+    typescript: bool,
     data: &mut AnalysisData,
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
 ) {
     let arena_source: &'a str = alloc.alloc_str(source);
-    match svelte_js::analyze_expression_with_alloc(alloc, arena_source, offset) {
+    match svelte_js::analyze_expression_with_alloc(alloc, arena_source, offset, typescript) {
         Ok((info, expr)) => {
             data.attr_expressions.insert(attr_id, info);
             parsed.attr_exprs.insert(attr_id, expr);
@@ -87,6 +91,7 @@ fn parse_concat_parts<'a>(
     parts: &[ConcatPart],
     attr_id: NodeId,
     component: &Component,
+    typescript: bool,
     data: &mut AnalysisData,
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
@@ -97,7 +102,7 @@ fn parse_concat_parts<'a>(
         if let ConcatPart::Dynamic(span) = part {
             let source = component.source_text(*span);
             let arena_source: &'a str = alloc.alloc_str(source);
-            match svelte_js::analyze_expression_with_alloc(alloc, arena_source, span.start) {
+            match svelte_js::analyze_expression_with_alloc(alloc, arena_source, span.start, typescript) {
                 Ok((info, expr)) => {
                     all_refs.extend(info.references);
                     parsed.concat_part_exprs.insert((attr_id, dyn_idx), expr);
@@ -120,12 +125,13 @@ fn walk_fragment<'a>(
     alloc: &'a Allocator,
     fragment: &Fragment,
     component: &Component,
+    typescript: bool,
     data: &mut AnalysisData,
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
 ) {
     for node in &fragment.nodes {
-        walk_node(alloc, node, component, data, parsed, diags);
+        walk_node(alloc, node, component, typescript, data, parsed, diags);
     }
 }
 
@@ -133,6 +139,7 @@ fn walk_node<'a>(
     alloc: &'a Allocator,
     node: &Node,
     component: &Component,
+    typescript: bool,
     data: &mut AnalysisData,
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
@@ -140,48 +147,48 @@ fn walk_node<'a>(
     match node {
         Node::ExpressionTag(tag) => {
             let source = component.source_text(tag.expression_span);
-            parse_expr(alloc, source, tag.expression_span.start, tag.id, data, parsed, diags);
+            parse_expr(alloc, source, tag.expression_span.start, tag.id, typescript, data, parsed, diags);
         }
         Node::Element(el) => {
-            walk_attrs(alloc, &el.attributes, component, data, parsed, diags);
-            walk_fragment(alloc, &el.fragment, component, data, parsed, diags);
+            walk_attrs(alloc, &el.attributes, component, typescript, data, parsed, diags);
+            walk_fragment(alloc, &el.fragment, component, typescript, data, parsed, diags);
         }
         Node::ComponentNode(cn) => {
-            walk_attrs(alloc, &cn.attributes, component, data, parsed, diags);
-            walk_fragment(alloc, &cn.fragment, component, data, parsed, diags);
+            walk_attrs(alloc, &cn.attributes, component, typescript, data, parsed, diags);
+            walk_fragment(alloc, &cn.fragment, component, typescript, data, parsed, diags);
         }
         Node::IfBlock(block) => {
             let source = component.source_text(block.test_span);
-            parse_expr(alloc, source, block.test_span.start, block.id, data, parsed, diags);
-            walk_fragment(alloc, &block.consequent, component, data, parsed, diags);
+            parse_expr(alloc, source, block.test_span.start, block.id, typescript, data, parsed, diags);
+            walk_fragment(alloc, &block.consequent, component, typescript, data, parsed, diags);
             if let Some(alt) = &block.alternate {
-                walk_fragment(alloc, alt, component, data, parsed, diags);
+                walk_fragment(alloc, alt, component, typescript, data, parsed, diags);
             }
         }
         Node::EachBlock(block) => {
             let source = component.source_text(block.expression_span);
-            parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
+            parse_expr(alloc, source, block.expression_span.start, block.id, typescript, data, parsed, diags);
             if let Some(key_span) = block.key_span {
                 let key_source = component.source_text(key_span);
                 let arena_source: &'a str = alloc.alloc_str(key_source);
-                match svelte_js::analyze_expression_with_alloc(alloc, arena_source, key_span.start) {
+                match svelte_js::analyze_expression_with_alloc(alloc, arena_source, key_span.start, typescript) {
                     Ok((_info, expr)) => {
                         parsed.key_exprs.insert(block.id, expr);
                     }
                     Err(diag) => diags.push(diag),
                 }
             }
-            walk_fragment(alloc, &block.body, component, data, parsed, diags);
+            walk_fragment(alloc, &block.body, component, typescript, data, parsed, diags);
             if let Some(fb) = &block.fallback {
-                walk_fragment(alloc, fb, component, data, parsed, diags);
+                walk_fragment(alloc, fb, component, typescript, data, parsed, diags);
             }
         }
         Node::SnippetBlock(block) => {
-            walk_fragment(alloc, &block.body, component, data, parsed, diags);
+            walk_fragment(alloc, &block.body, component, typescript, data, parsed, diags);
         }
         Node::RenderTag(tag) => {
             let source = component.source_text(tag.expression_span);
-            parse_expr(alloc, source, tag.expression_span.start, tag.id, data, parsed, diags);
+            parse_expr(alloc, source, tag.expression_span.start, tag.id, typescript, data, parsed, diags);
             // Store per-argument has_call flags and identifier names before transform
             if let Some(Expression::CallExpression(call)) = parsed.exprs.get(&tag.id) {
                 let flags: Vec<bool> = call.arguments.iter().map(|arg| {
@@ -201,30 +208,30 @@ fn walk_node<'a>(
         }
         Node::HtmlTag(tag) => {
             let source = component.source_text(tag.expression_span);
-            parse_expr(alloc, source, tag.expression_span.start, tag.id, data, parsed, diags);
+            parse_expr(alloc, source, tag.expression_span.start, tag.id, typescript, data, parsed, diags);
         }
         Node::KeyBlock(block) => {
             let source = component.source_text(block.expression_span);
-            parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
-            walk_fragment(alloc, &block.fragment, component, data, parsed, diags);
+            parse_expr(alloc, source, block.expression_span.start, block.id, typescript, data, parsed, diags);
+            walk_fragment(alloc, &block.fragment, component, typescript, data, parsed, diags);
         }
         Node::AwaitBlock(block) => {
             let source = component.source_text(block.expression_span);
-            parse_expr(alloc, source, block.expression_span.start, block.id, data, parsed, diags);
+            parse_expr(alloc, source, block.expression_span.start, block.id, typescript, data, parsed, diags);
             if let Some(ref p) = block.pending {
-                walk_fragment(alloc, p, component, data, parsed, diags);
+                walk_fragment(alloc, p, component, typescript, data, parsed, diags);
             }
             if let Some(ref t) = block.then {
-                walk_fragment(alloc, t, component, data, parsed, diags);
+                walk_fragment(alloc, t, component, typescript, data, parsed, diags);
             }
             if let Some(ref c) = block.catch {
-                walk_fragment(alloc, c, component, data, parsed, diags);
+                walk_fragment(alloc, c, component, typescript, data, parsed, diags);
             }
         }
         Node::ConstTag(tag) => {
             let decl_text = component.source_text(tag.declaration_span);
             let arena_source: &'a str = alloc.alloc_str(decl_text);
-            match svelte_js::parse_const_declaration_with_alloc(alloc, arena_source, tag.declaration_span.start) {
+            match svelte_js::parse_const_declaration_with_alloc(alloc, arena_source, tag.declaration_span.start, typescript) {
                 Ok((names, references, init_expr)) => {
                     data.expressions.insert(tag.id, ExpressionInfo {
                         kind: ExpressionKind::Other,
@@ -239,29 +246,29 @@ fn walk_node<'a>(
             }
         }
         Node::SvelteHead(head) => {
-            walk_fragment(alloc, &head.fragment, component, data, parsed, diags);
+            walk_fragment(alloc, &head.fragment, component, typescript, data, parsed, diags);
         }
         Node::SvelteElement(el) => {
             // Parse the tag expression (skip for static string tags like this="div")
             if !el.static_tag {
                 let tag_source = component.source_text(el.tag_span);
-                parse_expr(alloc, tag_source, el.tag_span.start, el.id, data, parsed, diags);
+                parse_expr(alloc, tag_source, el.tag_span.start, el.id, typescript, data, parsed, diags);
             }
-            walk_attrs(alloc, &el.attributes, component, data, parsed, diags);
-            walk_fragment(alloc, &el.fragment, component, data, parsed, diags);
+            walk_attrs(alloc, &el.attributes, component, typescript, data, parsed, diags);
+            walk_fragment(alloc, &el.fragment, component, typescript, data, parsed, diags);
         }
         Node::SvelteWindow(w) => {
-            walk_attrs(alloc, &w.attributes, component, data, parsed, diags);
+            walk_attrs(alloc, &w.attributes, component, typescript, data, parsed, diags);
         }
         Node::SvelteDocument(d) => {
-            walk_attrs(alloc, &d.attributes, component, data, parsed, diags);
+            walk_attrs(alloc, &d.attributes, component, typescript, data, parsed, diags);
         }
         Node::SvelteBody(b) => {
-            walk_attrs(alloc, &b.attributes, component, data, parsed, diags);
+            walk_attrs(alloc, &b.attributes, component, typescript, data, parsed, diags);
         }
         Node::SvelteBoundary(b) => {
-            walk_attrs(alloc, &b.attributes, component, data, parsed, diags);
-            walk_fragment(alloc, &b.fragment, component, data, parsed, diags);
+            walk_attrs(alloc, &b.attributes, component, typescript, data, parsed, diags);
+            walk_fragment(alloc, &b.fragment, component, typescript, data, parsed, diags);
         }
         Node::DebugTag(_) | Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
     }
@@ -272,6 +279,7 @@ fn walk_attrs<'a>(
     alloc: &'a Allocator,
     attrs: &[Attribute],
     component: &Component,
+    typescript: bool,
     data: &mut AnalysisData,
     parsed: &mut ParsedExprs<'a>,
     diags: &mut Vec<Diagnostic>,
@@ -281,7 +289,7 @@ fn walk_attrs<'a>(
         match attr {
             Attribute::ExpressionAttribute(a) => {
                 let source = component.source_text(a.expression_span);
-                parse_attr_expr(alloc, source, a.expression_span.start, attr_id, data, parsed, diags);
+                parse_attr_expr(alloc, source, a.expression_span.start, attr_id, typescript, data, parsed, diags);
                 // class={[...]} or class={{...}} or class={x} need clsx to resolve
                 if a.name == "class" {
                     if let Some(expr) = parsed.attr_exprs.get(&attr_id) {
@@ -298,12 +306,12 @@ fn walk_attrs<'a>(
                 }
             }
             Attribute::ConcatenationAttribute(a) => {
-                parse_concat_parts(alloc, &a.parts, attr_id, component, data, parsed, diags);
+                parse_concat_parts(alloc, &a.parts, attr_id, component, typescript, data, parsed, diags);
             }
             Attribute::ClassDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                    parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                 }
             }
             Attribute::StyleDirective(a) => {
@@ -311,10 +319,10 @@ fn walk_attrs<'a>(
                 match &a.value {
                     StyleDirectiveValue::Expression(span) => {
                         let source = component.source_text(*span);
-                        parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                        parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                     }
                     StyleDirectiveValue::Concatenation(parts) => {
-                        parse_concat_parts(alloc, parts, attr_id, component, data, parsed, diags);
+                        parse_concat_parts(alloc, parts, attr_id, component, typescript, data, parsed, diags);
                     }
                     StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
                 }
@@ -322,7 +330,7 @@ fn walk_attrs<'a>(
             Attribute::BindDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                    parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                 }
             }
             Attribute::SpreadAttribute(a) => {
@@ -333,16 +341,16 @@ fn walk_attrs<'a>(
                 );
                 let span = svelte_span::Span::new(a.expression_span.start + 3, a.expression_span.end);
                 let source = component.source_text(span);
-                parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
             }
             Attribute::Shorthand(a) => {
                 let source = component.source_text(a.expression_span);
-                parse_attr_expr(alloc, source, a.expression_span.start, attr_id, data, parsed, diags);
+                parse_attr_expr(alloc, source, a.expression_span.start, attr_id, typescript, data, parsed, diags);
             }
             Attribute::UseDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                    parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                 }
             }
             Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_) => {}
@@ -350,25 +358,25 @@ fn walk_attrs<'a>(
             Attribute::OnDirectiveLegacy(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                    parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                 }
             }
             Attribute::TransitionDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                    parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                 }
             }
             Attribute::AnimateDirective(a) => {
                 if let Some(span) = a.expression_span {
                     let source = component.source_text(span);
-                    parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                    parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
                 }
             }
             Attribute::AttachTag(a) => {
                 let span = a.expression_span;
                 let source = component.source_text(span);
-                parse_attr_expr(alloc, source, span.start, attr_id, data, parsed, diags);
+                parse_attr_expr(alloc, source, span.start, attr_id, typescript, data, parsed, diags);
             }
         }
     }

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -2,7 +2,9 @@ use rustc_hash::FxHashSet;
 
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast::{NONE, ast::{
-    ArrowFunctionExpression, Expression, FunctionBody, Program, Statement, VariableDeclarator,
+    ArrowFunctionExpression, ClassElement, Expression, FunctionBody,
+    ImportDeclarationSpecifier, MethodDefinitionType, Program,
+    PropertyDefinitionType, Statement, VariableDeclarator,
 }};
 use oxc_parser::Parser as OxcParser;
 use oxc_semantic::{Scoping, SemanticBuilder};
@@ -155,10 +157,6 @@ fn transform_script_text<'a>(
 
     for stmt in program.body {
         match &stmt {
-            Statement::TSTypeAliasDeclaration(_)
-                | Statement::TSInterfaceDeclaration(_)
-                | Statement::TSEnumDeclaration(_) => continue,
-            Statement::ImportDeclaration(import) if import.import_kind.is_type() => continue,
             Statement::ImportDeclaration(_) => imports.push(stmt),
             _ => body.push(stmt),
         }
@@ -220,10 +218,6 @@ fn transform_program<'a>(
 
     for stmt in program.body {
         match &stmt {
-            Statement::TSTypeAliasDeclaration(_)
-                | Statement::TSInterfaceDeclaration(_)
-                | Statement::TSEnumDeclaration(_) => continue,
-            Statement::ImportDeclaration(import) if import.import_kind.is_type() => continue,
             Statement::ImportDeclaration(_) => imports.push(stmt),
             _ => body.push(stmt),
         }
@@ -1259,6 +1253,20 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         node: &mut oxc_ast::ast::ClassBody<'a>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
+        if self.is_ts {
+            node.body.retain(|member| match member {
+                ClassElement::PropertyDefinition(prop) => {
+                    !prop.declare
+                        && prop.r#type != PropertyDefinitionType::TSAbstractPropertyDefinition
+                }
+                ClassElement::MethodDefinition(method) => {
+                    method.r#type != MethodDefinitionType::TSAbstractMethodDefinition
+                }
+                ClassElement::TSIndexSignature(_) => false,
+                _ => true,
+            });
+        }
+
         let Some(info) = self.class_state_stack.pop() else { return };
         if info.fields.is_empty() {
             return;
@@ -1386,6 +1394,48 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
+        // Strip TypeScript declarations and type-only imports/exports
+        if self.is_ts {
+            // Remove individual type specifiers from imports/exports
+            for stmt in stmts.iter_mut() {
+                match stmt {
+                    Statement::ImportDeclaration(import) => {
+                        if let Some(specs) = &mut import.specifiers {
+                            specs.retain(|spec| {
+                                !matches!(spec, ImportDeclarationSpecifier::ImportSpecifier(s) if s.import_kind.is_type())
+                            });
+                        }
+                    }
+                    Statement::ExportNamedDeclaration(export) if export.declaration.is_none() => {
+                        export.specifiers.retain(|spec| !spec.export_kind.is_type());
+                    }
+                    _ => {}
+                }
+            }
+
+            // Remove entire TS-only statements
+            stmts.retain(|stmt| match stmt {
+                Statement::TSTypeAliasDeclaration(_)
+                | Statement::TSInterfaceDeclaration(_)
+                | Statement::TSModuleDeclaration(_)
+                | Statement::TSEnumDeclaration(_) => false,
+                Statement::VariableDeclaration(decl) if decl.declare => false,
+                Statement::FunctionDeclaration(func) if func.declare => false,
+                Statement::ClassDeclaration(class) if class.declare => false,
+                Statement::ImportDeclaration(import) if import.import_kind.is_type() => false,
+                Statement::ExportNamedDeclaration(export) if export.export_kind.is_type() => false,
+                Statement::ExportAllDeclaration(export) if export.export_kind.is_type() => false,
+                // Remove imports/exports left with no specifiers after type-specifier filtering
+                Statement::ImportDeclaration(import) => {
+                    import.specifiers.as_ref().is_none_or(|s| !s.is_empty())
+                }
+                Statement::ExportNamedDeclaration(export) => {
+                    export.declaration.is_some() || !export.specifiers.is_empty()
+                }
+                _ => true,
+            });
+        }
+
         // Strip `export` keyword: ExportNamedDeclaration → inner declaration
         // (only for component scripts; module compilation preserves exports)
         if self.strip_exports {
@@ -1473,6 +1523,99 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
             node.accessibility = None;
             node.readonly = false;
             node.r#override = false;
+        }
+    }
+
+    fn enter_catch_parameter(
+        &mut self,
+        node: &mut oxc_ast::ast::CatchParameter<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_annotation = None;
+        }
+    }
+
+    fn enter_call_expression(
+        &mut self,
+        node: &mut oxc_ast::ast::CallExpression<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_arguments = None;
+        }
+    }
+
+    fn enter_new_expression(
+        &mut self,
+        node: &mut oxc_ast::ast::NewExpression<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_arguments = None;
+        }
+    }
+
+    fn enter_tagged_template_expression(
+        &mut self,
+        node: &mut oxc_ast::ast::TaggedTemplateExpression<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_arguments = None;
+        }
+    }
+
+    fn enter_class(
+        &mut self,
+        node: &mut oxc_ast::ast::Class<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_parameters = None;
+            node.super_type_arguments = None;
+            node.implements.clear();
+            node.r#abstract = false;
+        }
+    }
+
+    fn enter_property_definition(
+        &mut self,
+        node: &mut oxc_ast::ast::PropertyDefinition<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_annotation = None;
+            node.accessibility = None;
+            node.readonly = false;
+            node.r#override = false;
+            node.optional = false;
+            node.definite = false;
+        }
+    }
+
+    fn enter_accessor_property(
+        &mut self,
+        node: &mut oxc_ast::ast::AccessorProperty<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_annotation = None;
+            node.accessibility = None;
+            node.r#override = false;
+            node.definite = false;
+        }
+    }
+
+    fn enter_method_definition(
+        &mut self,
+        node: &mut oxc_ast::ast::MethodDefinition<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.accessibility = None;
+            node.r#override = false;
+            node.optional = false;
         }
     }
 

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -130,6 +130,7 @@ fn transform_script_text<'a>(
         derived_pending: FxHashSet::default(),
         strip_exports,
         dev,
+        is_ts,
         function_info_stack: Vec::new(),
         has_tracing: false,
         component_source,
@@ -153,18 +154,13 @@ fn transform_script_text<'a>(
     let mut body = vec![];
 
     for stmt in program.body {
-        if matches!(
-            stmt,
+        match &stmt {
             Statement::TSTypeAliasDeclaration(_)
                 | Statement::TSInterfaceDeclaration(_)
-                | Statement::TSEnumDeclaration(_)
-        ) {
-            continue;
-        }
-        if matches!(stmt, Statement::ImportDeclaration(_)) {
-            imports.push(stmt);
-        } else {
-            body.push(stmt);
+                | Statement::TSEnumDeclaration(_) => continue,
+            Statement::ImportDeclaration(import) if import.import_kind.is_type() => continue,
+            Statement::ImportDeclaration(_) => imports.push(stmt),
+            _ => body.push(stmt),
         }
     }
 
@@ -183,6 +179,9 @@ fn transform_program<'a>(
 ) -> (Vec<Statement<'a>>, Vec<Statement<'a>>, bool) {
     let b = Builder::new(allocator);
 
+    // Detect TypeScript from the program's source_type
+    let is_ts = program.source_type.is_typescript();
+
     // Re-run SemanticBuilder to get fresh scoping matching current AST state
     let sem = SemanticBuilder::new().build(&program);
     let scoping = sem.semantic.into_scoping();
@@ -197,6 +196,7 @@ fn transform_program<'a>(
         derived_pending: FxHashSet::default(),
         strip_exports: true,
         dev,
+        is_ts,
         function_info_stack: Vec::new(),
         has_tracing: false,
         component_source,
@@ -219,18 +219,13 @@ fn transform_program<'a>(
     let mut body = vec![];
 
     for stmt in program.body {
-        if matches!(
-            stmt,
+        match &stmt {
             Statement::TSTypeAliasDeclaration(_)
                 | Statement::TSInterfaceDeclaration(_)
-                | Statement::TSEnumDeclaration(_)
-        ) {
-            continue;
-        }
-        if matches!(stmt, Statement::ImportDeclaration(_)) {
-            imports.push(stmt);
-        } else {
-            body.push(stmt);
+                | Statement::TSEnumDeclaration(_) => continue,
+            Statement::ImportDeclaration(import) if import.import_kind.is_type() => continue,
+            Statement::ImportDeclaration(_) => imports.push(stmt),
+            _ => body.push(stmt),
         }
     }
 
@@ -295,6 +290,8 @@ struct ScriptTransformer<'b, 'a> {
     strip_exports: bool,
     /// Whether dev-mode transforms are enabled ($inspect → $.inspect).
     dev: bool,
+    /// Whether the script uses TypeScript (strip type annotations during traverse).
+    is_ts: bool,
     /// Stack tracking enclosing functions for $inspect.trace() context.
     function_info_stack: Vec<FunctionInfo>,
     /// Whether any $inspect.trace() was found (dev mode), triggers tracing import.
@@ -1274,6 +1271,11 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         node: &mut oxc_ast::ast::Function<'a>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
+        if self.is_ts {
+            node.type_parameters = None;
+            node.return_type = None;
+            node.this_param = None;
+        }
         let name = node.id.as_ref().map(|id| id.name.to_string());
         self.function_info_stack.push(FunctionInfo {
             is_async: node.r#async,
@@ -1295,6 +1297,10 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         node: &mut ArrowFunctionExpression<'a>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
+        if self.is_ts {
+            node.type_parameters = None;
+            node.return_type = None;
+        }
         let name = self.next_arrow_name.take();
         self.function_info_stack.push(FunctionInfo {
             is_async: node.r#async,
@@ -1457,11 +1463,28 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         }
     }
 
+    fn enter_formal_parameter(
+        &mut self,
+        node: &mut oxc_ast::ast::FormalParameter<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if self.is_ts {
+            node.type_annotation = None;
+            node.accessibility = None;
+            node.readonly = false;
+            node.r#override = false;
+        }
+    }
+
     fn enter_variable_declarator(
         &mut self,
         node: &mut VariableDeclarator<'a>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
+        if self.is_ts {
+            node.type_annotation = None;
+            node.definite = false;
+        }
         // Capture variable name for arrow functions (used by $inspect.trace auto-label)
         if let Some(Expression::ArrowFunctionExpression(_)) = &node.init {
             if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &node.id {
@@ -1557,6 +1580,29 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
     }
 
     fn enter_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a, ()>) {
+        // Strip TS expression wrappers (as, satisfies, non-null, type assertion, instantiation)
+        if self.is_ts {
+            loop {
+                match node {
+                    Expression::TSAsExpression(_)
+                    | Expression::TSSatisfiesExpression(_)
+                    | Expression::TSNonNullExpression(_)
+                    | Expression::TSTypeAssertion(_)
+                    | Expression::TSInstantiationExpression(_) => {
+                        let inner = match self.b.move_expr(node) {
+                            Expression::TSAsExpression(ts) => ts.unbox().expression,
+                            Expression::TSSatisfiesExpression(ts) => ts.unbox().expression,
+                            Expression::TSNonNullExpression(ts) => ts.unbox().expression,
+                            Expression::TSTypeAssertion(ts) => ts.unbox().expression,
+                            Expression::TSInstantiationExpression(ts) => ts.unbox().expression,
+                            _ => unreachable!(),
+                        };
+                        *node = inner;
+                    }
+                    _ => break,
+                }
+            }
+        }
         match node {
             Expression::AssignmentExpression(_) => {
                 self.transform_assignment(node, ctx);

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -186,13 +186,19 @@ pub fn parse_const_declaration_with_alloc<'a>(
     alloc: &'a Allocator,
     source: &'a str,
     offset: u32,
+    typescript: bool,
 ) -> Result<(Vec<CompactString>, Vec<Reference>, Expression<'a>), Diagnostic> {
     // Wrap as "const {source};" so OXC can parse it as a full statement
     let wrapped_owned = format!("const {};", source);
     let wrapped_str: &'a str = alloc.alloc_str(&wrapped_owned);
     let prefix_len: u32 = 6; // "const "
 
-    let result = OxcParser::new(alloc, wrapped_str, SourceType::default()).parse();
+    let src_type = if typescript {
+        SourceType::default().with_typescript(true).with_module(true)
+    } else {
+        SourceType::default()
+    };
+    let result = OxcParser::new(alloc, wrapped_str, src_type).parse();
 
     if !result.errors.is_empty() {
         return Err(Diagnostic::invalid_expression(Span::new(offset, offset + source.len() as u32)));
@@ -211,8 +217,12 @@ pub fn parse_const_declaration_with_alloc<'a>(
     let mut names = Vec::new();
     extract_all_binding_names(&declarator.id, &mut names);
 
-    let init = declarator.init.take()
+    let mut init = declarator.init.take()
         .ok_or_else(|| Diagnostic::invalid_expression(Span::new(offset, offset + source.len() as u32)))?;
+
+    if typescript {
+        strip_ts_expression(&mut init, alloc);
+    }
 
     // OXC spans are relative to the wrapped string; adjust by subtracting the prefix
     let ref_offset = offset.wrapping_sub(prefix_len);
@@ -254,13 +264,48 @@ pub fn analyze_expression_with_alloc<'a>(
     alloc: &'a Allocator,
     source: &'a str,
     offset: u32,
+    typescript: bool,
 ) -> Result<(ExpressionInfo, Expression<'a>), Diagnostic> {
-    let parser = OxcParser::new(alloc, source, SourceType::default());
-    let expr = parser
+    let src_type = if typescript {
+        SourceType::default().with_typescript(true)
+    } else {
+        SourceType::default()
+    };
+    let parser = OxcParser::new(alloc, source, src_type);
+    let mut expr = parser
         .parse_expression()
         .map_err(|_| Diagnostic::invalid_expression(Span::new(offset, offset + source.len() as u32)))?;
+    if typescript {
+        strip_ts_expression(&mut expr, alloc);
+    }
     let info = extract_expression_info(&expr, offset);
     Ok((info, expr))
+}
+
+/// Unwrap TypeScript expression wrappers in-place, extracting the inner JS expression.
+/// Handles: TSAsExpression, TSSatisfiesExpression, TSNonNullExpression,
+///          TSTypeAssertion, TSInstantiationExpression.
+fn strip_ts_expression<'a>(expr: &mut Expression<'a>, alloc: &'a Allocator) {
+    use std::cell::Cell;
+    let dummy = || Expression::NullLiteral(oxc_allocator::Box::new_in(
+        oxc_ast::ast::NullLiteral { span: oxc_span::SPAN, node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY) },
+        alloc,
+    ));
+    // Unwrap top-level TS wrappers (may be nested, e.g. `x as T satisfies U`)
+    loop {
+        let inner = match std::mem::replace(expr, dummy()) {
+            Expression::TSAsExpression(ts) => ts.unbox().expression,
+            Expression::TSSatisfiesExpression(ts) => ts.unbox().expression,
+            Expression::TSNonNullExpression(ts) => ts.unbox().expression,
+            Expression::TSTypeAssertion(ts) => ts.unbox().expression,
+            Expression::TSInstantiationExpression(ts) => ts.unbox().expression,
+            other => {
+                *expr = other;
+                break;
+            }
+        };
+        *expr = inner;
+    }
 }
 
 #[cfg(test)]
@@ -1248,7 +1293,7 @@ mod tests {
     fn parse_const_declaration_simple() {
         let alloc = Allocator::default();
         let source = alloc.alloc_str("doubled = item * 2");
-        let (names, refs, _expr) = parse_const_declaration_with_alloc(&alloc, source, 10).unwrap();
+        let (names, refs, _expr) = parse_const_declaration_with_alloc(&alloc, source, 10, false).unwrap();
         assert_eq!(names, vec![compact("doubled")]);
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].name, "item");
@@ -1262,7 +1307,7 @@ mod tests {
         let alloc = Allocator::default();
         // offset >= 6 required (compensates "const " prefix in wrapping arithmetic)
         let source = alloc.alloc_str("{a, b} = obj");
-        let (names, refs, _expr) = parse_const_declaration_with_alloc(&alloc, source, 10).unwrap();
+        let (names, refs, _expr) = parse_const_declaration_with_alloc(&alloc, source, 10, false).unwrap();
         assert_eq!(names, vec![compact("a"), compact("b")]);
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].name, "obj");
@@ -1272,7 +1317,7 @@ mod tests {
     fn parse_const_declaration_multiple_equals() {
         let alloc = Allocator::default();
         let source = alloc.alloc_str("a = b === c");
-        let (names, refs, _expr) = parse_const_declaration_with_alloc(&alloc, source, 10).unwrap();
+        let (names, refs, _expr) = parse_const_declaration_with_alloc(&alloc, source, 10, false).unwrap();
         assert_eq!(names, vec![compact("a")]);
         assert_eq!(refs.len(), 2);
         assert!(refs.iter().any(|r| r.name == "b"));

--- a/tasks/compiler_tests/cases2/ts_strip_attribute/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_strip_attribute/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>click</button>`);
+export default function App($$anchor) {
+	let handler = () => {};
+	var button = root();
+	$.delegated("click", button, handler);
+	$.append($$anchor, button);
+}
+$.delegate(["click"]);

--- a/tasks/compiler_tests/cases2/ts_strip_attribute/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_strip_attribute/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>click</button>`);
+export default function App($$anchor) {
+	let handler = () => {};
+	var button = root();
+	$.delegated("click", button, handler);
+	$.append($$anchor, button);
+}
+$.delegate(["click"]);

--- a/tasks/compiler_tests/cases2/ts_strip_attribute/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_strip_attribute/case.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+    type Handler = (e: MouseEvent) => void;
+    let handler: Handler = $state(() => {});
+</script>
+
+<button onclick={handler as any}>click</button>

--- a/tasks/compiler_tests/cases2/ts_strip_const_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_strip_const_tag/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		1,
+		2,
+		3
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		const doubled = $.derived(() => $.get(item) * 2);
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(doubled)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_const_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_strip_const_tag/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		1,
+		2,
+		3
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		const doubled = $.derived(() => $.get(item) * 2);
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(doubled)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_const_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_strip_const_tag/case.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    let items = $state<number[]>([1, 2, 3]);
+</script>
+
+{#each items as item}
+    {@const doubled: number = item * 2}
+    <p>{doubled}</p>
+{/each}

--- a/tasks/compiler_tests/cases2/ts_strip_expression_tag/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_strip_expression_tag/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let value = "hello";
+	var p = root();
+	p.textContent = "hello";
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_expression_tag/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_strip_expression_tag/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let value = "hello";
+	var p = root();
+	p.textContent = "hello";
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_expression_tag/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_strip_expression_tag/case.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    let value = $state<string>('hello');
+</script>
+
+<p>{value as string}</p>

--- a/tasks/compiler_tests/cases2/ts_strip_non_null/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_strip_non_null/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let value = "hello";
+	var p = root();
+	p.textContent = "hello";
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_non_null/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_strip_non_null/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let value = "hello";
+	var p = root();
+	p.textContent = "hello";
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_non_null/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_strip_non_null/case.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    let value = $state<string | null>('hello');
+</script>
+
+<p>{value!}</p>

--- a/tasks/compiler_tests/cases2/ts_strip_satisfies/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_strip_satisfies/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let count = $.state(0);
+	$.update(count);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(count)));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_satisfies/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_strip_satisfies/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let count = $.state(0);
+	$.update(count);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(count)));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_satisfies/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_strip_satisfies/case.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    type Count = number;
+    let count: Count = $state(0);
+    count++;
+</script>
+
+<p>{count satisfies Count}</p>

--- a/tasks/compiler_tests/cases2/ts_strip_script_types/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_strip_script_types/case-rust.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p> <p></p>`, 1);
+export default function App($$anchor) {
+	let name = "world";
+	let status = "active";
+	function greet(user) {
+		return `Hello ${user.name}`;
+	}
+	var fragment = root();
+	var p = $.first_child(fragment);
+	p.textContent = "world";
+	var p_1 = $.sibling(p, 2);
+	p_1.textContent = "active";
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_script_types/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_strip_script_types/case-svelte.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p> <p></p>`, 1);
+export default function App($$anchor) {
+	let name = "world";
+	let status = "active";
+	function greet(user) {
+		return `Hello ${user.name}`;
+	}
+	var fragment = root();
+	var p = $.first_child(fragment);
+	p.textContent = "world";
+	var p_1 = $.sibling(p, 2);
+	p_1.textContent = "active";
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/ts_strip_script_types/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_strip_script_types/case.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import type { SvelteComponent } from 'svelte';
+
+    interface User {
+        name: string;
+        age: number;
+    }
+
+    type Status = 'active' | 'inactive';
+
+    let name: string = $state('world');
+    let status: Status = $state<Status>('active');
+
+    function greet(user: User): string {
+        return `Hello ${user.name}`;
+    }
+</script>
+
+<p>{name}</p>
+<p>{status}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1310,5 +1310,36 @@ fn debug_single() {
     assert_compiler("debug_single");
 }
 
+// ---------------------------------------------------------------------------
+// TypeScript stripping tests
+// ---------------------------------------------------------------------------
 
+#[rstest]
+fn ts_strip_expression_tag() {
+    assert_compiler("ts_strip_expression_tag");
+}
 
+#[rstest]
+fn ts_strip_satisfies() {
+    assert_compiler("ts_strip_satisfies");
+}
+
+#[rstest]
+fn ts_strip_non_null() {
+    assert_compiler("ts_strip_non_null");
+}
+
+#[rstest]
+fn ts_strip_const_tag() {
+    assert_compiler("ts_strip_const_tag");
+}
+
+#[rstest]
+fn ts_strip_attribute() {
+    assert_compiler("ts_strip_attribute");
+}
+
+#[rstest]
+fn ts_strip_script_types() {
+    assert_compiler("ts_strip_script_types");
+}


### PR DESCRIPTION
Thread `typescript` flag through expression parsing in svelte_js and
parse_js so template expressions like `{value as string}`, `{value!}`,
`{value satisfies Type}` are parsed with TS syntax enabled and stripped.

Add Traverse visitor methods in ScriptTransformer to strip TS annotations
from script AST during codegen: variable type annotations, function
return types/type params/this param, formal parameter annotations, and
TS expression wrappers (as/satisfies/non-null/type assertion/instantiation).

Statement-level filtering already handles type aliases, interfaces, enums,
and `import type` declarations.

Test cases: ts_strip_expression_tag, ts_strip_satisfies, ts_strip_non_null,
ts_strip_const_tag, ts_strip_attribute, ts_strip_script_types.

https://claude.ai/code/session_01UKnQLNCPHr6uczrRgJAvUV