### PR TITLE
docs: document $host() + $.push/$.pop reference compiler bug

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -111,6 +111,18 @@ Directive targets (mutable rune? prop source? each-block context?) are classifie
 - `needs_var` — element needs a JS variable in codegen (for dynamic attributes, directives, etc.)
 - `needs_ref` — element needs a ref-semantic variable specifically (for `bind:this`)
 
+### 9. `$host()` without props/exports breaks at runtime (reference compiler bug)
+
+`$host()` transforms to `$$props.$$host`. But `$$props` is only added as a function parameter when `needs_push` is true (has props, exports, effects, or bindable). A custom element component that uses `$host()` alone (no `$props()`, no exports, no `$effect`) compiles to:
+
+```js
+export default function App($$anchor) {   // ← no $$props param
+  let host = $$props.$$host;              // ← ReferenceError at runtime
+}
+```
+
+**This is a bug in the reference Svelte compiler that we intentionally replicate.** The fix would be: detect `$host()` in script analysis → set `needs_context = true` → triggers `$$props` param + `$.push`/`$.pop`. Not implemented because the reference compiler has the same bug. See `host_basic` test case.
+
 ---
 
 ## Checklist for a New Node Type

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -444,7 +444,7 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] `custom_element_props_identifier` warning when `$props()` used without CE props config
 - [ ] HMR conditional registration: `if (customElements.get(tag) == null)`
 - [ ] Shadow DOM custom `ObjectExpression` (non-literal config)
-- [ ] `$.push`/`$.pop` lifecycle for `$host()` mutations
+- [ ] `$.push`/`$.pop` lifecycle for `$host()` mutations (reference compiler bug — see GOTCHAS.md #9)
 - [ ] Auto-detect boolean type from prop default literal value (in CE props config)
 
 ### `on:directive` legacy (Tier 10)


### PR DESCRIPTION
The reference Svelte compiler omits $$props param and $.push/$.pop
when $host() is used without props/exports/effects, causing a runtime
ReferenceError. We intentionally replicate this bug. Added as Trap #9
in GOTCHAS.md and annotated the deferred ROADMAP item.

https://claude.ai/code/session_01AChttqnJegC3a9GR3XZ5Di