### PR TITLE
feat: port render tag dynamic callee and optional chaining (Tier 1d)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,6 +71,8 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 - [x] `has_call` memoization — `onclick={getHandler()}` → `$.derived(getHandler)` + `$.get(event_handler)`
 - [x] Component prop memoization — `has_call` and non-simple+dynamic expressions wrapped in `$.derived`/`$.get`
 - [x] Render tag arg memoization — `{@render fn(getArg())}` → `$.derived`/`$.get`
+- [x] Render tag dynamic callee — `{@render show(args)}` where `show` is prop/state → `$.snippet(node, () => show, ...)`
+- [x] Render tag optional chaining — `{@render fn?.()}` → `fn?.(anchor)` or `$.snippet(node, () => fn ?? $.noop, ...)`
 - [x] `on:event` — legacy event directive (Svelte 4)
 
 ### Bind directives
@@ -347,8 +349,8 @@ Items discovered during porting but not critical for the feature to work. Groupe
 - [ ] Validation: disallow `$props()`, `$bindable()`, `$store` auto-subscriptions in modules
 
 ### Render tag (Tier 1d)
-- [ ] Dynamic snippet callee: `{@render show(args)}` where `show` is `$state`/prop → `$.snippet(node, () => show, ...)` instead of direct call. Requires `metadata.dynamic` flag in analysis (`binding.kind !== 'normal'`)
-- [ ] Optional chaining: `{@render fn?.()}` → `$.noop` fallback when fn is nullish
+- [x] Dynamic snippet callee: `{@render show(args)}` where `show` is `$state`/prop → `$.snippet(node, () => show, ...)` instead of direct call. Requires `metadata.dynamic` flag in analysis (`binding.kind !== 'normal'`)
+- [x] Optional chaining: `{@render fn?.()}` → `$.noop` fallback when fn is nullish
 
 ### `{@html expr}` (Tier 2)
 - [ ] `is_controlled` optimization (single child → innerHTML)

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -307,6 +307,17 @@ pub struct AnalysisData {
     /// Per-argument prop-source SymbolId for render tags.
     /// Some(sym) = prop-source arg (pass getter directly), None = not a prop-source.
     pub render_tag_prop_sources: FxHashMap<NodeId, Vec<Option<SymbolId>>>,
+    /// Callee identifier name for render tags (only set when callee is an Identifier).
+    pub(crate) render_tag_callee_name: FxHashMap<NodeId, String>,
+    /// Callee SymbolId for render tags (resolved during resolve_references).
+    pub(crate) render_tag_callee_sym: FxHashMap<NodeId, SymbolId>,
+    /// Render tags whose expression was a ChainExpression (`{@render fn?.()}`).
+    pub render_tag_is_chain: FxHashSet<NodeId>,
+    /// Dynamic render tags — callee is a non-normal binding (prop, state, snippet param, etc.).
+    pub render_tag_dynamic: FxHashSet<NodeId>,
+    /// Render tags whose callee is a getter function (prop-source or snippet param).
+    /// These pass the callee directly to `$.snippet` instead of wrapping in a thunk.
+    pub render_tag_callee_is_getter: FxHashSet<NodeId>,
     /// Pre-computed bind/directive semantics (mutable rune targets, prop sources).
     pub bind_semantics: BindSemanticsData,
     /// Pre-computed import SymbolIds from root scope (O(1) lookup in codegen).
@@ -339,6 +350,11 @@ impl AnalysisData {
             render_tag_arg_has_call: FxHashMap::default(),
             render_tag_arg_idents: FxHashMap::default(),
             render_tag_prop_sources: FxHashMap::default(),
+            render_tag_callee_name: FxHashMap::default(),
+            render_tag_callee_sym: FxHashMap::default(),
+            render_tag_is_chain: FxHashSet::default(),
+            render_tag_dynamic: FxHashSet::default(),
+            render_tag_callee_is_getter: FxHashSet::default(),
             bind_semantics: BindSemanticsData::new(),
             import_syms: FxHashSet::default(),
             custom_element: false,
@@ -353,6 +369,9 @@ impl AnalysisData {
     pub fn attr_expression(&self, id: NodeId) -> Option<&ExpressionInfo> { self.attr_expressions.get(&id) }
     pub fn render_tag_arg_has_call(&self, id: NodeId) -> Option<&[bool]> { self.render_tag_arg_has_call.get(&id).map(|v| v.as_slice()) }
     pub fn render_tag_prop_sources(&self, id: NodeId) -> Option<&[Option<SymbolId>]> { self.render_tag_prop_sources.get(&id).map(|v| v.as_slice()) }
+    pub fn render_tag_is_chain(&self, id: NodeId) -> bool { self.render_tag_is_chain.contains(&id) }
+    pub fn render_tag_is_dynamic(&self, id: NodeId) -> bool { self.render_tag_dynamic.contains(&id) }
+    pub fn render_tag_callee_is_getter(&self, id: NodeId) -> bool { self.render_tag_callee_is_getter.contains(&id) }
 
     /// Known compile-time value for a name at root scope (looks up SymbolId internally).
     pub fn known_value(&self, name: &str) -> Option<&str> {

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -74,6 +74,7 @@ pub fn analyze_with_options<'a>(
     known_values::collect_known_values(component, &mut data);
     props::analyze_props(&mut data);
     resolve_render_tag_prop_sources(&mut data);
+    resolve_render_tag_dynamic(&mut data);
     lower::lower(component, &mut data);
 
     // Single composite walk: reactivity + elseif + element flags + hoistable snippets
@@ -171,6 +172,30 @@ fn resolve_render_tag_prop_sources(data: &mut AnalysisData) {
             })
         }).collect();
         data.render_tag_prop_sources.insert(node_id, resolved);
+    }
+}
+
+/// Determine which render tags have dynamic callees and which are getter-type.
+/// Must run after `resolve_render_tag_prop_sources` (which runs after `props`).
+fn resolve_render_tag_dynamic(data: &mut AnalysisData) {
+    // Collect all render tag IDs from arg_has_call (populated for every render tag).
+    let all_ids: Vec<svelte_ast::NodeId> = data.render_tag_arg_has_call.keys().copied().collect();
+
+    for node_id in all_ids {
+        let is_dynamic = match data.render_tag_callee_sym.get(&node_id) {
+            Some(&sym_id) => {
+                let normal = data.scoping.is_normal_binding(sym_id);
+                if !normal && (data.scoping.is_prop_source(sym_id) || data.scoping.is_snippet_param(sym_id)) {
+                    data.render_tag_callee_is_getter.insert(node_id);
+                }
+                !normal
+            }
+            // No sym: non-Identifier callee or unresolved binding — always dynamic.
+            None => true,
+        };
+        if is_dynamic {
+            data.render_tag_dynamic.insert(node_id);
+        }
     }
 }
 

--- a/crates/svelte_analyze/src/parse_js.rs
+++ b/crates/svelte_analyze/src/parse_js.rs
@@ -190,8 +190,25 @@ fn walk_node<'a>(
         Node::RenderTag(tag) => {
             let source = component.source_text(tag.expression_span);
             parse_expr(alloc, source, tag.expression_span.start, tag.id, typescript, data, parsed, diags);
-            // Store per-argument has_call flags and identifier names before transform
+
+            // Unwrap ChainExpression → CallExpression, recording the chain flag.
+            // OXC parses `fn?.()` as ChainExpression { expression: CallExpression }.
+            if matches!(parsed.exprs.get(&tag.id), Some(Expression::ChainExpression(_))) {
+                data.render_tag_is_chain.insert(tag.id);
+                if let Some(Expression::ChainExpression(chain)) = parsed.exprs.remove(&tag.id) {
+                    if let oxc_ast::ast::ChainElement::CallExpression(call) = chain.unbox().expression {
+                        parsed.exprs.insert(tag.id, Expression::CallExpression(call));
+                    }
+                }
+            }
+
+            // Store per-argument has_call flags, identifier names, and callee name
             if let Some(Expression::CallExpression(call)) = parsed.exprs.get(&tag.id) {
+                // Extract callee identifier name for dynamic detection
+                if let Expression::Identifier(ident) = &call.callee {
+                    data.render_tag_callee_name.insert(tag.id, ident.name.to_string());
+                }
+
                 let flags: Vec<bool> = call.arguments.iter().map(|arg| {
                     svelte_js::expression_has_call(arg.to_expression())
                 }).collect();

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -97,6 +97,14 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
 
     fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
         resolve_expr_refs(tag.id, scope, data);
+
+        // Store the scope for this render tag so we can resolve dynamic callees later
+        // (after props analysis populates is_prop_source).
+        if let Some(name) = data.render_tag_callee_name.get(&tag.id) {
+            if let Some(sym_id) = data.scoping.find_binding(scope, name) {
+                data.render_tag_callee_sym.insert(tag.id, sym_id);
+            }
+        }
     }
 
     fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -32,6 +32,7 @@ pub struct ComponentScoping {
     store_syms: FxHashMap<SymbolId, String>,
     known_values: FxHashMap<SymbolId, String>,
     snippet_param_syms: FxHashSet<SymbolId>,
+    snippet_name_syms: FxHashSet<SymbolId>,
     each_block_syms: FxHashSet<SymbolId>,
     /// FragmentKey → ScopeId for scope-introducing fragments (IfBlock branches, KeyBlock, etc.)
     fragment_scopes: FxHashMap<FragmentKey, ScopeId>,
@@ -54,6 +55,7 @@ impl ComponentScoping {
             store_syms: FxHashMap::default(),
             known_values: FxHashMap::default(),
             snippet_param_syms: FxHashSet::default(),
+            snippet_name_syms: FxHashSet::default(),
             each_block_syms: FxHashSet::default(),
             fragment_scopes: FxHashMap::default(),
             const_alias_tags: FxHashMap::default(),
@@ -210,6 +212,10 @@ impl ComponentScoping {
         self.snippet_param_syms.insert(sym_id);
     }
 
+    pub fn mark_snippet_name(&mut self, sym_id: SymbolId) {
+        self.snippet_name_syms.insert(sym_id);
+    }
+
     pub fn mark_each_block_var(&mut self, sym_id: SymbolId) {
         self.each_block_syms.insert(sym_id);
     }
@@ -241,8 +247,23 @@ impl ComponentScoping {
         self.snippet_param_syms.contains(&sym_id)
     }
 
+    pub fn is_snippet_name(&self, sym_id: SymbolId) -> bool {
+        self.snippet_name_syms.contains(&sym_id)
+    }
+
     pub fn is_each_block_var(&self, sym_id: SymbolId) -> bool {
         self.each_block_syms.contains(&sym_id)
+    }
+
+    /// A binding is "normal" if it's a regular const/let/function — not a rune, prop,
+    /// snippet param, each var, or store subscription.
+    pub fn is_normal_binding(&self, sym_id: SymbolId) -> bool {
+        !self.is_rune(sym_id)
+            && !self.is_prop_source(sym_id)
+            && self.prop_non_source_name(sym_id).is_none()
+            && !self.is_snippet_param(sym_id)
+            && !self.is_each_block_var(sym_id)
+            && !self.is_store(sym_id)
     }
 
     pub(crate) fn set_fragment_scope(&mut self, key: FragmentKey, scope_id: ScopeId) {
@@ -400,6 +421,9 @@ fn walk_template_scopes(
                 }
             }
             Node::SnippetBlock(block) => {
+                // Snippet name is a normal binding in the parent scope
+                let name_sym = scoping.add_binding(current_scope, &block.name);
+                scoping.mark_snippet_name(name_sym);
                 // Create a child scope for snippet params — they shadow outer bindings.
                 let snippet_scope = scoping.add_child_scope(current_scope);
                 scoping.set_node_scope(block.id, snippet_scope);

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -328,7 +328,7 @@ fn emit_single_block<'a>(
     // RenderTag / ComponentNode / TitleElement: call directly with $$anchor, no wrapping.
     // Non-root consumes a "fragment" ident for consistent numbering.
     match item {
-        FragmentItem::RenderTag(id) => {
+        FragmentItem::RenderTag(id) if !ctx.analysis.render_tag_is_dynamic(*id) => {
             if !is_root { ctx.gen_ident("fragment"); }
             gen_render_tag(ctx, *id, ctx.b.rid_expr("$$anchor"), body);
             return;
@@ -379,6 +379,9 @@ fn emit_single_block<'a>(
         }
         FragmentItem::AwaitBlock(id) => {
             gen_await_block(ctx, *id, ctx.b.rid_expr(&node), body);
+        }
+        FragmentItem::RenderTag(id) => {
+            gen_render_tag(ctx, *id, ctx.b.rid_expr(&node), body);
         }
         _ => unreachable!("SingleBlock dispatch: all variants covered above"),
     }

--- a/crates/svelte_codegen_client/src/template/render_tag.rs
+++ b/crates/svelte_codegen_client/src/template/render_tag.rs
@@ -9,22 +9,28 @@ use crate::builder::Arg;
 use crate::context::Ctx;
 
 /// Generate a render tag call: `snippet(anchor, () => arg1, () => arg2, ...)`
+///
+/// Dynamic callees (non-normal bindings) use `$.snippet(anchor, getter, ...args)`.
+/// Optional chaining (`{@render fn?.()}`) uses `callee?.(anchor, ...)` or nullish coalescing.
 pub(crate) fn gen_render_tag<'a>(
     ctx: &mut Ctx<'a>,
     id: NodeId,
     anchor_expr: Expression<'a>,
     stmts: &mut Vec<Statement<'a>>,
 ) {
-    // Extract callee name from original source using the stored expression's callee span
     let tag = ctx.render_tag(id);
     let full_source = ctx.component.source_text(tag.expression_span);
 
-    // Pre-computed per-argument has_call flags (from original source, before transform)
+    let is_dynamic = ctx.analysis.render_tag_is_dynamic(id);
+    let is_chain = ctx.analysis.render_tag_is_chain(id);
+    let callee_is_getter = ctx.analysis.render_tag_callee_is_getter(id);
+
+    // Pre-computed per-argument has_call flags
     let arg_has_call = ctx.analysis.render_tag_arg_has_call(id)
         .map(|v| v.to_vec())
         .unwrap_or_default();
 
-    // Take ownership from ParsedExprs
+    // Take ownership from ParsedExprs (already unwrapped from ChainExpression)
     let expr = ctx.parsed.exprs.remove(&id)
         .expect("render tag expression should be pre-parsed");
 
@@ -33,24 +39,29 @@ pub(crate) fn gen_render_tag<'a>(
         return;
     };
 
-    // Get callee text from original source (spans are 0-based relative to expression source)
+    // Extract callee text from original source for non-dynamic path
+    // (non-dynamic callees are normal bindings that haven't been transformed)
     let callee_span = call.callee.span();
     let callee_text = &full_source[callee_span.start as usize..callee_span.end as usize];
 
     let prop_sources = ctx.analysis.render_tag_prop_sources(id);
 
-    let mut call_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor_expr)];
+    // Unbox to separate callee expression and arguments
+    let unboxed = call.unbox();
+    let callee_expr = unboxed.callee;
+
+    // Build argument thunks (shared between dynamic and non-dynamic paths)
+    let mut arg_thunks: Vec<Arg<'a, '_>> = Vec::new();
     let mut memo_counter: u32 = 0;
     let mut memo_stmts: Vec<Statement<'a>> = Vec::new();
 
-    // Wrap each argument in a thunk () => arg
-    for (i, arg) in call.unbox().arguments.into_iter().enumerate() {
+    for (i, arg) in unboxed.arguments.into_iter().enumerate() {
         let arg_expr = arg.into_expression();
 
         // Prop-source args: pass the getter identifier directly without a thunk
         if let Some(Some(sym_id)) = prop_sources.and_then(|ps| ps.get(i)) {
             let name = ctx.analysis.scoping.symbol_name(*sym_id);
-            call_args.push(Arg::Expr(ctx.b.rid_expr(name)));
+            arg_thunks.push(Arg::Expr(ctx.b.rid_expr(name)));
             continue;
         }
 
@@ -65,19 +76,65 @@ pub(crate) fn gen_render_tag<'a>(
             let memo_ref = ctx.b.alloc_str(&memo_name);
             let get = ctx.b.call_expr("$.get", [Arg::Ident(memo_ref)]);
             let thunk = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(get)]);
-            call_args.push(Arg::Expr(thunk));
+            arg_thunks.push(Arg::Expr(thunk));
         } else {
             let thunk = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(arg_expr)]);
-            call_args.push(Arg::Expr(thunk));
+            arg_thunks.push(Arg::Expr(thunk));
         }
     }
 
-    let call_stmt = ctx.b.call_stmt(callee_text, call_args);
+    let final_stmt = if is_dynamic {
+        // Dynamic callee: $.snippet(anchor, callee_getter, ...args)
+        // Use the already-transformed callee expression from the AST:
+        // - Prop-source: show → show() (by transform), thunk → show (by unthunk)
+        // - Snippet param: inner → inner() (by transform), thunk → inner (by unthunk)
+        // - $state: show → $.get(show) (by transform), thunk → () => $.get(show)
+        let callee_arg = build_dynamic_callee(ctx, callee_expr, is_chain, callee_is_getter);
+
+        let mut snippet_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor_expr), Arg::Expr(callee_arg)];
+        snippet_args.extend(arg_thunks);
+
+        ctx.b.call_stmt("$.snippet", snippet_args)
+    } else if is_chain {
+        // Non-dynamic optional: callee?.(anchor, ...args)
+        let callee_expr = ctx.b.rid_expr(callee_text);
+        let mut all_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor_expr)];
+        all_args.extend(arg_thunks);
+        let call_expr = ctx.b.maybe_call_expr(callee_expr, all_args);
+        ctx.b.expr_stmt(call_expr)
+    } else {
+        // Non-dynamic regular: callee(anchor, ...args)
+        let mut all_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor_expr)];
+        all_args.extend(arg_thunks);
+        ctx.b.call_stmt(callee_text, all_args)
+    };
 
     if memo_stmts.is_empty() {
-        stmts.push(call_stmt);
+        stmts.push(final_stmt);
     } else {
-        memo_stmts.push(call_stmt);
+        memo_stmts.push(final_stmt);
         stmts.push(ctx.b.block_stmt(memo_stmts));
+    }
+}
+
+/// Build the callee argument for `$.snippet()`.
+///
+/// Uses the already-transformed callee expression from the AST.
+/// Getter callees produce `thunk(callee_expr)` which unthunks `() => f()` to `f`.
+/// Non-getter callees produce `thunk(callee_expr)` = `() => $.get(x)`.
+/// Optional chaining adds `?? $.noop`.
+fn build_dynamic_callee<'a>(
+    ctx: &mut Ctx<'a>,
+    callee_expr: Expression<'a>,
+    is_chain: bool,
+    _callee_is_getter: bool,
+) -> Expression<'a> {
+    if is_chain {
+        // Optional: () => callee_expr ?? $.noop
+        let coalesced = ctx.b.logical_coalesce(callee_expr, ctx.b.rid_expr("$.noop"));
+        ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(coalesced)])
+    } else {
+        // Regular: thunk(callee_expr) — unthunk optimizes () => f() to f
+        ctx.b.thunk(callee_expr)
     }
 }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -278,8 +278,10 @@ impl<'a> VisitMut<'a> for ExprTransformer<'a, '_, '_> {
                 == self.ctx.analysis.scoping.root_scope_id();
 
             if !is_root {
-                if self.ctx.analysis.scoping.is_arrow_param(sym_id) {
-                    // Arrow function parameter — leave as-is
+                if self.ctx.analysis.scoping.is_arrow_param(sym_id)
+                    || self.ctx.analysis.scoping.is_snippet_name(sym_id)
+                {
+                    // Arrow function parameter or template snippet name — leave as-is
                 } else if self.ctx.analysis.scoping.is_snippet_param(sym_id) {
                     *it = rune_refs::make_thunk_call(self.ctx.alloc, name);
                 } else {

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_prop/case-rust.js
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_prop/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	let show = $.prop($$props, "show", 3, null);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.snippet(node, show, () => "hello");
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_prop/case-svelte.js
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_prop/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	let show = $.prop($$props, "show", 3, null);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.snippet(node, show, () => "hello");
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_prop/case.svelte
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_prop/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { show = null } = $props();
+</script>
+
+{@render show("hello")}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_snippet_param/case-rust.js
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_snippet_param/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+const wrapper = ($$anchor, inner = $.noop) => {
+	var div = root_1();
+	var node = $.child(div);
+	$.snippet(node, inner);
+	$.reset(div);
+	$.append($$anchor, div);
+};
+const greeting = ($$anchor) => {
+	var p = root_2();
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<div><!></div>`);
+var root_2 = $.from_html(`<p>Hello</p>`);
+export default function App($$anchor) {
+	let msg = "hi";
+	wrapper($$anchor, () => greeting);
+}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_snippet_param/case-svelte.js
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_snippet_param/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+const wrapper = ($$anchor, inner = $.noop) => {
+	var div = root_1();
+	var node = $.child(div);
+	$.snippet(node, inner);
+	$.reset(div);
+	$.append($$anchor, div);
+};
+const greeting = ($$anchor) => {
+	var p = root_2();
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<div><!></div>`);
+var root_2 = $.from_html(`<p>Hello</p>`);
+export default function App($$anchor) {
+	let msg = "hi";
+	wrapper($$anchor, () => greeting);
+}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_snippet_param/case.svelte
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_snippet_param/case.svelte
@@ -1,0 +1,13 @@
+<script>
+	let msg = $state("hi");
+</script>
+
+{#snippet wrapper(inner)}
+	<div>{@render inner()}</div>
+{/snippet}
+
+{#snippet greeting()}
+	<p>Hello</p>
+{/snippet}
+
+{@render wrapper(greeting)}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_state/case-rust.js
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_state/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+const greeting = ($$anchor, name = $.noop) => {
+	var p = root_1();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `Hello ${name() ?? ""}`));
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let show = null;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.snippet(node, () => show);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_state/case-svelte.js
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_state/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+const greeting = ($$anchor, name = $.noop) => {
+	var p = root_1();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `Hello ${name() ?? ""}`));
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let show = null;
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.snippet(node, () => show);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/render_tag_dynamic_state/case.svelte
+++ b/tasks/compiler_tests/cases2/render_tag_dynamic_state/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let show = $state(null);
+</script>
+
+{#snippet greeting(name)}
+	<p>Hello {name}</p>
+{/snippet}
+
+{@render show()}

--- a/tasks/compiler_tests/cases2/render_tag_optional/case-rust.js
+++ b/tasks/compiler_tests/cases2/render_tag_optional/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+const greeting = ($$anchor) => {
+	var p = root_1();
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<p>Hello</p>`);
+export default function App($$anchor) {
+	greeting?.($$anchor);
+}

--- a/tasks/compiler_tests/cases2/render_tag_optional/case-svelte.js
+++ b/tasks/compiler_tests/cases2/render_tag_optional/case-svelte.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+const greeting = ($$anchor) => {
+	var p = root_1();
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<p>Hello</p>`);
+export default function App($$anchor) {
+	greeting?.($$anchor);
+}

--- a/tasks/compiler_tests/cases2/render_tag_optional/case.svelte
+++ b/tasks/compiler_tests/cases2/render_tag_optional/case.svelte
@@ -1,0 +1,5 @@
+{#snippet greeting()}
+	<p>Hello</p>
+{/snippet}
+
+{@render greeting?.()}

--- a/tasks/compiler_tests/cases2/render_tag_optional_dynamic/case-rust.js
+++ b/tasks/compiler_tests/cases2/render_tag_optional_dynamic/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	let show = $.prop($$props, "show", 3, null);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.snippet(node, () => show() ?? $.noop, () => "hello");
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/render_tag_optional_dynamic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/render_tag_optional_dynamic/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	let show = $.prop($$props, "show", 3, null);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.snippet(node, () => show() ?? $.noop, () => "hello");
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/render_tag_optional_dynamic/case.svelte
+++ b/tasks/compiler_tests/cases2/render_tag_optional_dynamic/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { show = null } = $props();
+</script>
+
+{@render show?.("hello")}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1257,6 +1257,31 @@ fn render_tag_arg_mixed() {
     assert_compiler("render_tag_arg_mixed");
 }
 
+#[rstest]
+fn render_tag_dynamic_prop() {
+    assert_compiler("render_tag_dynamic_prop");
+}
+
+#[rstest]
+fn render_tag_dynamic_state() {
+    assert_compiler("render_tag_dynamic_state");
+}
+
+#[rstest]
+fn render_tag_dynamic_snippet_param() {
+    assert_compiler("render_tag_dynamic_snippet_param");
+}
+
+#[rstest]
+fn render_tag_optional() {
+    assert_compiler("render_tag_optional");
+}
+
+#[rstest]
+fn render_tag_optional_dynamic() {
+    assert_compiler("render_tag_optional_dynamic");
+}
+
 // ---------------------------------------------------------------------------
 // $inspect rune tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add support for dynamic snippet callees (`$.snippet()`) when the callee
is a non-normal binding (prop, $state, snippet param, each var) and
optional chaining (`{@render fn?.()}`) with `?.()` or `?? $.noop`.

Key changes:
- Analysis: detect dynamic callees via `is_normal_binding()`, track
  chain expressions, resolve callee SymbolIds in correct template scope
- Scoping: register snippet names as bindings with `mark_snippet_name`
  so they're found by `find_binding` but skipped by transform
- Codegen: use transformed callee expression directly (handles prop
  `show()` → unthunk → `show`), wrap dynamic tags in `$.comment()`
- Transform: skip snippet name identifiers (not reactive variables)

5 new test cases: render_tag_dynamic_prop, render_tag_dynamic_state,
render_tag_dynamic_snippet_param, render_tag_optional,
render_tag_optional_dynamic

https://claude.ai/code/session_016HWxC5ts1mGAGN15ueJq2f