### PR TITLE
feat: port $state.eager(val) and $effect.pending() experimental async runes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -311,8 +311,8 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [x] `$state` / `$state.raw` destructuring support in script codegen
 - [x] `$state` / `$state.raw` class field support
 - [ ] `$state.frozen` → `$state.raw` rename validation
-- [ ] `$state.eager(val)` — experimental async, requires `experimental.async` flag
-- [ ] `$effect.pending()` — requires `<svelte:boundary>` (Tier 5)
+- [x] `$state.eager(val)` — experimental async, requires `experimental.async` flag
+- [x] `$effect.pending()` — requires `<svelte:boundary>` (Tier 5)
 
 ### $host() (Tier 1)
 - [ ] Validation: `$host()` must have zero arguments (`rune_invalid_arguments`)

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -117,6 +117,7 @@ fn parse_concat_parts<'a>(
         references: all_refs,
         has_side_effects: false,
         has_call: false,
+        has_state_rune: false,
     };
     data.attr_expressions.insert(attr_id, merged);
 }
@@ -238,6 +239,7 @@ fn walk_node<'a>(
                         references,
                         has_side_effects: false,
                         has_call: false,
+                        has_state_rune: false,
                     });
                     parsed.exprs.insert(tag.id, init_expr);
                     data.const_tags.names.insert(tag.id, names.iter().map(|n| n.to_string()).collect());

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -16,6 +16,9 @@ impl ReactivityVisitor {
         data: &AnalysisData,
     ) -> bool {
         if let Some(info) = data.expressions.get(node_id) {
+            if info.has_state_rune {
+                return true;
+            }
             return info.references.iter().any(|r| {
                 // Store subscriptions ($count) are always dynamic
                 if data.scoping.is_store_ref(&r.name) {

--- a/crates/svelte_codegen_client/src/script.rs
+++ b/crates/svelte_codegen_client/src/script.rs
@@ -1714,6 +1714,16 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
                         node.init = Some(value);
                     }
                 }
+                RuneKind::StateEager => {
+                    // $state.eager(expr) → $.eager(() => expr)
+                    let arg = call.arguments.remove(0).into_expression();
+                    node.init = Some(self.b.call_expr("$.eager", [Arg::Expr(self.b.thunk(arg))]));
+                }
+                RuneKind::EffectPending => {
+                    // $effect.pending() → $.eager($.pending)
+                    let pending_call = self.b.call_expr("$.pending", std::iter::empty::<Arg<'a, '_>>());
+                    node.init = Some(self.b.call_expr("$.eager", [Arg::Expr(self.b.thunk(pending_call))]));
+                }
                 _ => {
                     // Other rune kinds — put back the call unchanged
                     node.init = Some(Expression::CallExpression(call));
@@ -1764,6 +1774,26 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
                             "$$host",
                         );
                         return;
+                    }
+                }
+
+                // $state.eager(expr) → $.eager(() => expr)
+                if let Expression::StaticMemberExpression(member) = &call.callee {
+                    if let Expression::Identifier(obj) = &member.object {
+                        match (obj.name.as_str(), member.property.name.as_str()) {
+                            ("$state", "eager") => {
+                                let Expression::CallExpression(mut call) = self.b.move_expr(node) else { unreachable!() };
+                                let arg = call.arguments.remove(0).into_expression();
+                                *node = self.b.call_expr("$.eager", [Arg::Expr(self.b.thunk(arg))]);
+                                return;
+                            }
+                            ("$effect", "pending") => {
+                                let pending_call = self.b.call_expr("$.pending", std::iter::empty::<Arg<'a, '_>>());
+                                *node = self.b.call_expr("$.eager", [Arg::Expr(self.b.thunk(pending_call))]);
+                                return;
+                            }
+                            _ => {}
+                        }
                     }
                 }
 

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -10,7 +10,7 @@ use crate::context::Ctx;
 
 use super::attributes::{process_attr, process_attrs_spread, process_class_attribute_and_directives, process_style_directives};
 use super::each_block::gen_each_block;
-use super::expression::{build_concat, emit_trailing_next};
+use super::expression::{build_concat, emit_memoized_text_effect, emit_trailing_next, text_content_needs_memo};
 use super::traverse::traverse_items;
 
 /// Process an element's attributes and children.
@@ -105,11 +105,19 @@ pub(crate) fn process_element<'a>(
             init.push(ctx.b.var_stmt(&text_name, child_call));
             init.push(ctx.b.call_stmt("$.reset", [Arg::Ident(el_name)]));
 
+            // Check if the expression needs call memoization (has_call + reactive refs)
+            let has_call = text_content_needs_memo(&items[0], ctx);
+
             let expr = build_concat(ctx, &items[0]);
-            update.push(ctx.b.call_stmt(
-                "$.set_text",
-                [Arg::Ident(&text_name), Arg::Expr(expr)],
-            ));
+            if has_call {
+                // Memoized form: $.template_effect(($0) => $.set_text(text, $0), [() => expr])
+                emit_memoized_text_effect(ctx, &text_name, expr, init);
+            } else {
+                update.push(ctx.b.call_stmt(
+                    "$.set_text",
+                    [Arg::Ident(&text_name), Arg::Expr(expr)],
+                ));
+            }
         }
 
         ContentStrategy::SingleBlock(FragmentItem::EachBlock(id)) => {

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -221,6 +221,53 @@ pub(crate) fn item_is_dynamic(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
     }
 }
 
+/// Check if a text content expression needs call memoization.
+/// Requires `has_call` AND references to resolved bindings (not just rune names).
+pub(crate) fn text_content_needs_memo(item: &FragmentItem, ctx: &Ctx<'_>) -> bool {
+    if let FragmentItem::TextConcat { parts, .. } = item {
+        return parts.iter().any(|p| {
+            if let LoweredTextPart::Expr(id) = p {
+                let info = ctx.expression(*id);
+                let has_call = info.map_or(false, |e| e.has_call);
+                // Only memoize when there are references that resolve to actual bindings
+                let has_resolved_refs = info.map_or(false, |e|
+                    e.references.iter().any(|r| r.symbol_id.is_some())
+                );
+                has_call && has_resolved_refs
+            } else {
+                false
+            }
+        });
+    }
+    false
+}
+
+/// Emit memoized template_effect for text with `has_call` expressions:
+/// `$.template_effect(($0) => $.set_text(text, $0), [() => expr])`
+pub(crate) fn emit_memoized_text_effect<'a>(
+    ctx: &mut Ctx<'a>,
+    text_name: &str,
+    expr: Expression<'a>,
+    body: &mut Vec<Statement<'a>>,
+) {
+    // Build the lazy getter: [() => expr]
+    let thunk = ctx.b.thunk(expr);
+    let getter_array = ctx.b.array_expr([thunk]);
+
+    // Build the callback: ($0) => $.set_text(text, $0)
+    let params = ctx.b.params(["$0"]);
+    let set_text = ctx.b.call_stmt(
+        "$.set_text",
+        [Arg::Ident(text_name), Arg::Ident("$0")],
+    );
+    let callback = ctx.b.arrow_expr(params, [set_text]);
+
+    body.push(ctx.b.call_stmt(
+        "$.template_effect",
+        [Arg::Expr(callback), Arg::Expr(getter_array)],
+    ));
+}
+
 pub(crate) fn parts_are_dynamic(parts: &[LoweredTextPart], ctx: &Ctx<'_>) -> bool {
     parts.iter().any(|p| {
         if let LoweredTextPart::Expr(id) = p {

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -79,6 +79,26 @@ pub(crate) fn gen_if_block<'a>(
         None
     };
 
+    // 2b. Pre-compute has_call memoization for each branch condition.
+    // When a condition has a function call AND reactive references, wrap in $.derived.
+    let mut derived_names: Vec<Option<String>> = Vec::new();
+    for branch in branches.iter() {
+        let info = ctx.expression(branch.block_id);
+        let needs_memo = info.map_or(false, |e| {
+            e.has_call && e.references.iter().any(|r| r.symbol_id.is_some())
+        });
+        if needs_memo {
+            let expr = get_node_expr(ctx, branch.block_id);
+            let thunk = ctx.b.thunk(expr);
+            let derived = ctx.b.call_expr("$.derived", [Arg::Expr(thunk)]);
+            let name = ctx.gen_ident("d");
+            stmts.push(ctx.b.var_stmt(&name, derived));
+            derived_names.push(Some(name));
+        } else {
+            derived_names.push(None);
+        }
+    }
+
     // 3. Build the if/else-if/else chain (bottom-up)
     let num_branches = branches.len();
 
@@ -89,7 +109,11 @@ pub(crate) fn gen_if_block<'a>(
 
     // Build from last branch to first
     for i in (0..num_branches).rev() {
-        let test = get_node_expr(ctx, branches[i].block_id);
+        let test = if let Some(ref derived_name) = derived_names[i] {
+            ctx.b.call_expr("$.get", [Arg::Ident(derived_name)])
+        } else {
+            get_node_expr(ctx, branches[i].block_id)
+        };
         let render_args: Vec<Arg<'a, '_>> = if i == 0 {
             // First branch: no second argument
             vec![Arg::Ident(&branch_names[i])]

--- a/crates/svelte_js/src/lib.rs
+++ b/crates/svelte_js/src/lib.rs
@@ -30,6 +30,8 @@ pub struct ExpressionInfo {
     pub references: Vec<Reference>,
     pub has_side_effects: bool,
     pub has_call: bool,
+    /// Set when the expression contains `$effect.pending()` — forces the expression to be dynamic.
+    pub has_state_rune: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +132,8 @@ pub enum RuneKind {
     EffectTracking,
     Props,
     Bindable,
+    StateEager,
+    EffectPending,
     Inspect,
     Host,
     PropsId,
@@ -829,11 +833,15 @@ fn extract_expression_info(expr: &Expression<'_>, offset: u32) -> ExpressionInfo
 
     let has_call = expression_has_call(expr);
 
+    let has_state_rune = expression_has_rune(expr, RuneKind::EffectPending)
+        || expression_has_rune(expr, RuneKind::StateEager);
+
     ExpressionInfo {
         kind,
         references,
         has_side_effects,
         has_call,
+        has_state_rune,
     }
 }
 
@@ -859,6 +867,26 @@ pub fn expression_has_call(expr: &Expression<'_>) -> bool {
         Expression::SequenceExpression(s) => s.expressions.iter().any(|e| expression_has_call(e)),
         // Function boundaries are opaque
         Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => false,
+        _ => false,
+    }
+}
+
+/// Check if the expression (or any sub-expression) contains a call to a specific rune.
+fn expression_has_rune(expr: &Expression<'_>, target: RuneKind) -> bool {
+    match expr {
+        Expression::CallExpression(_) => detect_rune(expr) == Some(target),
+        Expression::ConditionalExpression(c) => {
+            expression_has_rune(&c.test, target)
+                || expression_has_rune(&c.consequent, target)
+                || expression_has_rune(&c.alternate, target)
+        }
+        Expression::BinaryExpression(b) => {
+            expression_has_rune(&b.left, target) || expression_has_rune(&b.right, target)
+        }
+        Expression::LogicalExpression(l) => {
+            expression_has_rune(&l.left, target) || expression_has_rune(&l.right, target)
+        }
+        Expression::SequenceExpression(s) => s.expressions.iter().any(|e| expression_has_rune(e, target)),
         _ => false,
     }
 }
@@ -1138,7 +1166,9 @@ fn detect_rune(expr: &Expression<'_>) -> Option<RuneKind> {
                     return match (obj.name.as_str(), prop) {
                         ("$derived", "by") => Some(RuneKind::DerivedBy),
                         ("$state", "raw") => Some(RuneKind::StateRaw),
+                        ("$state", "eager") => Some(RuneKind::StateEager),
                         ("$effect", "tracking") => Some(RuneKind::EffectTracking),
+                        ("$effect", "pending") => Some(RuneKind::EffectPending),
                         ("$props", "id") => Some(RuneKind::PropsId),
                         _ => None,
                     };

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -325,6 +325,38 @@ impl<'a> VisitMut<'a> for ExprTransformer<'a, '_, '_> {
             return;
         }
 
+        // CallExpression: $state.eager(val) → $.eager(() => val), $effect.pending() → $.eager($.pending)
+        if let Expression::CallExpression(call) = it {
+            if let Expression::StaticMemberExpression(member) = &call.callee {
+                if let Expression::Identifier(obj) = &member.object {
+                    match (obj.name.as_str(), member.property.name.as_str()) {
+                        ("$state", "eager") => {
+                            // Walk the argument first so inner rune refs are transformed
+                            for arg in call.arguments.iter_mut() {
+                                if let Some(expr) = arg.as_expression_mut() {
+                                    self.visit_expression(expr);
+                                }
+                            }
+                            // Replace: $state.eager(val) → $.eager(() => val)
+                            if let Expression::CallExpression(call) = std::mem::replace(it, rune_refs::make_eager_pending(self.ctx.alloc)) {
+                                let mut call = call.unbox();
+                                if !call.arguments.is_empty() {
+                                    let arg = call.arguments.remove(0).into_expression();
+                                    *it = rune_refs::make_eager_thunk(self.ctx.alloc, arg);
+                                }
+                            }
+                            return;
+                        }
+                        ("$effect", "pending") => {
+                            *it = rune_refs::make_eager_pending(self.ctx.alloc);
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
         // Walk all children (covers every expression type automatically)
         walk_expression(self, it);
 

--- a/crates/svelte_transform/src/rune_refs.rs
+++ b/crates/svelte_transform/src/rune_refs.rs
@@ -82,6 +82,51 @@ pub fn make_props_access<'a>(alloc: &'a Allocator, prop_name: &str) -> Expressio
     ))
 }
 
+/// Build `$.eager(() => expr)` — wrap the argument in a thunk and call $.eager.
+/// Applies unthunk optimization: `() => fn()` → `fn` when fn is a zero-arg call to an identifier.
+pub fn make_eager_thunk<'a>(alloc: &'a Allocator, arg: Expression<'a>) -> Expression<'a> {
+    let ast = AstBuilder::new(alloc);
+    let callee = make_dollar_member(&ast, "eager");
+    let thunked = make_thunk(&ast, arg);
+    ast.expression_call(SPAN, callee, NONE, ast.vec1(Argument::from(thunked)), false)
+}
+
+/// Build `$.eager($.pending)` — thunk-optimized form of `$.eager(() => $.pending())`.
+pub fn make_eager_pending<'a>(alloc: &'a Allocator) -> Expression<'a> {
+    let ast = AstBuilder::new(alloc);
+    let eager_callee = make_dollar_member(&ast, "eager");
+    // $.pending (identifier, not call — thunk optimization of () => $.pending())
+    let pending_ref = make_dollar_member(&ast, "pending");
+    ast.expression_call(SPAN, eager_callee, NONE, ast.vec1(Argument::from(pending_ref)), false)
+}
+
+/// Build `() => expr`, with unthunk optimization for zero-arg calls to identifiers.
+fn make_thunk<'a>(ast: &AstBuilder<'a>, expr: Expression<'a>) -> Expression<'a> {
+    // Optimize `() => fn()` → `fn` when fn is a zero-arg call to an identifier/member
+    if let Expression::CallExpression(call) = &expr {
+        if call.arguments.is_empty()
+            && !call.optional
+            && matches!(&call.callee, Expression::Identifier(_) | Expression::StaticMemberExpression(_))
+        {
+            // Return just the callee
+            if let Expression::CallExpression(call) = expr {
+                return call.unbox().callee;
+            }
+        }
+    }
+    // Build `() => expr` — expression-body arrow function
+    let params = ast.alloc_formal_parameters(
+        SPAN,
+        FormalParameterKind::ArrowFormalParameters,
+        ast.vec(),
+        NONE,
+    );
+    let body = ast.alloc(ast.function_body(SPAN, ast.vec(), ast.vec1(
+        ast.statement_expression(SPAN, expr),
+    )));
+    ast.expression_arrow_function(SPAN, true, false, NONE, params, NONE, body)
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/tasks/compiler_tests/cases2/effect_pending_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/effect_pending_basic/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.eager($.pending)));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/effect_pending_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/effect_pending_basic/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.eager($.pending)));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/effect_pending_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/effect_pending_basic/case.svelte
@@ -1,0 +1,4 @@
+<script>
+</script>
+
+<p>{$effect.pending()}</p>

--- a/tasks/compiler_tests/cases2/effect_pending_if/case-rust.js
+++ b/tasks/compiler_tests/cases2/effect_pending_if/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Loading</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		$.if(node, ($$render) => {
+			if ($.eager($.pending)) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/effect_pending_if/case-svelte.js
+++ b/tasks/compiler_tests/cases2/effect_pending_if/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Loading</p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		$.if(node, ($$render) => {
+			if ($.eager($.pending)) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/effect_pending_if/case.svelte
+++ b/tasks/compiler_tests/cases2/effect_pending_if/case.svelte
@@ -1,0 +1,6 @@
+<script>
+</script>
+
+{#if $effect.pending()}
+	<p>Loading</p>
+{/if}

--- a/tasks/compiler_tests/cases2/effect_pending_var/case-rust.js
+++ b/tasks/compiler_tests/cases2/effect_pending_var/case-rust.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p></p>`);
+var root_2 = $.from_html(`<p>Done</p>`);
+export default function App($$anchor) {
+	let count = 0;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+			p.textContent = "Loading 0";
+			$.append($$anchor, p);
+		};
+		var alternate = ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		};
+		$.if(node, ($$render) => {
+			if ($.eager($.pending)) $$render(consequent);
+			else $$render(alternate, -1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/effect_pending_var/case-svelte.js
+++ b/tasks/compiler_tests/cases2/effect_pending_var/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p></p>`);
+var root_2 = $.from_html(`<p>Done</p>`);
+export default function App($$anchor) {
+	let count = 0;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+			p.textContent = "Loading 0";
+			$.append($$anchor, p);
+		};
+		var alternate = ($$anchor) => {
+			var p_1 = root_2();
+			$.append($$anchor, p_1);
+		};
+		$.if(node, ($$render) => {
+			if ($.eager($.pending)) $$render(consequent);
+			else $$render(alternate, -1);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/effect_pending_var/case.svelte
+++ b/tasks/compiler_tests/cases2/effect_pending_var/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let count = $state(0);
+</script>
+
+{#if $effect.pending()}
+	<p>Loading {count}</p>
+{:else}
+	<p>Done</p>
+{/if}

--- a/tasks/compiler_tests/cases2/state_eager_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_eager_basic/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let val = 0;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(($0) => $.set_text(text, $0), [() => $.eager(() => val)]);
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_eager_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_eager_basic/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let val = 0;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(($0) => $.set_text(text, $0), [() => $.eager(() => val)]);
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_eager_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/state_eager_basic/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let val = $state(0);
+</script>
+
+<p>{$state.eager(val)}</p>

--- a/tasks/compiler_tests/cases2/state_eager_reactive/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_eager_reactive/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Active</p>`);
+export default function App($$anchor) {
+	let count = 0;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		var d = $.derived(() => $.eager(() => count));
+		$.if(node, ($$render) => {
+			if ($.get(d)) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/state_eager_reactive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_eager_reactive/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Active</p>`);
+export default function App($$anchor) {
+	let count = 0;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+			$.append($$anchor, p);
+		};
+		var d = $.derived(() => $.eager(() => count));
+		$.if(node, ($$render) => {
+			if ($.get(d)) $$render(consequent);
+		});
+	}
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/state_eager_reactive/case.svelte
+++ b/tasks/compiler_tests/cases2/state_eager_reactive/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	let count = $state(0);
+</script>
+
+{#if $state.eager(count)}
+	<p>Active</p>
+{/if}

--- a/tasks/compiler_tests/cases2/state_eager_template/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_eager_template/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let a = 1;
+	let b = 2;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(($0) => $.set_text(text, $0), [() => $.eager(() => a + b)]);
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_eager_template/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_eager_template/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let a = 1;
+	let b = 2;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(($0) => $.set_text(text, $0), [() => $.eager(() => a + b)]);
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/state_eager_template/case.svelte
+++ b/tasks/compiler_tests/cases2/state_eager_template/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let a = $state(1);
+	let b = $state(2);
+</script>
+
+<p>{$state.eager(a + b)}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -94,6 +94,21 @@ fn state_raw() {
 }
 
 #[rstest]
+fn state_eager_basic() {
+    assert_compiler("state_eager_basic");
+}
+
+#[rstest]
+fn state_eager_reactive() {
+    assert_compiler("state_eager_reactive");
+}
+
+#[rstest]
+fn state_eager_template() {
+    assert_compiler("state_eager_template");
+}
+
+#[rstest]
 fn state_snapshot_basic() {
     assert_compiler("state_snapshot_basic");
 }
@@ -316,6 +331,21 @@ fn effect_root_cleanup() {
 #[rstest]
 fn effect_tracking() {
     assert_compiler("effect_tracking");
+}
+
+#[rstest]
+fn effect_pending_basic() {
+    assert_compiler("effect_pending_basic");
+}
+
+#[rstest]
+fn effect_pending_if() {
+    assert_compiler("effect_pending_if");
+}
+
+#[rstest]
+fn effect_pending_var() {
+    assert_compiler("effect_pending_var");
 }
 
 #[rstest]


### PR DESCRIPTION
- Add StateEager and EffectPending variants to RuneKind with detection
- Transform $state.eager(val) → $.eager(() => val) in both script and template
- Transform $effect.pending() → $.eager($.pending) with thunk optimization
- Add has_state_rune flag to ExpressionInfo for reactivity analysis
- Add memoized template_effect pattern for has_call expressions
- Add $.derived/$.get memoization for if-block conditions with calls
- 6 test cases covering basic, reactive, template, and if-block contexts

https://claude.ai/code/session_01UM3oKBpzwHnpwpdU1Un3cU