### PR TITLE
Add compiler tests for component snippets

### DIFF
--- a/tasks/compiler_tests/cases2/component_multiple_snippets/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_multiple_snippets/case-rust.js
@@ -1,0 +1,4 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	Card($$anchor, {});
+}

--- a/tasks/compiler_tests/cases2/component_multiple_snippets/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_multiple_snippets/case-svelte.js
@@ -1,0 +1,23 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<h1>Header</h1>`);
+var root_2 = $.from_html(`<p>Footer</p>`);
+export default function App($$anchor) {
+	{
+		const header = ($$anchor) => {
+			var h1 = root_1();
+			$.append($$anchor, h1);
+		};
+		const footer = ($$anchor) => {
+			var p = root_2();
+			$.append($$anchor, p);
+		};
+		Card($$anchor, {
+			header,
+			footer,
+			$$slots: {
+				header: true,
+				footer: true
+			}
+		});
+	}
+}

--- a/tasks/compiler_tests/cases2/component_multiple_snippets/case.svelte
+++ b/tasks/compiler_tests/cases2/component_multiple_snippets/case.svelte
@@ -1,0 +1,8 @@
+<Card>
+	{#snippet header()}
+		<h1>Header</h1>
+	{/snippet}
+	{#snippet footer()}
+		<p>Footer</p>
+	{/snippet}
+</Card>

--- a/tasks/compiler_tests/cases2/component_snippet_only/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_snippet_only/case-rust.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	Table($$anchor, { get items() {
+		return $$props.data;
+	} });
+}

--- a/tasks/compiler_tests/cases2/component_snippet_only/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_snippet_only/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<span> </span>`);
+export default function App($$anchor, $$props) {
+	{
+		const row = ($$anchor, item = $.noop) => {
+			var span = root_1();
+			var text = $.child(span, true);
+			$.reset(span);
+			$.template_effect(() => $.set_text(text, item()));
+			$.append($$anchor, span);
+		};
+		Table($$anchor, {
+			get items() {
+				return $$props.data;
+			},
+			row,
+			$$slots: { row: true }
+		});
+	}
+}

--- a/tasks/compiler_tests/cases2/component_snippet_only/case.svelte
+++ b/tasks/compiler_tests/cases2/component_snippet_only/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let { data } = $props();
+</script>
+
+<Table items={data}>
+	{#snippet row(item)}
+		<span>{item}</span>
+	{/snippet}
+</Table>

--- a/tasks/compiler_tests/cases2/component_snippet_prop/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_snippet_prop/case-rust.js
@@ -1,0 +1,5 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor) {
+	let count = 0;
+	Dialog($$anchor, {});
+}

--- a/tasks/compiler_tests/cases2/component_snippet_prop/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_snippet_prop/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<h2></h2>`);
+export default function App($$anchor) {
+	let count = 0;
+	{
+		const header = ($$anchor) => {
+			var h2 = root_1();
+			h2.textContent = "Title 0";
+			$.append($$anchor, h2);
+		};
+		Dialog($$anchor, {
+			header,
+			$$slots: { header: true }
+		});
+	}
+}

--- a/tasks/compiler_tests/cases2/component_snippet_prop/case.svelte
+++ b/tasks/compiler_tests/cases2/component_snippet_prop/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let count = $state(0);
+</script>
+
+<Dialog>
+	{#snippet header()}
+		<h2>Title {count}</h2>
+	{/snippet}
+</Dialog>

--- a/tasks/compiler_tests/cases2/component_snippet_with_children/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_snippet_with_children/case-rust.js
@@ -1,0 +1,13 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let name = "world";
+	Card($$anchor, {
+		children: ($$anchor, $$slotProps) => {
+			var p = root_1();
+			p.textContent = "Content world";
+			$.append($$anchor, p);
+		},
+		$$slots: { default: true }
+	});
+}

--- a/tasks/compiler_tests/cases2/component_snippet_with_children/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_snippet_with_children/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<h2>Hello</h2>`);
+var root_2 = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let name = "world";
+	{
+		const title = ($$anchor) => {
+			var h2 = root_1();
+			$.append($$anchor, h2);
+		};
+		Card($$anchor, {
+			title,
+			children: ($$anchor, $$slotProps) => {
+				var p = root_2();
+				p.textContent = "Content world";
+				$.append($$anchor, p);
+			},
+			$$slots: {
+				title: true,
+				default: true
+			}
+		});
+	}
+}

--- a/tasks/compiler_tests/cases2/component_snippet_with_children/case.svelte
+++ b/tasks/compiler_tests/cases2/component_snippet_with_children/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	let name = $state("world");
+</script>
+
+<Card>
+	{#snippet title()}
+		<h2>Hello</h2>
+	{/snippet}
+	<p>Content {name}</p>
+</Card>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1743,3 +1743,23 @@ fn state_inside_function() {
 fn derived_by_inside_function() {
     assert_compiler("derived_by_inside_function");
 }
+
+#[rstest]
+fn component_snippet_prop() {
+    assert_compiler("component_snippet_prop");
+}
+
+#[rstest]
+fn component_snippet_with_children() {
+    assert_compiler("component_snippet_with_children");
+}
+
+#[rstest]
+fn component_multiple_snippets() {
+    assert_compiler("component_multiple_snippets");
+}
+
+#[rstest]
+fn component_snippet_only() {
+    assert_compiler("component_snippet_only");
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive compiler test cases for Svelte component snippets, covering various snippet usage patterns including single snippets, multiple snippets, snippets with children, and snippets with parameters.

## Key Changes
- Added 4 new test cases to validate snippet compilation:
  - `component_snippet_prop`: Tests a single snippet passed as a named slot to a component
  - `component_snippet_with_children`: Tests a named snippet alongside default slot content
  - `component_multiple_snippets`: Tests multiple named snippets passed to a component
  - `component_snippet_only`: Tests a parameterized snippet used as a named slot

- Each test case includes:
  - Source `.svelte` file demonstrating the snippet usage pattern
  - Expected compiled output (`case-svelte.js`) showing full snippet compilation
  - Rust compiler reference output (`case-rust.js`) for comparison

- Updated `test_v3.rs` with 4 new test functions to validate the compiler output for each case

## Notable Implementation Details
- Snippets are compiled into functions that accept an anchor element and optional slot properties
- Named snippets are passed as properties to component calls with a `$$slots` object indicating which slots are provided
- The compiler generates `$.from_html()` calls for static HTML content within snippets
- Reactive content within snippets uses `$.template_effect()` for proper reactivity tracking
- Default slot content is passed via the `children` property with `$$slotProps` parameter support

https://claude.ai/code/session_01ThneYhmswroLmABw9TALDp