### PR TITLE
Add compiler tests for TypeScript imports, spread, and bind props

### DIFF
--- a/tasks/compiler_tests/cases2/component_bind_prop_forward/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_bind_prop_forward/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+import Input from "./Input.svelte";
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = $.prop($$props, "value", 15);
+	Input($$anchor, {});
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/component_bind_prop_forward/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_bind_prop_forward/case-svelte.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+import Input from "./Input.svelte";
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = $.prop($$props, "value", 15);
+	Input($$anchor, {
+		get value() {
+			return value();
+		},
+		set value($$value) {
+			value($$value);
+		}
+	});
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/component_bind_prop_forward/case.svelte
+++ b/tasks/compiler_tests/cases2/component_bind_prop_forward/case.svelte
@@ -1,0 +1,5 @@
+<script>
+import Input from './Input.svelte';
+let { value = $bindable() } = $props();
+</script>
+<Input bind:value />

--- a/tasks/compiler_tests/cases2/component_spread_props/case-rust.js
+++ b/tasks/compiler_tests/cases2/component_spread_props/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+import Button from "./Button.svelte";
+export default function App($$anchor, $$props) {
+	let props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy"
+	]);
+	Button($$anchor, {});
+}

--- a/tasks/compiler_tests/cases2/component_spread_props/case-svelte.js
+++ b/tasks/compiler_tests/cases2/component_spread_props/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+import Button from "./Button.svelte";
+export default function App($$anchor, $$props) {
+	let props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy"
+	]);
+	Button($$anchor, $.spread_props(() => props));
+}

--- a/tasks/compiler_tests/cases2/component_spread_props/case.svelte
+++ b/tasks/compiler_tests/cases2/component_spread_props/case.svelte
@@ -1,0 +1,5 @@
+<script>
+import Button from './Button.svelte';
+let { ...props } = $props();
+</script>
+<Button {...props} />

--- a/tasks/compiler_tests/cases2/rest_props_member_access/case-rust.js
+++ b/tasks/compiler_tests/cases2/rest_props_member_access/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	let props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy",
+		"id"
+	]);
+	const label = $.derived(() => props.label + "!");
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(label)));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/rest_props_member_access/case-svelte.js
+++ b/tasks/compiler_tests/cases2/rest_props_member_access/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy",
+		"id"
+	]);
+	const label = $.derived(() => $$props.label + "!");
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(label)));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/rest_props_member_access/case.svelte
+++ b/tasks/compiler_tests/cases2/rest_props_member_access/case.svelte
@@ -1,0 +1,5 @@
+<script>
+let { id, ...props } = $props();
+const label = $derived(props.label + '!');
+</script>
+<p>{label}</p>

--- a/tasks/compiler_tests/cases2/ts_type_import_comment/case-rust.js
+++ b/tasks/compiler_tests/cases2/ts_type_import_comment/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+import { foo } from "./foo";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let count = 0;
+	var p = root();
+	p.textContent = "0";
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_type_import_comment/case-svelte.js
+++ b/tasks/compiler_tests/cases2/ts_type_import_comment/case-svelte.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+import { foo } from "./foo";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	// this comment should move
+	let count = 0;
+	var p = root();
+	p.textContent = "0";
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/ts_type_import_comment/case.svelte
+++ b/tasks/compiler_tests/cases2/ts_type_import_comment/case.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import { foo } from './foo';
+// this comment should move
+import type { Bar } from './bar';
+let count = $state(0);
+</script>
+<p>{count}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1743,3 +1743,27 @@ fn state_inside_function() {
 fn derived_by_inside_function() {
     assert_compiler("derived_by_inside_function");
 }
+
+// ---------------------------------------------------------------------------
+// Diagnose: TypeScript import + spread + bind:prop tests
+// ---------------------------------------------------------------------------
+
+#[rstest]
+fn ts_type_import_comment() {
+    assert_compiler("ts_type_import_comment");
+}
+
+#[rstest]
+fn rest_props_member_access() {
+    assert_compiler("rest_props_member_access");
+}
+
+#[rstest]
+fn component_spread_props() {
+    assert_compiler("component_spread_props");
+}
+
+#[rstest]
+fn component_bind_prop_forward() {
+    assert_compiler("component_bind_prop_forward");
+}


### PR DESCRIPTION
## Summary
This PR adds four new compiler test cases to validate the handling of TypeScript type imports with comments, rest/spread props, and bind prop forwarding in Svelte components.

## Key Changes
- Added `ts_type_import_comment` test: Validates that comments between TypeScript type imports and regular imports are preserved during compilation
- Added `rest_props_member_access` test: Ensures rest props can be destructured and their properties accessed in derived expressions
- Added `component_spread_props` test: Tests spreading rest props to child components using the `spread_props` utility
- Added `component_bind_prop_forward` test: Validates binding and forwarding props to child components with default values

## Test Cases
Each test includes:
- Original Svelte source file (`case.svelte`)
- Expected Svelte compiler output (`case-svelte.js`)
- Expected Rust compiler output (`case-rust.js`)

The test cases demonstrate differences in how the Svelte and Rust compilers handle:
- Comment preservation around type imports
- Rest props extraction and usage
- Spread props compilation
- Bindable prop forwarding with getters/setters

https://claude.ai/code/session_01KxTfM8xz9a1VdUwjoXWCz4