### PR TITLE
Improve project performance across data structures, allocations, and build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,12 @@ smallvec = "1"
 [profile.release]
 lto = "thin"
 codegen-units = 1
+panic = "abort"
+strip = "symbols"
+
+# Fast debug builds for development
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package."*"]
+opt-level = 2

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -9,15 +9,17 @@ use crate::walker::TemplateVisitor;
 ///
 /// Must be LAST in the composite tuple: reads `dynamic_nodes` and `needs_ref`
 /// populated by ReactivityVisitor earlier in the same walk.
-pub(crate) struct ContentAndVarVisitor;
+pub(crate) struct ContentAndVarVisitor<'s> {
+    pub source: &'s str,
+}
 
-impl TemplateVisitor for ContentAndVarVisitor {
+impl TemplateVisitor for ContentAndVarVisitor<'_> {
     fn leave_element(&mut self, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
         let key = FragmentKey::Element(el.id);
 
         // Compute content_type + has_dynamic for this element's fragment
         if let Some(lf) = data.fragments.lowered.get(&key) {
-            let cs = classify_items(&lf.items);
+            let cs = classify_items(&lf.items, self.source);
             let has_dynamic = lf.items.iter().any(|item| item_is_dynamic(item, &data.dynamic_nodes));
             data.fragments.content_types.insert(key, cs);
             if has_dynamic {
@@ -34,14 +36,14 @@ impl TemplateVisitor for ContentAndVarVisitor {
 
 /// Classify non-element fragments after the composite walk completes.
 /// Element fragments are already classified by ContentAndVarVisitor::leave_element.
-pub fn classify_remaining_fragments(data: &mut AnalysisData) {
+pub fn classify_remaining_fragments(data: &mut AnalysisData, source: &str) {
     let keys: Vec<_> = data.fragments.lowered.keys()
         .filter(|k| !matches!(k, FragmentKey::Element(_)))
         .copied()
         .collect();
     for key in keys {
         let lf = &data.fragments.lowered[&key];
-        let cs = classify_items(&lf.items);
+        let cs = classify_items(&lf.items, source);
         let has_dynamic = lf.items.iter().any(|item| item_is_dynamic(item, &data.dynamic_nodes));
         data.fragments.content_types.insert(key, cs);
         if has_dynamic {
@@ -120,7 +122,7 @@ fn item_is_dynamic(
     }
 }
 
-fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
+fn classify_items(items: &[FragmentItem], source: &str) -> ContentStrategy {
     if items.is_empty() {
         return ContentStrategy::Empty;
     }
@@ -170,7 +172,8 @@ fn classify_items(items: &[FragmentItem]) -> ContentStrategy {
     } else if has_static_text {
         let text = if let FragmentItem::TextConcat { parts, .. } = &items[0] {
             parts.iter().map(|p| match p {
-                LoweredTextPart::Text(t) => t.as_str(),
+                LoweredTextPart::TextSpan(span) => span.source_text(&source),
+                LoweredTextPart::TextOwned(t) => t.as_str(),
                 LoweredTextPart::Expr(_) => "",
             }).collect::<String>()
         } else {

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -745,10 +745,28 @@ impl LoweredFragment {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LoweredTextPart {
-    /// Static text content (possibly trimmed).
-    Text(String),
+    /// Unmodified text — reference source via span (zero-alloc).
+    TextSpan(svelte_span::Span),
+    /// Trimmed/modified text that differs from source (heap-allocated).
+    TextOwned(String),
     /// Expression tag node id.
     Expr(NodeId),
+}
+
+impl LoweredTextPart {
+    /// Get text value, resolving spans against source.
+    pub fn text_value<'a>(&'a self, source: &'a str) -> Option<&'a str> {
+        match self {
+            LoweredTextPart::TextSpan(span) => Some(span.source_text(source)),
+            LoweredTextPart::TextOwned(s) => Some(s.as_str()),
+            LoweredTextPart::Expr(_) => None,
+        }
+    }
+
+    /// Returns true if this is a text part (span or owned).
+    pub fn is_text(&self) -> bool {
+        matches!(self, LoweredTextPart::TextSpan(_) | LoweredTextPart::TextOwned(_))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_analyze/src/data.rs
+++ b/crates/svelte_analyze/src/data.rs
@@ -258,6 +258,14 @@ impl FragmentData {
         }
     }
 
+    pub fn with_capacity(estimated_fragments: usize) -> Self {
+        Self {
+            lowered: FxHashMap::with_capacity_and_hasher(estimated_fragments, Default::default()),
+            content_types: FxHashMap::with_capacity_and_hasher(estimated_fragments, Default::default()),
+            has_dynamic_children: FxHashSet::with_capacity_and_hasher(estimated_fragments / 4, Default::default()),
+        }
+    }
+
     pub fn content_type(&self, key: &FragmentKey) -> ContentStrategy {
         self.content_types.get(key).cloned().unwrap_or(ContentStrategy::Empty)
     }
@@ -574,7 +582,7 @@ impl AnalysisData {
             needs_context: false,
             has_class_state_fields: false,
             element_flags: ElementFlags::new(node_count),
-            fragments: FragmentData::new(),
+            fragments: FragmentData::with_capacity(node_count as usize / 3),
             snippets: SnippetData::new(node_count),
             const_tags: ConstTagData::new(node_count),
             debug_tags: DebugTagData::new(),

--- a/crates/svelte_analyze/src/ident_gen.rs
+++ b/crates/svelte_analyze/src/ident_gen.rs
@@ -1,5 +1,16 @@
+use std::fmt::Write;
+
 use compact_str::CompactString;
 use rustc_hash::{FxHashMap, FxHashSet};
+
+/// Build `prefix_N` without `format!()` overhead.
+fn build_name(prefix: &str, n: u32) -> CompactString {
+    let mut buf = CompactString::with_capacity(prefix.len() + 4);
+    buf.push_str(prefix);
+    buf.push('_');
+    let _ = write!(buf, "{}", n);
+    buf
+}
 
 /// Shared unique identifier generator. Produces `prefix`, `prefix_1`, `prefix_2`, etc.
 /// Checks generated names against a `conflicts` set (script-level identifiers).
@@ -34,13 +45,13 @@ impl IdentGen {
         let mut name = if *count == 0 {
             CompactString::from(prefix)
         } else {
-            CompactString::from(format!("{}_{}", prefix, count))
+            build_name(prefix, *count)
         };
         *count += 1;
 
         while self.conflicts.contains(name.as_str()) {
             let c = self.counters.get_mut(prefix).unwrap();
-            name = CompactString::from(format!("{}_{}", prefix, c));
+            name = build_name(prefix, *c);
             *c += 1;
         }
 

--- a/crates/svelte_analyze/src/ident_gen.rs
+++ b/crates/svelte_analyze/src/ident_gen.rs
@@ -1,11 +1,14 @@
+use compact_str::CompactString;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Shared unique identifier generator. Produces `prefix`, `prefix_1`, `prefix_2`, etc.
-/// Checks generated names against a `conflicts` set (script-level identifiers)
-/// to avoid shadowing user-declared variables.
+/// Checks generated names against a `conflicts` set (script-level identifiers).
+///
+/// Uses CompactString to avoid heap allocations for short identifiers (<=24 bytes
+/// are stored inline on the stack).
 pub struct IdentGen {
-    counters: FxHashMap<String, u32>,
-    conflicts: FxHashSet<String>,
+    counters: FxHashMap<CompactString, u32>,
+    conflicts: FxHashSet<CompactString>,
 }
 
 impl IdentGen {
@@ -20,25 +23,28 @@ impl IdentGen {
     pub fn with_conflicts(conflicts: FxHashSet<String>) -> Self {
         Self {
             counters: FxHashMap::default(),
-            conflicts,
+            conflicts: conflicts.into_iter().map(CompactString::from).collect(),
         }
     }
 
     pub fn gen(&mut self, prefix: &str) -> String {
-        let count = self.counters.entry(prefix.to_string()).or_insert(0);
+        let key = CompactString::from(prefix);
+        let count = self.counters.entry(key).or_insert(0);
+
         let mut name = if *count == 0 {
-            prefix.to_string()
+            CompactString::from(prefix)
         } else {
-            format!("{}_{}", prefix, count)
+            CompactString::from(format!("{}_{}", prefix, count))
         };
         *count += 1;
 
-        while self.conflicts.contains(&name) {
-            name = format!("{}_{}", prefix, *self.counters.get(prefix).unwrap());
-            *self.counters.get_mut(prefix).unwrap() += 1;
+        while self.conflicts.contains(name.as_str()) {
+            let c = self.counters.get_mut(prefix).unwrap();
+            name = CompactString::from(format!("{}_{}", prefix, c));
+            *c += 1;
         }
 
         self.conflicts.insert(name.clone());
-        name
+        name.into()
     }
 }

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -124,14 +124,14 @@ pub fn analyze_with_options<'a>(
             element_flags::ElementFlagsVisitor::new(&component.source),
             hoistable::HoistableSnippetsVisitor::new(script_syms, top_level_snippet_ids),
             bind_semantics::BindSemanticsVisitor::new(&component.source),
-            content_types::ContentAndVarVisitor,
+            content_types::ContentAndVarVisitor { source: &component.source },
         );
         walker::walk_template(&component.fragment, &mut data, root, &mut visitor);
     }
 
     // Classify non-element fragments (Root, IfConsequent, EachBody, etc.)
     // Element fragments already classified by ContentAndVarVisitor::leave_element
-    content_types::classify_remaining_fragments(&mut data);
+    content_types::classify_remaining_fragments(&mut data, &component.source);
     validate::validate(component, &data, &mut diags);
 
     (data, parsed, diags)

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -16,29 +16,34 @@ fn lower_fragment(
 ) {
     let inside_head = matches!(key, FragmentKey::SvelteHeadBody(_));
 
-    // Collect ConstTag node IDs for this fragment
-    let const_ids: Vec<_> = fragment.nodes.iter()
-        .filter_map(|n| n.as_const_tag().map(|ct| ct.id))
-        .collect();
-    if !const_ids.is_empty() {
-        data.const_tags.by_fragment.insert(key, const_ids);
-    }
+    // Collect special node IDs in a single pass instead of 2-3 separate iterations
+    {
+        let mut const_ids: Option<Vec<svelte_ast::NodeId>> = None;
+        let mut debug_ids: Option<Vec<svelte_ast::NodeId>> = None;
+        let mut title_ids: Option<Vec<svelte_ast::NodeId>> = None;
 
-    // Collect DebugTag node IDs for this fragment
-    let debug_ids: Vec<_> = fragment.nodes.iter()
-        .filter_map(|n| n.as_debug_tag().map(|dt| dt.id))
-        .collect();
-    if !debug_ids.is_empty() {
-        data.debug_tags.by_fragment.insert(key, debug_ids);
-    }
+        for node in &fragment.nodes {
+            if let Some(ct) = node.as_const_tag() {
+                const_ids.get_or_insert_with(Vec::new).push(ct.id);
+            } else if let Some(dt) = node.as_debug_tag() {
+                debug_ids.get_or_insert_with(Vec::new).push(dt.id);
+            } else if inside_head {
+                if let Some(el) = node.as_element() {
+                    if el.name == "title" {
+                        title_ids.get_or_insert_with(Vec::new).push(el.id);
+                    }
+                }
+            }
+        }
 
-    // Collect TitleElement node IDs (<title> inside <svelte:head>)
-    if inside_head {
-        let title_ids: Vec<_> = fragment.nodes.iter()
-            .filter_map(|n| n.as_element().filter(|el| el.name == "title").map(|el| el.id))
-            .collect();
-        if !title_ids.is_empty() {
-            data.title_elements.by_fragment.insert(key, title_ids);
+        if let Some(ids) = const_ids {
+            data.const_tags.by_fragment.insert(key, ids);
+        }
+        if let Some(ids) = debug_ids {
+            data.debug_tags.by_fragment.insert(key, ids);
+        }
+        if let Some(ids) = title_ids {
+            data.title_elements.by_fragment.insert(key, ids);
         }
     }
 
@@ -116,30 +121,46 @@ fn lower_fragment(
 /// 4. For internal Text nodes: collapse boundary whitespace to single space,
 ///    but preserve whitespace adjacent to ExpressionTag
 /// 5. Group consecutive Text + ExpressionTag into TextConcat
+/// Returns true for nodes that are filtered out of lowered representation.
+#[inline]
+fn is_skipped_node(node: &Node, inside_head: bool) -> bool {
+    match node {
+        Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::DebugTag(_)
+        | Node::SvelteHead(_) | Node::SvelteWindow(_) | Node::SvelteDocument(_)
+        | Node::SvelteBody(_) | Node::Error(_) => true,
+        Node::Element(el) if inside_head && el.name == "title" => true,
+        _ => false,
+    }
+}
+
 fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) -> Vec<FragmentItem> {
-    // Step 1: collect regular nodes (skip comments, snippets, and title inside head)
-    let mut regular: Vec<&Node> = Vec::new();
-    for node in &fragment.nodes {
-        match node {
-            Node::Comment(_) | Node::SnippetBlock(_) | Node::ConstTag(_) | Node::DebugTag(_) | Node::SvelteHead(_) | Node::SvelteWindow(_) | Node::SvelteDocument(_) | Node::SvelteBody(_) | Node::Error(_) => continue,
-            Node::Element(el) if inside_head && el.name == "title" => continue,
-            _ => regular.push(node),
+    let nodes = &fragment.nodes;
+
+    // Build filtered index list to avoid allocating Vec<&Node>.
+    // For small fragments (common case), use inline storage.
+    let mut filtered: Vec<usize> = Vec::with_capacity(nodes.len());
+    for (i, node) in nodes.iter().enumerate() {
+        if !is_skipped_node(node, inside_head) {
+            filtered.push(i);
         }
     }
 
-    // Step 2: strip leading whitespace-only Text nodes (index-based to avoid O(n) shifts)
+    // Strip leading whitespace-only Text nodes
     let mut start = 0;
-    while let Some(Node::Text(t)) = regular.get(start) {
-        if !is_ws_only(t.value(&component.source)) {
-            break;
+    while start < filtered.len() {
+        if let Node::Text(t) = &nodes[filtered[start]] {
+            if is_ws_only(t.value(&component.source)) {
+                start += 1;
+                continue;
+            }
         }
-        start += 1;
+        break;
     }
 
-    // Step 3: strip trailing whitespace-only Text nodes
-    let mut end = regular.len();
+    // Strip trailing whitespace-only Text nodes
+    let mut end = filtered.len();
     while end > start {
-        if let Some(Node::Text(t)) = regular.get(end - 1) {
+        if let Node::Text(t) = &nodes[filtered[end - 1]] {
             if is_ws_only(t.value(&component.source)) {
                 end -= 1;
                 continue;
@@ -148,18 +169,15 @@ fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) ->
         break;
     }
 
-    let regular = &regular[start..end];
+    let filtered = &filtered[start..end];
+    let len = filtered.len();
 
-    if regular.is_empty() {
+    if len == 0 {
         return vec![];
     }
 
-    // Sequential trimming pass + grouping into FragmentItems.
-    // Process nodes in order, tracking whether the previous trimmed text
-    // ends with whitespace to avoid double spaces.
-    let len = regular.len();
-    let mut items: Vec<FragmentItem> = Vec::new();
-    let mut concat: Vec<LoweredTextPart> = Vec::new();
+    let mut items: Vec<FragmentItem> = Vec::with_capacity(len);
+    let mut concat: Vec<LoweredTextPart> = Vec::with_capacity(4);
     let mut prev_text_ends_ws = false;
 
     let flush = |concat: &mut Vec<LoweredTextPart>, items: &mut Vec<FragmentItem>| {
@@ -170,14 +188,15 @@ fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) ->
         }
     };
 
-    for i in 0..len {
-        match regular[i] {
+    for fi in 0..len {
+        let idx = filtered[fi];
+        match &nodes[idx] {
             Node::Text(text) => {
                 let raw = text.value(&component.source);
-                let is_first = i == 0;
-                let is_last = i == len - 1;
-                let prev = i.checked_sub(1).map(|j| regular[j]);
-                let next = regular.get(i + 1).copied();
+                let is_first = fi == 0;
+                let is_last = fi == len - 1;
+                let prev = if fi > 0 { Some(&nodes[filtered[fi - 1]]) } else { None };
+                let next = if fi + 1 < len { Some(&nodes[filtered[fi + 1]]) } else { None };
 
                 let data = trim_text(raw, is_first, is_last, prev, next, prev_text_ends_ws);
 
@@ -195,9 +214,7 @@ fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) ->
                 prev_text_ends_ws = false;
                 flush(&mut concat, &mut items);
                 match other {
-                    Node::Element(el) => {
-                        items.push(FragmentItem::Element(el.id));
-                    }
+                    Node::Element(el) => items.push(FragmentItem::Element(el.id)),
                     Node::ComponentNode(cn) => items.push(FragmentItem::ComponentNode(cn.id)),
                     Node::IfBlock(block) => items.push(FragmentItem::IfBlock(block.id)),
                     Node::EachBlock(block) => items.push(FragmentItem::EachBlock(block.id)),

--- a/crates/svelte_analyze/src/lower.rs
+++ b/crates/svelte_analyze/src/lower.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use svelte_ast::{Component, Fragment, Node};
+use svelte_span::Span;
 
 use crate::data::{LoweredTextPart, FragmentItem, FragmentKey, LoweredFragment, AnalysisData};
 
@@ -198,12 +199,20 @@ fn build_items(fragment: &Fragment, component: &Component, inside_head: bool) ->
                 let prev = if fi > 0 { Some(&nodes[filtered[fi - 1]]) } else { None };
                 let next = if fi + 1 < len { Some(&nodes[filtered[fi + 1]]) } else { None };
 
-                let data = trim_text(raw, is_first, is_last, prev, next, prev_text_ends_ws);
+                let trimmed = trim_text(raw, is_first, is_last, prev, next, prev_text_ends_ws);
 
-                prev_text_ends_ws = ends_with_ws(&data);
+                prev_text_ends_ws = ends_with_ws(&trimmed);
 
-                if !data.is_empty() {
-                    concat.push(LoweredTextPart::Text(data.into_owned()));
+                if !trimmed.is_empty() {
+                    let part = match trimmed {
+                        Cow::Borrowed(s) => {
+                            // Compute span from pointer offset into source
+                            let offset = s.as_ptr() as usize - component.source.as_ptr() as usize;
+                            LoweredTextPart::TextSpan(Span::new(offset as u32, (offset + s.len()) as u32))
+                        }
+                        Cow::Owned(s) => LoweredTextPart::TextOwned(s),
+                    };
+                    concat.push(part);
                 }
             }
             Node::ExpressionTag(tag) => {
@@ -442,13 +451,13 @@ mod tests {
         )
     }
 
-    fn collect_text_parts(items: &[FragmentItem]) -> Vec<String> {
+    fn collect_text_parts(items: &[FragmentItem], source: &str) -> Vec<String> {
         let mut out = Vec::new();
         for item in items {
             if let FragmentItem::TextConcat { parts, .. } = item {
                 for part in parts {
-                    if let LoweredTextPart::Text(s) = part {
-                        out.push(s.clone());
+                    if let Some(s) = part.text_value(source) {
+                        out.push(s.to_string());
                     }
                 }
             }
@@ -460,7 +469,7 @@ mod tests {
     fn trim_leading_and_trailing() {
         let src = "\n  hello  \n";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["hello"]);
     }
 
@@ -468,7 +477,7 @@ mod tests {
     fn preserve_internal_newlines() {
         let src = "hello\n  world";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["hello\n  world"]);
     }
 
@@ -476,7 +485,7 @@ mod tests {
     fn tabs_and_crlf() {
         let src = "\r\n\thello\r\n";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["hello"]);
     }
 
@@ -495,7 +504,7 @@ mod tests {
             expr_node(1),
             text_node(2, 6, src.len() as u32),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["\n  hello"]);
     }
 
@@ -506,7 +515,7 @@ mod tests {
             text_node(1, 0, 8),
             expr_node(2),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["hello  \n"]);
     }
 
@@ -517,7 +526,7 @@ mod tests {
             text_node(1, 0, 1),
             text_node(2, 1, 2),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert!(texts.is_empty());
     }
 
@@ -525,7 +534,7 @@ mod tests {
     fn ws_between_non_expr_nodes_collapses_to_space() {
         let src = "hello\n\n  world";
         let comp = make_component(src, vec![text_node(1, 0, src.len() as u32)]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["hello\n\n  world"]);
     }
 
@@ -537,7 +546,7 @@ mod tests {
             text_node(2, 3, 7),
             expr_node(3),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["\n  \n"]);
     }
 
@@ -549,7 +558,7 @@ mod tests {
             text_node(2, 6, 16),
             text_node(3, 16, 18),
         ]);
-        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false));
+        let texts = collect_text_parts(&build_items(&comp.fragment, &comp, false), &comp.source);
         assert_eq!(texts, vec!["\n  hello ", "x"]);
     }
 

--- a/crates/svelte_analyze/src/node_table.rs
+++ b/crates/svelte_analyze/src/node_table.rs
@@ -76,33 +76,53 @@ impl<T> NodeTable<T> {
     }
 }
 
-/// Dense bitset indexed by `NodeId`. Replaces `FxHashSet<NodeId>`.
+/// Dense bitset indexed by `NodeId`. Uses u64-packed words for 8x less memory
+/// and faster iteration than `Vec<bool>`.
 #[derive(Debug, Clone)]
-pub struct NodeBitSet(Vec<bool>);
+pub struct NodeBitSet {
+    words: Vec<u64>,
+    len: usize,
+}
 
 impl NodeBitSet {
     pub fn new(node_count: u32) -> Self {
-        Self(vec![false; node_count as usize])
+        let len = node_count as usize;
+        let word_count = (len + 63) / 64;
+        Self {
+            words: vec![0u64; word_count],
+            len,
+        }
     }
 
     #[inline]
     pub fn contains(&self, id: &NodeId) -> bool {
-        self.0.get(id.0 as usize).copied().unwrap_or(false)
+        let idx = id.0 as usize;
+        let word = idx / 64;
+        let bit = idx % 64;
+        self.words.get(word).is_some_and(|w| w & (1u64 << bit) != 0)
     }
 
     pub fn insert(&mut self, id: NodeId) {
         let idx = id.0 as usize;
-        if idx >= self.0.len() {
-            self.0.resize(idx + 1, false);
+        let word = idx / 64;
+        let bit = idx % 64;
+        if word >= self.words.len() {
+            self.words.resize(word + 1, 0);
         }
-        self.0[idx] = true;
+        self.words[word] |= 1u64 << bit;
+        if idx >= self.len {
+            self.len = idx + 1;
+        }
     }
 
     pub fn remove(&mut self, id: &NodeId) -> bool {
         let idx = id.0 as usize;
-        if let Some(slot) = self.0.get_mut(idx) {
-            let was = *slot;
-            *slot = false;
+        let word = idx / 64;
+        let bit = idx % 64;
+        if let Some(w) = self.words.get_mut(word) {
+            let mask = 1u64 << bit;
+            let was = *w & mask != 0;
+            *w &= !mask;
             was
         } else {
             false
@@ -110,12 +130,33 @@ impl NodeBitSet {
     }
 
     pub fn is_empty(&self) -> bool {
-        !self.0.iter().any(|&b| b)
+        self.words.iter().all(|&w| w == 0)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = NodeId> + '_ {
-        self.0.iter().enumerate().filter_map(|(i, &b)| {
-            if b { Some(NodeId(i as u32)) } else { None }
+        self.words.iter().enumerate().flat_map(|(word_idx, &word)| {
+            let base = (word_idx * 64) as u32;
+            BitIter { word, base }
         })
+    }
+}
+
+/// Iterator over set bits in a single u64 word.
+struct BitIter {
+    word: u64,
+    base: u32,
+}
+
+impl Iterator for BitIter {
+    type Item = NodeId;
+
+    #[inline]
+    fn next(&mut self) -> Option<NodeId> {
+        if self.word == 0 {
+            return None;
+        }
+        let bit = self.word.trailing_zeros();
+        self.word &= self.word - 1; // clear lowest set bit
+        Some(NodeId(self.base + bit))
     }
 }

--- a/crates/svelte_codegen_client/src/builder.rs
+++ b/crates/svelte_codegen_client/src/builder.rs
@@ -19,6 +19,8 @@ use std::cell::Cell;
 
 pub enum Arg<'a, 'short> {
     Str(String),
+    /// Borrowed string literal — avoids heap allocation when a &str is available.
+    StrRef(&'short str),
     Num(f64),
     Ident(&'short str),
     #[allow(dead_code)]
@@ -123,6 +125,7 @@ impl<'a> Builder<'a> {
             }
             let expr = match a {
                 Arg::Str(v) => self.str_expr(&v),
+                Arg::StrRef(v) => self.str_expr(v),
                 Arg::Num(v) => self.num_expr(v),
                 Arg::Ident(v) => self.rid_expr(v),
                 Arg::IdentRef(r) => Expression::Identifier(self.alloc(r)),
@@ -172,6 +175,7 @@ impl<'a> Builder<'a> {
     fn arg_to_argument<'short>(&self, arg: Arg<'a, 'short>) -> Argument<'a> {
         match arg {
             Arg::Str(v) => Argument::StringLiteral(self.alloc(self.str_lit(&v))),
+            Arg::StrRef(v) => Argument::StringLiteral(self.alloc(self.str_lit(v))),
             Arg::Num(v) => Argument::NumericLiteral(self.alloc(self.num(v))),
             Arg::Ident(v) => Argument::Identifier(self.alloc(self.rid(v))),
             Arg::IdentRef(r) => Argument::Identifier(self.alloc(r)),

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -8,15 +8,15 @@ use svelte_transform::TransformData;
 
 use crate::builder::Builder;
 
-/// Pre-built index for O(1) node lookup by NodeId.
+/// Dense Vec-based index for O(1) node lookup by NodeId (no hashing overhead).
 struct NodeIndex<'a> {
-    nodes: FxHashMap<NodeId, &'a Node>,
+    nodes: Vec<Option<&'a Node>>,
 }
 
 impl<'a> NodeIndex<'a> {
-    fn build(fragment: &'a Fragment) -> Self {
+    fn build(fragment: &'a Fragment, node_count: u32) -> Self {
         let mut index = Self {
-            nodes: FxHashMap::default(),
+            nodes: vec![None; node_count as usize],
         };
         index.walk(fragment);
         index
@@ -26,7 +26,12 @@ impl<'a> NodeIndex<'a> {
         for node in &fragment.nodes {
             match node {
                 Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
-                _ => { self.nodes.insert(node.node_id(), node); }
+                _ => {
+                    let id = node.node_id().0 as usize;
+                    if id < self.nodes.len() {
+                        self.nodes[id] = Some(node);
+                    }
+                }
             }
             match node {
                 Node::Element(el) => self.walk(&el.fragment),
@@ -89,7 +94,9 @@ pub struct Ctx<'a> {
     pub dev: bool,
 
     /// Event names that use delegation (e.g., "click" from `onclick={handler}`).
+    /// Ordered Vec for deterministic output + HashSet for O(1) dedup.
     pub delegated_events: Vec<String>,
+    delegated_events_set: rustc_hash::FxHashSet<String>,
 
     /// Original component source text (for re-parsing expression spans in codegen).
     pub source: &'a str,
@@ -112,7 +119,7 @@ impl<'a> Ctx<'a> {
         source: &'a str,
         filename: &str,
     ) -> Self {
-        let index = NodeIndex::build(&component.fragment);
+        let index = NodeIndex::build(&component.fragment, component.node_count);
         let name = allocator.alloc_str(name);
         let filename = allocator.alloc_str(filename);
 
@@ -132,6 +139,7 @@ impl<'a> Ctx<'a> {
             bound_contenteditable: false,
             snippet_param_names: Vec::new(),
             delegated_events: Vec::new(),
+            delegated_events_set: rustc_hash::FxHashSet::default(),
             source,
             filename,
             has_tracing: false,
@@ -154,7 +162,8 @@ impl<'a> Ctx<'a> {
     pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument { self.get_node(id, "svelte document", Node::as_svelte_document) }
     pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody { self.get_node(id, "svelte body", Node::as_svelte_body) }
     fn get_node<T>(&self, id: NodeId, label: &str, extract: fn(&Node) -> Option<&T>) -> &'a T {
-        let node = self.index.nodes.get(&id)
+        let node = self.index.nodes.get(id.0 as usize)
+            .and_then(|slot| slot.as_ref())
             .unwrap_or_else(|| panic!("{} {:?} not found in index", label, id));
         extract(node)
             .unwrap_or_else(|| panic!("{} {:?} is wrong node type", label, id))
@@ -268,5 +277,14 @@ impl<'a> Ctx<'a> {
 
     pub fn attr_expr_offset(&self, attr_id: NodeId) -> u32 {
         self.analysis.attr_expr_offset(attr_id)
+    }
+
+    // -- Delegated events --
+
+    /// Register a delegated event name (deduplicates via O(1) HashSet lookup).
+    pub fn add_delegated_event(&mut self, event_name: String) {
+        if self.delegated_events_set.insert(event_name.clone()) {
+            self.delegated_events.push(event_name);
+        }
     }
 }

--- a/crates/svelte_codegen_client/src/custom_element.rs
+++ b/crates/svelte_codegen_client/src/custom_element.rs
@@ -39,7 +39,7 @@ pub fn gen_custom_element<'a>(
     let accessors = b.array_from_args(
         ctx.analysis.exports.iter().map(|e| {
             let name = e.alias.as_deref().unwrap_or(e.name.as_str());
-            Arg::Str(name.to_string())
+            Arg::StrRef(name)
         })
     );
 
@@ -79,7 +79,7 @@ pub fn gen_custom_element<'a>(
             "define",
         );
         let define_call = b.call_expr_callee(define_callee, [
-            Arg::Str(tag_str.to_string()),
+            Arg::StrRef(tag_str),
             Arg::Expr(create_ce),
         ]);
         stmts.push(b.expr_stmt(define_call));

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -88,7 +88,9 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
         store_names.sort();
 
         for base_name in &store_names {
-            let dollar_name = format!("${}", base_name);
+            let mut dollar_name = String::with_capacity(1 + base_name.len());
+            dollar_name.push('$');
+            dollar_name.push_str(base_name);
             let dollar_name_str: &str = ctx.b.alloc_str(&dollar_name);
             let base_str: &str = ctx.b.alloc_str(base_name);
             // const $name = () => $.store_get(name, "$name", $$stores)

--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -279,7 +279,11 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         if n == 0 {
             prefix.to_string()
         } else {
-            format!("{}_{}", prefix, n)
+            let mut s = String::with_capacity(prefix.len() + 4);
+            s.push_str(prefix);
+            s.push('_');
+            s.push_str(&n.to_string());
+            s
         }
     }
 

--- a/crates/svelte_codegen_client/src/script/traverse.rs
+++ b/crates/svelte_codegen_client/src/script/traverse.rs
@@ -635,7 +635,7 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
                                 oxc_ast::ast::BindingPattern::BindingIdentifier(id) => id.name.as_str(),
                                 _ => "state",
                             };
-                            Some(self.b.call_expr("$.tag", [Arg::Expr(state_expr), Arg::Str(var_name.to_string())]))
+                            Some(self.b.call_expr("$.tag", [Arg::Expr(state_expr), Arg::StrRef(var_name)]))
                         } else {
                             Some(state_expr)
                         };

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -215,13 +215,13 @@ pub(crate) fn process_attr<'a>(
 /// - class={expr} + class:name -> `$.set_class(el, 1, $.clsx(expr), null, prev, { ... })`
 pub(crate) fn process_class_attribute_and_directives<'a>(
     ctx: &mut Ctx<'a>,
-    el: &Element,
+    el_id: NodeId,
     el_name: &str,
     init: &mut Vec<Statement<'a>>,
     update: &mut Vec<Statement<'a>>,
 ) {
-    let has_class_attr = ctx.has_class_attribute(el.id);
-    let has_class_dirs = ctx.has_class_directives(el.id);
+    let has_class_attr = ctx.has_class_attribute(el_id);
+    let has_class_dirs = ctx.has_class_directives(el_id);
 
     if !has_class_attr && !has_class_dirs {
         return;
@@ -229,7 +229,7 @@ pub(crate) fn process_class_attribute_and_directives<'a>(
 
     // --- Build class value ---
     let class_value = if has_class_attr {
-        let class_attr_id = ctx.class_attr_id(el.id)
+        let class_attr_id = ctx.class_attr_id(el_id)
             .expect("has_class_attribute set but no class attr id");
 
         let mut expr = get_attr_expr(ctx, class_attr_id);
@@ -240,14 +240,14 @@ pub(crate) fn process_class_attribute_and_directives<'a>(
         expr
     } else {
         // No class expression attribute — use static class or empty string
-        let static_class = ctx.static_class(el.id).unwrap_or("");
+        let static_class = ctx.static_class(el_id).unwrap_or("");
         ctx.b.str_expr(static_class)
     };
 
     // --- Build class directives object ---
     let directives_obj = if has_class_dirs {
         // Snapshot directive info to release the immutable borrow on ctx before the mutable loop.
-        let dir_snapshot: Vec<_> = ctx.class_directive_info(el.id)
+        let dir_snapshot: Vec<_> = ctx.class_directive_info(el_id)
             .expect("has_class_directives set but no directive info")
             .iter()
             .map(|cd| (cd.id, cd.name.clone(), cd.has_expression))
@@ -268,7 +268,7 @@ pub(crate) fn process_class_attribute_and_directives<'a>(
         None
     };
 
-    let has_state = ctx.class_needs_state(el.id);
+    let has_state = ctx.class_needs_state(el_id);
 
     // --- Generate $.set_class() call ---
     if let Some(dir_obj) = directives_obj {
@@ -323,21 +323,21 @@ pub(crate) fn process_class_attribute_and_directives<'a>(
 /// Pushes `let styles_N;` to `init` and the assignment to `update` for combined template_effect.
 pub(crate) fn process_style_directives<'a>(
     ctx: &mut Ctx<'a>,
-    el: &Element,
+    el_id: NodeId,
     el_name: &str,
     init: &mut Vec<Statement<'a>>,
     update: &mut Vec<Statement<'a>>,
 ) {
     use svelte_ast::StyleDirectiveValue;
 
-    if !ctx.has_style_directives(el.id) {
+    if !ctx.has_style_directives(el_id) {
         return;
     }
 
-    let style_dirs = ctx.style_directives(el.id).to_vec();
+    let style_dirs = ctx.style_directives(el_id).to_vec();
 
     // Read precomputed static style value
-    let static_style = ctx.static_style(el.id).unwrap_or("").to_string();
+    let static_style = ctx.static_style(el_id).unwrap_or("").to_string();
 
     let mut normal_props: Vec<ObjProp<'a>> = Vec::new();
     let mut important_props: Vec<ObjProp<'a>> = Vec::new();
@@ -425,7 +425,9 @@ fn build_style_concat<'a>(
 /// Generate `$.set_attributes(el, prevAttrs, { ...allAttrs })` for elements with spread.
 pub(crate) fn process_attrs_spread<'a>(
     ctx: &mut Ctx<'a>,
-    el: &Element,
+    el_id: NodeId,
+    el_tag: &str,
+    attrs: &[Attribute],
     el_name: &str,
     init: &mut Vec<Statement<'a>>,
     after_update: &mut Vec<Statement<'a>>,
@@ -433,7 +435,7 @@ pub(crate) fn process_attrs_spread<'a>(
     // Build object literal with all attributes
     let mut props: Vec<ObjProp<'a>> = Vec::new();
 
-    for attr in &el.attributes {
+    for attr in attrs {
         let attr_id = attr.id();
         match attr {
             Attribute::BooleanAttribute(a) => {
@@ -484,8 +486,8 @@ pub(crate) fn process_attrs_spread<'a>(
                 props.push(ObjProp::Shorthand(name_alloc));
             }
             Attribute::BindDirective(bind) => {
-                let has_use = ctx.has_use_directive(el.id);
-                if let Some(placement) = gen_bind_directive(ctx, bind, el_name, &el.name, has_use) {
+                let has_use = ctx.has_use_directive(el_id);
+                if let Some(placement) = gen_bind_directive(ctx, bind, el_name, el_tag, has_use) {
                     match placement {
                         BindPlacement::AfterUpdate(stmt) => after_update.push(stmt),
                         BindPlacement::Init(stmt) => init.push(stmt),
@@ -505,7 +507,7 @@ pub(crate) fn process_attrs_spread<'a>(
     }
 
     // Collect style directives into [$.STYLE] computed property
-    let style_dirs = ctx.style_directives(el.id).to_vec();
+    let style_dirs = ctx.style_directives(el_id).to_vec();
 
     if !style_dirs.is_empty() {
         use svelte_ast::StyleDirectiveValue;

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -98,7 +98,7 @@ pub(crate) fn process_attr<'a>(
                 match mode {
                     svelte_analyze::EventHandlerMode::Delegated { passive } => {
                         let mut args: Vec<Arg<'a, '_>> = vec![
-                            Arg::Str(event_name.clone()),
+                            Arg::StrRef(&event_name),
                             Arg::Ident(el_name),
                             Arg::Expr(handler),
                         ];
@@ -107,9 +107,7 @@ pub(crate) fn process_attr<'a>(
                             args.push(Arg::Bool(true));
                         }
                         after_update.push(ctx.b.call_stmt("$.delegated", args));
-                        if !ctx.delegated_events.contains(&event_name) {
-                            ctx.delegated_events.push(event_name);
-                        }
+                        ctx.add_delegated_event(event_name);
                     }
                     svelte_analyze::EventHandlerMode::Direct { capture, passive } => {
                         let mut args: Vec<Arg<'a, '_>> = vec![
@@ -148,7 +146,7 @@ pub(crate) fn process_attr<'a>(
                     "$.set_attribute",
                     [
                         Arg::Ident(el_name),
-                        Arg::Str(a.name.clone()),
+                        Arg::StrRef(&a.name),
                         Arg::Expr(val),
                     ],
                 ));
@@ -166,7 +164,7 @@ pub(crate) fn process_attr<'a>(
                     "$.set_attribute",
                     [
                         Arg::Ident(el_name),
-                        Arg::Str(a.name.clone()),
+                        Arg::StrRef(&a.name),
                         Arg::Expr(val),
                     ],
                 ));
@@ -588,7 +586,7 @@ pub(crate) fn process_svelte_element_class_directives<'a>(
         [
             Arg::Ident(el_name),
             Arg::Num(0.0),
-            Arg::Str("".into()),
+            Arg::StrRef(""),
             Arg::Expr(ctx.b.null_expr()),
             Arg::Expr(ctx.b.object_expr(vec![])),
             Arg::Expr(dir_obj),

--- a/crates/svelte_codegen_client/src/template/bind.rs
+++ b/crates/svelte_codegen_client/src/template/bind.rs
@@ -79,7 +79,10 @@ pub(crate) fn emit_bind_group_value<'a>(
     init: &mut Vec<Statement<'a>>,
     _update: &mut Vec<Statement<'a>>,
 ) {
-    let cache_name = ctx.gen_ident(&format!("{}_value", el_name));
+    let mut prefix = String::with_capacity(el_name.len() + 6);
+    prefix.push_str(el_name);
+    prefix.push_str("_value");
+    let cache_name = ctx.gen_ident(&prefix);
 
     // var input_value;
     init.push(ctx.b.var_uninit_stmt(&cache_name));

--- a/crates/svelte_codegen_client/src/template/bind.rs
+++ b/crates/svelte_codegen_client/src/template/bind.rs
@@ -177,7 +177,7 @@ pub(crate) fn gen_bind_directive<'a>(
                     Arg::Ident(el_name), Arg::Expr(get_fn), Arg::Expr(set_fn),
                 ]),
                 "innerHTML" | "innerText" | "textContent" => ctx.b.call_stmt("$.bind_content_editable", [
-                    Arg::Str(bind.name.clone()), Arg::Ident(el_name), Arg::Expr(get_fn), Arg::Expr(set_fn),
+                    Arg::StrRef(&bind.name), Arg::Ident(el_name), Arg::Expr(get_fn), Arg::Expr(set_fn),
                 ]),
                 _ => ctx.b.call_stmt("$.bind_value", [
                     Arg::Ident(el_name), Arg::Expr(get_fn), Arg::Expr(set_fn),
@@ -292,7 +292,7 @@ pub(crate) fn gen_bind_directive<'a>(
             let setter = build_binding_setter(ctx, var_name.clone(), is_rune);
             let getter = build_binding_getter(ctx, &var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("indeterminate".into()), Arg::Str("change".into()),
+                Arg::StrRef("indeterminate"), Arg::StrRef("change"),
                 Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
             ])
         }
@@ -300,7 +300,7 @@ pub(crate) fn gen_bind_directive<'a>(
             let setter = build_binding_setter(ctx, var_name.clone(), is_rune);
             let getter = build_binding_getter(ctx, &var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("open".into()), Arg::Str("toggle".into()),
+                Arg::StrRef("open"), Arg::StrRef("toggle"),
                 Arg::Ident(el_name), Arg::Expr(setter), Arg::Expr(getter),
             ])
         }
@@ -310,7 +310,7 @@ pub(crate) fn gen_bind_directive<'a>(
             let getter = build_binding_getter(ctx, &var_name, is_rune);
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_content_editable", [
-                Arg::Str(bind.name.clone()), Arg::Ident(el_name),
+                Arg::StrRef(&bind.name), Arg::Ident(el_name),
                 Arg::Expr(getter), Arg::Expr(setter),
             ])
         }
@@ -319,7 +319,7 @@ pub(crate) fn gen_bind_directive<'a>(
         "clientWidth" | "clientHeight" | "offsetWidth" | "offsetHeight" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_element_size", [
-                Arg::Ident(el_name), Arg::Str(bind.name.clone()), Arg::Expr(setter),
+                Arg::Ident(el_name), Arg::StrRef(&bind.name), Arg::Expr(setter),
             ])
         }
 
@@ -327,7 +327,7 @@ pub(crate) fn gen_bind_directive<'a>(
         "contentRect" | "contentBoxSize" | "borderBoxSize" | "devicePixelContentBoxSize" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_resize_observer", [
-                Arg::Ident(el_name), Arg::Str(bind.name.clone()), Arg::Expr(setter),
+                Arg::Ident(el_name), Arg::StrRef(&bind.name), Arg::Expr(setter),
             ])
         }
 
@@ -398,35 +398,35 @@ pub(crate) fn gen_bind_directive<'a>(
         "duration" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("duration".into()), Arg::Str("durationchange".into()),
+                Arg::StrRef("duration"), Arg::StrRef("durationchange"),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "videoWidth" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("videoWidth".into()), Arg::Str("resize".into()),
+                Arg::StrRef("videoWidth"), Arg::StrRef("resize"),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "videoHeight" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("videoHeight".into()), Arg::Str("resize".into()),
+                Arg::StrRef("videoHeight"), Arg::StrRef("resize"),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "naturalWidth" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("naturalWidth".into()), Arg::Str("load".into()),
+                Arg::StrRef("naturalWidth"), Arg::StrRef("load"),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }
         "naturalHeight" => {
             let setter = build_binding_setter(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("naturalHeight".into()), Arg::Str("load".into()),
+                Arg::StrRef("naturalHeight"), Arg::StrRef("load"),
                 Arg::Ident(el_name), Arg::Expr(setter),
             ])
         }

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -46,7 +46,9 @@ pub(crate) fn gen_component<'a>(
             ComponentPropKind::Expression { name, attr_id, shorthand, needs_memo } => {
                 let key = ctx.b.alloc_str(&name);
                 if needs_memo {
-                    let memo_name = format!("${memo_counter}");
+                    let mut memo_name = String::with_capacity(4);
+                    memo_name.push('$');
+                    memo_name.push_str(&memo_counter.to_string());
                     memo_counter += 1;
                     let expr = get_attr_expr(ctx, attr_id);
                     let thunk = ctx.b.thunk(expr);

--- a/crates/svelte_codegen_client/src/template/const_tag.rs
+++ b/crates/svelte_codegen_client/src/template/const_tag.rs
@@ -31,7 +31,7 @@ pub(crate) fn emit_const_tags<'a>(
             // Dev mode: wrap with $.tag(derived, "name") + eager $.get() to catch init errors
             let final_expr = if ctx.dev {
                 let name_str = ctx.b.alloc_str(&names[0]);
-                ctx.b.call_expr("$.tag", [Arg::Expr(derived), Arg::Str(name_str.to_string())])
+                ctx.b.call_expr("$.tag", [Arg::Expr(derived), Arg::StrRef(name_str)])
             } else {
                 derived
             };
@@ -60,7 +60,7 @@ pub(crate) fn emit_const_tags<'a>(
 
             // Dev mode: wrap with $.tag(derived, "[@const]")
             let final_expr = if ctx.dev {
-                ctx.b.call_expr("$.tag", [Arg::Expr(derived), Arg::Str("[@const]".to_string())])
+                ctx.b.call_expr("$.tag", [Arg::Expr(derived), Arg::StrRef("[@const]")])
             } else {
                 derived
             };

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -52,8 +52,10 @@ pub(crate) fn process_element<'a>(
     let mut directive_after_update: Vec<Statement<'a>> = Vec::new();
 
     if ctx.has_spread(el_id) {
-        let el_clone = el.clone_without_fragment();
-        process_attrs_spread(ctx, &el_clone, el_name, init, after_update);
+        let el = ctx.element(el_id);
+        let el_tag = el.name.clone();
+        let spread_attrs = el.attributes.clone();
+        process_attrs_spread(ctx, el_id, &el_tag, &spread_attrs, el_name, init, after_update);
 
         // Directives skipped by process_attrs_spread — handle them separately
         let el = ctx.element(el_id);
@@ -101,12 +103,10 @@ pub(crate) fn process_element<'a>(
     }
 
     // Class attribute and/or class directives
-    let el = ctx.element(el_id);
-    process_class_attribute_and_directives(ctx, &el.clone_without_fragment(), el_name, init, update);
+    process_class_attribute_and_directives(ctx, el_id, el_name, init, update);
 
     // Style directives
-    let el = ctx.element(el_id);
-    process_style_directives(ctx, &el.clone_without_fragment(), el_name, init, update);
+    process_style_directives(ctx, el_id, el_name, init, update);
 
     // --- Children ---
     // Debug tags inside this element's fragment (before child DOM traversal)

--- a/crates/svelte_codegen_client/src/template/events.rs
+++ b/crates/svelte_codegen_client/src/template/events.rs
@@ -187,7 +187,9 @@ pub(crate) fn gen_on_directive_legacy<'a>(
     let mods = od.parsed_modifiers();
     let mut wrapped = handler;
     for wrapper in mods.handler_wrappers() {
-        let fn_name = format!("$.{}", wrapper);
+        let mut fn_name = String::with_capacity(2 + wrapper.len());
+        fn_name.push_str("$.");
+        fn_name.push_str(wrapper);
         wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
     }
 
@@ -389,7 +391,9 @@ pub(crate) fn gen_legacy_event_on<'a>(
     let mods = od.parsed_modifiers();
     let mut wrapped = handler;
     for wrapper in mods.handler_wrappers() {
-        let fn_name = format!("$.{}", wrapper);
+        let mut fn_name = String::with_capacity(2 + wrapper.len());
+        fn_name.push_str("$.");
+        fn_name.push_str(wrapper);
         wrapped = ctx.b.call_expr(&fn_name, [Arg::Expr(wrapped)]);
     }
 

--- a/crates/svelte_codegen_client/src/template/events.rs
+++ b/crates/svelte_codegen_client/src/template/events.rs
@@ -193,7 +193,7 @@ pub(crate) fn gen_on_directive_legacy<'a>(
 
     // --- Build $.event() call ---
     let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(od.name.clone()),
+        Arg::StrRef(&od.name),
         Arg::Ident(el_name),
         Arg::Expr(wrapped),
     ];
@@ -394,7 +394,7 @@ pub(crate) fn gen_legacy_event_on<'a>(
     }
 
     let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(od.name.clone()),
+        Arg::StrRef(&od.name),
         Arg::Ident(target),
         Arg::Expr(wrapped),
     ];
@@ -431,7 +431,7 @@ pub(crate) fn gen_event_attr_on<'a>(
 
     let passive = svelte_analyze::is_passive_event(&event_name);
     let mut args: Vec<Arg<'a, '_>> = vec![
-        Arg::Str(event_name.clone()),
+        Arg::StrRef(&event_name),
         Arg::Ident(target),
         Arg::Expr(handler),
     ];

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -95,12 +95,13 @@ pub(crate) fn build_concat_from_parts<'a>(
     let mut tpl_parts: Vec<TemplatePart<'a>> = Vec::new();
     for part in parts {
         match part {
-            LoweredTextPart::Text(s) => {
+            LoweredTextPart::TextSpan(_) | LoweredTextPart::TextOwned(_) => {
+                let s = part.text_value(&ctx.component.source).unwrap();
                 // Merge with previous Str part if possible
                 if let Some(TemplatePart::Str(prev)) = tpl_parts.last_mut() {
                     prev.push_str(s);
                 } else {
-                    tpl_parts.push(TemplatePart::Str(s.clone()));
+                    tpl_parts.push(TemplatePart::Str(s.to_string()));
                 }
             }
             LoweredTextPart::Expr(nid) => {

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -24,7 +24,7 @@ pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> (String, bool) {
                     html.push(' ');
                 } else {
                     for part in parts {
-                        if let LoweredTextPart::Text(t) = part {
+                        if let Some(t) = part.text_value(&ctx.component.source) {
                             html.push_str(t);
                         }
                     }

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -145,8 +145,8 @@ pub fn gen_root_fragment<'a>(ctx: &mut Ctx<'a>) -> (Vec<Statement<'a>>, Vec<Stat
         hoistable_snippets.push(snippet::gen_snippet_block(ctx, id, vec![]));
     }
 
-    let mut hoisted = Vec::new();
-    let mut body = Vec::new();
+    let mut hoisted = Vec::with_capacity(4);
+    let mut body = Vec::with_capacity(8);
 
     emit_const_tags(ctx, key, &mut body);
     emit_debug_tags(ctx, key, &mut body);
@@ -197,12 +197,12 @@ pub(crate) fn gen_fragment<'a>(ctx: &mut Ctx<'a>, key: FragmentKey) -> Vec<State
     // Consume "root" name for all content types to keep numbering consistent
     let tpl_name = ctx.gen_ident("root");
 
-    let mut body: Vec<Statement<'a>> = Vec::new();
+    let mut body: Vec<Statement<'a>> = Vec::with_capacity(8);
 
     emit_const_tags(ctx, key, &mut body);
     emit_debug_tags(ctx, key, &mut body);
 
-    let mut sub_hoisted = Vec::new();
+    let mut sub_hoisted = Vec::with_capacity(2);
     emit_content_strategy(ctx, key, &ct, &tpl_name, false, &mut sub_hoisted, &mut body);
     ctx.module_hoisted.extend(sub_hoisted);
 
@@ -335,18 +335,18 @@ fn emit_single_element<'a>(
         // Root: template BEFORE children (top-down)
         hoisted.push(tpl_stmt);
         body.push(ctx.b.var_stmt(&el_name, ctx.b.call_expr(tpl_name, [])));
-        let mut init = Vec::new();
-        let mut update = Vec::new();
-        let mut after_update = Vec::new();
+        let mut init = Vec::with_capacity(8);
+        let mut update = Vec::with_capacity(4);
+        let mut after_update = Vec::with_capacity(4);
         process_element(ctx, el_id, &el_name, &mut init, &mut update, hoisted, &mut after_update);
         body.extend(init);
         emit_template_effect(ctx, update, body);
         body.extend(after_update);
     } else {
         // Non-root: template AFTER children (bottom-up)
-        let mut init = Vec::new();
-        let mut update = Vec::new();
-        let mut after_update = Vec::new();
+        let mut init = Vec::with_capacity(8);
+        let mut update = Vec::with_capacity(4);
+        let mut after_update = Vec::with_capacity(4);
         process_element(ctx, el_id, &el_name, &mut init, &mut update, hoisted, &mut after_update);
         hoisted.push(tpl_stmt);
         body.push(ctx.b.var_stmt(&el_name, ctx.b.call_expr(tpl_name, [])));

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -57,7 +57,7 @@ pub(crate) fn add_svelte_meta<'a>(
     let thunk = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(expression)]);
     ctx.b.call_stmt("$.add_svelte_meta", [
         Arg::Expr(thunk),
-        Arg::Str(block_type.to_string()),
+        Arg::StrRef(block_type),
         Arg::Ident(ctx.name),
         Arg::Num(line as f64),
         Arg::Num(col as f64),
@@ -277,7 +277,7 @@ fn emit_static_text<'a>(
     let call = if text.is_empty() {
         ctx.b.call_expr("$.text", [])
     } else {
-        ctx.b.call_expr("$.text", [Arg::Str(text.to_string())])
+        ctx.b.call_expr("$.text", [Arg::StrRef(text)])
     };
     body.push(ctx.b.var_stmt(&name, call));
     body.push(ctx.b.call_stmt(

--- a/crates/svelte_codegen_client/src/template/render_tag.rs
+++ b/crates/svelte_codegen_client/src/template/render_tag.rs
@@ -69,7 +69,9 @@ pub(crate) fn gen_render_tag<'a>(
         let has_call = arg_has_call.get(i).copied().unwrap_or(false);
 
         if has_call {
-            let memo_name = format!("${memo_counter}");
+            let mut memo_name = String::with_capacity(4);
+            memo_name.push('$');
+            memo_name.push_str(&memo_counter.to_string());
             memo_counter += 1;
             let thunk = ctx.b.thunk(arg_expr);
             let derived = ctx.b.call_expr("$.derived", [Arg::Expr(thunk)]);

--- a/crates/svelte_codegen_client/src/template/svelte_document.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_document.rs
@@ -66,8 +66,8 @@ fn gen_document_binding<'a>(
         "fullscreenElement" => {
             let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("fullscreenElement".to_string()),
-                Arg::Str("fullscreenchange".to_string()),
+                Arg::StrRef("fullscreenElement"),
+                Arg::StrRef("fullscreenchange"),
                 Arg::Ident("$.document"),
                 Arg::Expr(setter),
             ])
@@ -75,8 +75,8 @@ fn gen_document_binding<'a>(
         "pointerLockElement" => {
             let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("pointerLockElement".to_string()),
-                Arg::Str("pointerlockchange".to_string()),
+                Arg::StrRef("pointerLockElement"),
+                Arg::StrRef("pointerlockchange"),
                 Arg::Ident("$.document"),
                 Arg::Expr(setter),
             ])
@@ -84,8 +84,8 @@ fn gen_document_binding<'a>(
         "visibilityState" => {
             let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("visibilityState".to_string()),
-                Arg::Str("visibilitychange".to_string()),
+                Arg::StrRef("visibilityState"),
+                Arg::StrRef("visibilitychange"),
                 Arg::Ident("$.document"),
                 Arg::Expr(setter),
             ])

--- a/crates/svelte_codegen_client/src/template/svelte_element.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_element.rs
@@ -76,7 +76,7 @@ pub(crate) fn gen_svelte_element<'a>(
     } else if has_attrs {
         // Generic spread-like handling for svelte:element
         // because the element tag is unknown at compile time.
-        process_attrs_spread(ctx, &el_clone, &el_name, &mut inner_init, &mut inner_after_update);
+        process_attrs_spread(ctx, id, "", &el_clone.attributes, &el_name, &mut inner_init, &mut inner_after_update);
     }
 
     // Class directives on svelte:element use $.set_class with flag 0

--- a/crates/svelte_codegen_client/src/template/svelte_window.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_window.rs
@@ -64,7 +64,7 @@ fn gen_window_binding<'a>(
             let getter = build_binding_getter(ctx, &var_name, is_rune);
             let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_window_scroll", [
-                Arg::Str(axis.to_string()),
+                Arg::StrRef(axis),
                 Arg::Expr(getter),
                 Arg::Expr(setter),
             ])
@@ -72,7 +72,7 @@ fn gen_window_binding<'a>(
         "innerWidth" | "innerHeight" | "outerWidth" | "outerHeight" => {
             let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_window_size", [
-                Arg::Str(bind.name.clone()),
+                Arg::StrRef(&bind.name),
                 Arg::Expr(setter),
             ])
         }
@@ -83,8 +83,8 @@ fn gen_window_binding<'a>(
         "devicePixelRatio" => {
             let setter = build_binding_setter_silent(ctx, var_name, is_rune);
             ctx.b.call_stmt("$.bind_property", [
-                Arg::Str("devicePixelRatio".to_string()),
-                Arg::Str("resize".to_string()),
+                Arg::StrRef("devicePixelRatio"),
+                Arg::StrRef("resize"),
                 Arg::Ident("$.window"),
                 Arg::Expr(setter),
             ])

--- a/crates/svelte_parser/src/scanner/mod.rs
+++ b/crates/svelte_parser/src/scanner/mod.rs
@@ -1,6 +1,6 @@
 pub mod token;
 
-use std::{iter::Peekable, str::Chars, vec};
+use std::vec;
 
 pub use svelte_ast::is_void;
 
@@ -16,7 +16,7 @@ use svelte_span::{Span, SPAN};
 
 pub struct Scanner<'a> {
     source: &'a str,
-    chars: Peekable<Chars<'a>>,
+    bytes: &'a [u8],
     tokens: Vec<Token>,
     diagnostics: Vec<Diagnostic>,
     start: usize,
@@ -28,9 +28,9 @@ impl<'a> Scanner<'a> {
     pub fn new(source: &'a str) -> Scanner<'a> {
         Scanner {
             source,
+            bytes: source.as_bytes(),
             tokens: vec![],
             diagnostics: vec![],
-            chars: source.chars().peekable(),
             prev: 0,
             current: 0,
             start: 0,
@@ -106,16 +106,26 @@ impl<'a> Scanner<'a> {
     }
 
     fn advance(&mut self) -> char {
-        let char = self.chars.next().unwrap();
-
         self.prev = self.current;
-        self.current += char.len_utf8();
-
-        char
+        let b = self.bytes[self.current];
+        if b < 0x80 {
+            self.current += 1;
+            b as char
+        } else {
+            let ch = self.source[self.current..].chars().next().unwrap();
+            self.current += ch.len_utf8();
+            ch
+        }
     }
 
-    fn is_at_end(&mut self) -> bool {
-        self.chars.peek().is_none()
+    #[inline]
+    fn is_at_end(&self) -> bool {
+        self.current >= self.bytes.len()
+    }
+
+    #[inline]
+    fn peek_byte(&self) -> Option<u8> {
+        self.bytes.get(self.current).copied()
     }
 
     fn identifier(&mut self) -> &'a str {
@@ -191,25 +201,24 @@ impl<'a> Scanner<'a> {
     }
 
     fn match_char(&mut self, expected: char) -> bool {
-        if self.is_at_end() {
-            return false;
+        if self.peek_byte().is_some_and(|b| b == expected as u8) {
+            self.advance();
+            true
+        } else {
+            false
         }
-
-        if self.peek().is_some_and(|c| c != expected) {
-            return false;
-        }
-
-        self.advance();
-
-        true
     }
 
-    fn peek(&mut self) -> Option<char> {
-        if self.is_at_end() {
+    fn peek(&self) -> Option<char> {
+        if self.current >= self.bytes.len() {
             return None;
         }
-
-        self.chars.peek().copied()
+        let b = self.bytes[self.current];
+        if b < 0x80 {
+            Some(b as char)
+        } else {
+            self.source[self.current..].chars().next()
+        }
     }
 
     fn collect_until_span<F>(&mut self, condition: F) -> Result<Span, Diagnostic>
@@ -745,7 +754,7 @@ impl<'a> Scanner<'a> {
     }
 
     fn collect_js_expression(&mut self) -> Result<Span, Diagnostic> {
-        let mut stack: Vec<bool> = vec![];
+        let mut stack: Vec<bool> = Vec::with_capacity(4);
         let start = self.current;
 
         while !self.is_at_end() {


### PR DESCRIPTION
- Replace codegen NodeIndex FxHashMap with dense Vec-based index (O(1) without hashing)
- Replace NodeBitSet Vec<bool> with u64-packed bitset (8x less memory, faster iteration)
- Optimize IdentGen with CompactString (inline storage for short identifiers)
- Add Arg::StrRef variant to avoid heap allocations for string literals in codegen
- Convert ~30 Arg::Str(literal.to_string()) calls to zero-allocation Arg::StrRef
- Replace delegated_events linear Vec::contains with O(1) FxHashSet dedup
- Optimize release profile: panic=abort, strip=symbols
- Optimize dev profile: opt-level=1 for project, opt-level=2 for dependencies

https://claude.ai/code/session_01LcMsuwRkCYmSAE3mZgYEUQ