### PR TITLE
Move analysis types (ExpressionInfo, Reference, ReferenceFlags, ExpressionKind) from svelte_parser to svelte_analyze

### DIFF
--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -528,12 +528,14 @@ pub struct AnalysisData {
 }
 
 impl AnalysisData {
-    pub fn new() -> Self {
+    /// Create AnalysisData with all fields defaulted.
+    /// `scoping` is left uninitialized — caller must assign it before use.
+    pub(crate) fn new_empty() -> Self {
         Self {
             expressions: FxHashMap::default(),
             attr_expressions: FxHashMap::default(),
             script: None,
-            scoping: ComponentScoping::empty(),
+            scoping: ComponentScoping::new(None),
             dynamic_nodes: FxHashSet::default(),
             alt_is_elseif: FxHashSet::default(),
             props: None,

--- a/crates/svelte_analyze/src/js_analyze.rs
+++ b/crates/svelte_analyze/src/js_analyze.rs
@@ -13,7 +13,6 @@ use svelte_ast::{Component, Fragment, Node, NodeId};
 use crate::data::{
     AnalysisData, ExpressionInfo, ExpressionKind, ParsedExprs, Reference, ReferenceFlags,
 };
-use crate::scope::ComponentScoping;
 
 // ---------------------------------------------------------------------------
 // Entry-point functions (called from analyze pipeline)
@@ -21,12 +20,13 @@ use crate::scope::ComponentScoping;
 
 /// Enrich pre-extracted ScriptInfo with semantic data and build Scoping.
 /// `script_info` comes from `JsParseResult` (extracted by parser).
+/// Returns the OXC Scoping for the script block.
 pub(crate) fn analyze_script(
     parsed: &ParsedExprs<'_>,
     data: &mut AnalysisData,
     mut script_info: ScriptInfo,
-) {
-    let Some(ref program) = parsed.script_program else { return };
+) -> Option<oxc_semantic::Scoping> {
+    let Some(ref program) = parsed.script_program else { return None };
 
     let sem = oxc_semantic::SemanticBuilder::new().build(program);
     svelte_parser::script_info::enrich_from_unresolved(&sem.semantic.scoping(), &mut script_info);
@@ -43,8 +43,8 @@ pub(crate) fn analyze_script(
     data.exports = std::mem::take(&mut script_info.exports);
     data.needs_context = script_info.has_effects || script_info.has_class_state_fields;
     data.has_class_state_fields = script_info.has_class_state_fields;
-    data.scoping = ComponentScoping::from_scoping(sem.semantic.into_scoping());
     data.script = Some(script_info);
+    Some(sem.semantic.into_scoping())
 }
 
 /// Extract ExpressionInfo for all parsed template and attribute expressions.

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -48,16 +48,17 @@ pub fn analyze_with_options<'a>(
     js_result: JsParseResult<'a>,
     custom_element: bool,
 ) -> (AnalysisData, ParsedExprs<'a>, Vec<Diagnostic>) {
-    let mut data = AnalysisData::new();
-    data.custom_element = custom_element;
     let mut diags = Vec::new();
+
+    let mut data = AnalysisData::new_empty();
+    data.custom_element = custom_element;
 
     let (parsed, script_info) = ingest_js_result(js_result, &mut data);
 
-    // JS analysis passes (before scoping)
-    if let Some(script_info) = script_info {
-        js_analyze::analyze_script(&parsed, &mut data, script_info);
-    }
+    // JS analysis: enrich script info and extract OXC Scoping
+    let script_scoping = script_info
+        .and_then(|si| js_analyze::analyze_script(&parsed, &mut data, si));
+    data.scoping = ComponentScoping::new(script_scoping);
     js_analyze::extract_all_expressions(&parsed, &mut data);
     js_analyze::compute_each_index_usage(&parsed, component, &mut data);
     js_analyze::compute_render_tag_args(&parsed, &mut data);
@@ -153,12 +154,12 @@ fn ingest_js_result<'a>(
 /// no fragment classification — modules are pure JS with rune transforms.
 pub fn analyze_module(source: &str, is_ts: bool, dev: bool) -> (AnalysisData, Vec<Diagnostic>) {
     let _ = dev; // reserved for future dev-mode analysis (e.g. $inspect.trace labels)
-    let mut data = AnalysisData::new();
     let mut diags = Vec::new();
 
+    let mut data = AnalysisData::new_empty();
     match svelte_parser::parse_module(source, is_ts) {
         Ok((script_info, scoping)) => {
-            data.scoping = scope::ComponentScoping::from_scoping(scoping);
+            data.scoping = scope::ComponentScoping::new(Some(scoping));
 
             // Mark runes from script declarations
             for decl in &script_info.declarations {

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -68,7 +68,12 @@ impl ComponentScoping {
 
     /// Create an empty scoping (no script block).
     pub fn empty() -> Self {
-        Self::from_scoping(Scoping::default())
+        let mut scoping = Scoping::default();
+        // Scoping::default() has no scopes at all, but root_scope_id() returns ScopeId(0).
+        // We must add a root scope so that ScopeId(0) exists and add_child_scope doesn't
+        // create a self-referential parent pointer (which causes infinite loops in find_binding).
+        scoping.add_scope(None, OxcNodeId::DUMMY, ScopeFlags::empty());
+        Self::from_scoping(scoping)
     }
 
     // -- Scope management --

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -45,8 +45,18 @@ pub struct ComponentScoping {
 }
 
 impl ComponentScoping {
-    /// Create from a pre-built OXC Scoping (produced by `analyze_script_with_scoping`).
-    pub fn from_scoping(scoping: Scoping) -> Self {
+    /// Create ComponentScoping from an optional OXC Scoping.
+    ///
+    /// - `Some(scoping)` — script block was parsed, use its scope tree (already has a root scope).
+    /// - `None` — no script block; creates a minimal Scoping with just a root scope.
+    pub fn new(scoping: Option<Scoping>) -> Self {
+        let scoping = scoping.unwrap_or_else(|| {
+            let mut s = Scoping::default();
+            // Scoping::default() has no scopes, but root_scope_id() returns ScopeId(0).
+            // Add a root scope so ScopeId(0) exists and child scopes get a valid parent.
+            s.add_scope(None, OxcNodeId::DUMMY, ScopeFlags::empty());
+            s
+        });
         Self {
             scoping,
             runes: FxHashMap::default(),
@@ -64,16 +74,6 @@ impl ComponentScoping {
             const_alias_tags: FxHashMap::default(),
             arrow_scopes: FxHashMap::default(),
         }
-    }
-
-    /// Create an empty scoping (no script block).
-    pub fn empty() -> Self {
-        let mut scoping = Scoping::default();
-        // Scoping::default() has no scopes at all, but root_scope_id() returns ScopeId(0).
-        // We must add a root scope so that ScopeId(0) exists and add_child_scope doesn't
-        // create a self-referential parent pointer (which causes infinite loops in find_binding).
-        scoping.add_scope(None, OxcNodeId::DUMMY, ScopeFlags::empty());
-        Self::from_scoping(scoping)
     }
 
     // -- Scope management --


### PR DESCRIPTION
These types are created and consumed entirely within svelte_analyze — the parser
never constructs them. Having them in svelte_parser pulled in oxc_semantic::SymbolId
as a parser dependency, violating the architectural boundary where symbol resolution
belongs to the analysis phase.

https://claude.ai/code/session_011CyDZJditCRUaqamxu7v7o