### PR TITLE
Refactor template visitor to use VisitContext for parent tracking

### DIFF
--- a/crates/svelte_analyze/src/analyze_semantic.rs
+++ b/crates/svelte_analyze/src/analyze_semantic.rs
@@ -29,64 +29,60 @@ impl TemplateVisitor for JsMetadataVisitor<'_> {
     fn visit_expression_tag(
         &mut self,
         tag: &ExpressionTag,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_expr_arrows(
             self.parsed.exprs.get(&tag.expression_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
-    fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_render_tag(&mut self, tag: &RenderTag, ctx: &mut crate::walker::VisitContext<'_>) {
         scan_expr_arrows(
             self.parsed.exprs.get(&tag.expression_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
-    fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_html_tag(&mut self, tag: &HtmlTag, ctx: &mut crate::walker::VisitContext<'_>) {
         scan_expr_arrows(
             self.parsed.exprs.get(&tag.expression_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
     fn visit_const_tag(
         &mut self,
         tag: &svelte_ast::ConstTag,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_expr_arrows(
             self.parsed.exprs.get(&tag.expression_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
-    fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_if_block(&mut self, block: &IfBlock, ctx: &mut crate::walker::VisitContext<'_>) {
         scan_expr_arrows(
             self.parsed.exprs.get(&block.test_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
     fn visit_each_block(
         &mut self,
         block: &EachBlock,
-        parent_scope: ScopeId,
-        _body_scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_expr_arrows(
             self.parsed.exprs.get(&block.expression_span.start),
-            &mut data.scoping,
-            parent_scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
 
         // Each-block index usage detection
@@ -96,231 +92,242 @@ impl TemplateVisitor for JsMetadataVisitor<'_> {
                 if let Some(key_expr) = self.parsed.exprs.get(&key_span.start) {
                     let info = analyze_expression(key_expr);
                     if info.references.iter().any(|r| r.name.as_str() == idx_name) {
-                        data.each_blocks.key_uses_index.insert(block.id);
+                        ctx.data.each_blocks.key_uses_index.insert(block.id);
                     }
                 }
             }
-            if check_fragment_uses_name(&block.body, idx_name, data) {
-                data.each_blocks.body_uses_index.insert(block.id);
+            if check_fragment_uses_name(&block.body, idx_name, ctx.data) {
+                ctx.data.each_blocks.body_uses_index.insert(block.id);
             }
         }
     }
 
-    fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_key_block(&mut self, block: &KeyBlock, ctx: &mut crate::walker::VisitContext<'_>) {
         scan_expr_arrows(
             self.parsed.exprs.get(&block.expression_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
-    fn visit_await_block(&mut self, block: &AwaitBlock, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_await_block(
+        &mut self,
+        block: &AwaitBlock,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
         scan_expr_arrows(
             self.parsed.exprs.get(&block.expression_span.start),
-            &mut data.scoping,
-            scope,
+            &mut ctx.data.scoping,
+            ctx.scope,
         );
     }
 
     fn visit_expression_attribute(
         &mut self,
         attr: &ExpressionAttribute,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             Some(attr.expression_span.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
     fn visit_concatenation_attribute(
         &mut self,
         attr: &ConcatenationAttribute,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        scan_concat_arrows(&attr.parts, &mut data.scoping, self.parsed, scope);
+        scan_concat_arrows(&attr.parts, &mut ctx.data.scoping, self.parsed, ctx.scope);
     }
     fn visit_spread_attribute(
         &mut self,
         attr: &SpreadAttribute,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             Some(attr.expression_span.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
-    fn visit_shorthand(&mut self, attr: &Shorthand, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_shorthand(
+        &mut self,
+        attr: &Shorthand,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
         scan_attr_arrows_by_offset(
             Some(attr.expression_span.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
     fn visit_class_directive(
         &mut self,
         dir: &ClassDirective,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             dir.expression_span.map(|s| s.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
     fn visit_style_directive(
         &mut self,
         dir: &StyleDirective,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         let offset = match &dir.value {
             svelte_ast::StyleDirectiveValue::Expression(span) => Some(span.start),
             _ => None,
         };
-        scan_attr_arrows_by_offset(offset, &mut data.scoping, self.parsed, scope);
+        scan_attr_arrows_by_offset(offset, &mut ctx.data.scoping, self.parsed, ctx.scope);
         if let svelte_ast::StyleDirectiveValue::Concatenation(parts) = &dir.value {
-            scan_concat_arrows(parts, &mut data.scoping, self.parsed, scope);
+            scan_concat_arrows(parts, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
     fn visit_bind_directive(
         &mut self,
         dir: &BindDirective,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             dir.expression_span.map(|s| s.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
-    fn visit_use_directive(&mut self, dir: &UseDirective, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_use_directive(
+        &mut self,
+        dir: &UseDirective,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
         scan_attr_arrows_by_offset(
             dir.expression_span.map(|s| s.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
     fn visit_on_directive_legacy(
         &mut self,
         dir: &OnDirectiveLegacy,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             dir.expression_span.map(|s| s.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
     fn visit_transition_directive(
         &mut self,
         dir: &TransitionDirective,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             dir.expression_span.map(|s| s.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
     fn visit_animate_directive(
         &mut self,
         dir: &AnimateDirective,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         scan_attr_arrows_by_offset(
             dir.expression_span.map(|s| s.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
-    fn visit_attach_tag(&mut self, tag: &AttachTag, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_attach_tag(
+        &mut self,
+        tag: &AttachTag,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
         scan_attr_arrows_by_offset(
             Some(tag.expression_span.start),
-            &mut data.scoping,
+            &mut ctx.data.scoping,
             self.parsed,
-            scope,
+            ctx.scope,
         );
     }
 
     fn visit_component_node(
         &mut self,
         cn: &ComponentNode,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         for attr in &cn.attributes {
-            scan_single_attr_arrows(attr, &mut data.scoping, self.parsed, scope);
+            scan_single_attr_arrows(attr, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
 
     fn visit_svelte_element(
         &mut self,
         el: &SvelteElement,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         if !el.static_tag {
             scan_expr_arrows(
                 self.parsed.exprs.get(&el.tag_span.start),
-                &mut data.scoping,
-                scope,
+                &mut ctx.data.scoping,
+                ctx.scope,
             );
         }
         for attr in &el.attributes {
-            scan_single_attr_arrows(attr, &mut data.scoping, self.parsed, scope);
+            scan_single_attr_arrows(attr, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
 
-    fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_svelte_window(
+        &mut self,
+        w: &SvelteWindow,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
         for attr in &w.attributes {
-            scan_single_attr_arrows(attr, &mut data.scoping, self.parsed, scope);
+            scan_single_attr_arrows(attr, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
 
     fn visit_svelte_document(
         &mut self,
         doc: &SvelteDocument,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         for attr in &doc.attributes {
-            scan_single_attr_arrows(attr, &mut data.scoping, self.parsed, scope);
+            scan_single_attr_arrows(attr, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
 
-    fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_svelte_body(
+        &mut self,
+        body: &SvelteBody,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
         for attr in &body.attributes {
-            scan_single_attr_arrows(attr, &mut data.scoping, self.parsed, scope);
+            scan_single_attr_arrows(attr, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
 
     fn visit_svelte_boundary(
         &mut self,
         boundary: &SvelteBoundary,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         for attr in &boundary.attributes {
-            scan_single_attr_arrows(attr, &mut data.scoping, self.parsed, scope);
+            scan_single_attr_arrows(attr, &mut ctx.data.scoping, self.parsed, ctx.scope);
         }
     }
 }

--- a/crates/svelte_analyze/src/bind_semantics.rs
+++ b/crates/svelte_analyze/src/bind_semantics.rs
@@ -5,7 +5,7 @@ use svelte_ast::{
 };
 
 use crate::data::AnalysisData;
-use crate::walker::TemplateVisitor;
+use crate::walker::{TemplateVisitor, VisitContext};
 
 /// Pre-computes bind/directive semantics so codegen doesn't re-derive
 /// symbol classifications from source text via string-based lookups.
@@ -134,87 +134,78 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
     fn visit_bind_directive(
         &mut self,
         dir: &BindDirective,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_bind(dir, data);
-        self.classify_bind_this(dir, scope, data);
+        self.classify_bind(dir, ctx.data);
+        self.classify_bind_this(dir, ctx.scope, ctx.data);
     }
 
     fn visit_class_directive(
         &mut self,
         dir: &ClassDirective,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_class(dir, data);
+        self.classify_class(dir, ctx.data);
     }
 
     fn visit_style_directive(
         &mut self,
         dir: &StyleDirective,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_style(dir, data);
+        self.classify_style(dir, ctx.data);
     }
 
     fn visit_svelte_window(
         &mut self,
         w: &SvelteWindow,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_attrs(&w.attributes, data);
+        self.classify_attrs(&w.attributes, ctx.data);
     }
 
     fn visit_svelte_document(
         &mut self,
         doc: &SvelteDocument,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_attrs(&doc.attributes, data);
+        self.classify_attrs(&doc.attributes, ctx.data);
     }
 
     fn visit_svelte_body(
         &mut self,
         body: &SvelteBody,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_attrs(&body.attributes, data);
+        self.classify_attrs(&body.attributes, ctx.data);
     }
 
     fn visit_svelte_element(
         &mut self,
         el: &SvelteElement,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        self.classify_attrs(&el.attributes, data);
+        self.classify_attrs(&el.attributes, ctx.data);
     }
 
     fn visit_each_block(
         &mut self,
         block: &EachBlock,
-        _parent_scope: ScopeId,
-        body_scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         let text = self.source[block.expression_span.start as usize..block.expression_span.end as usize].trim();
-        if Self::is_prop_source(text, data) {
-            data.bind_semantics.prop_source_nodes.insert(block.id);
+        if Self::is_prop_source(text, ctx.data) {
+            ctx.data.bind_semantics.prop_source_nodes.insert(block.id);
         }
+        // ctx.scope is the parent scope at visit time; body_scope is looked up from scoping data
+        let body_scope = ctx.data.scoping.node_scope(block.id).unwrap_or(ctx.scope);
         self.each_block_stack.push((block.id, body_scope));
     }
 
     fn leave_each_block(
         &mut self,
         _block: &EachBlock,
-        _parent_scope: ScopeId,
-        _body_scope: ScopeId,
-        _data: &mut AnalysisData,
+        _ctx: &mut VisitContext<'_>,
     ) {
         self.each_block_stack.pop();
     }
@@ -222,8 +213,7 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
     fn leave_element(
         &mut self,
         el: &Element,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         // Detect bind:group → mark element and find value attribute
         let bind_group = el.attributes.iter().find_map(|a| {
@@ -233,12 +223,12 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
             None
         });
         if let Some(bg) = bind_group {
-            data.bind_semantics.has_bind_group.insert(el.id);
+            ctx.data.bind_semantics.has_bind_group.insert(el.id);
             // Find the value attribute on the same element (for getter thunk wrapping)
             if let Some(val_attr) = el.attributes.iter().find(|a| {
                 matches!(a, Attribute::ExpressionAttribute(ea) if ea.name == "value")
             }) {
-                data.bind_semantics.bind_group_value_attr.insert(bg.id, val_attr.id());
+                ctx.data.bind_semantics.bind_group_value_attr.insert(bg.id, val_attr.id());
             }
 
             // Walk ancestor each blocks to find which ones declare vars
@@ -249,19 +239,19 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
                 let mut parent_eaches = Vec::new();
                 for &(each_id, body_scope) in self.each_block_stack.iter().rev() {
                     let has_match = idents.iter().any(|name| {
-                        data.scoping.find_binding(body_scope, name)
+                        ctx.data.scoping.find_binding(body_scope, name)
                             .is_some_and(|sym| {
-                                data.scoping.is_each_block_var(sym)
-                                    && data.scoping.symbol_scope_id(sym) == body_scope
+                                ctx.data.scoping.is_each_block_var(sym)
+                                    && ctx.data.scoping.symbol_scope_id(sym) == body_scope
                             })
                     });
                     if has_match {
                         parent_eaches.push(each_id);
-                        data.bind_semantics.contains_group_binding.insert(each_id);
+                        ctx.data.bind_semantics.contains_group_binding.insert(each_id);
                     }
                 }
                 if !parent_eaches.is_empty() {
-                    data.bind_semantics.parent_each_blocks.insert(bg.id, parent_eaches);
+                    ctx.data.bind_semantics.parent_each_blocks.insert(bg.id, parent_eaches);
                 }
             }
         }
@@ -284,7 +274,7 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
             matches!(a, Attribute::BindDirective(bd) if matches!(bd.name.as_str(), "innerHTML" | "innerText" | "textContent"))
         });
         if has_content_bind {
-            data.element_flags.bound_contenteditable.insert(el.id);
+            ctx.data.element_flags.bound_contenteditable.insert(el.id);
         }
     }
 

--- a/crates/svelte_analyze/src/content_types.rs
+++ b/crates/svelte_analyze/src/content_types.rs
@@ -1,4 +1,3 @@
-use oxc_semantic::ScopeId;
 use svelte_ast::{Attribute, Element};
 
 use crate::data::{AnalysisData, ContentStrategy, FragmentItem, FragmentKey, LoweredTextPart};
@@ -14,22 +13,22 @@ pub(crate) struct ContentAndVarVisitor<'s> {
 }
 
 impl TemplateVisitor for ContentAndVarVisitor<'_> {
-    fn leave_element(&mut self, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
+    fn leave_element(&mut self, el: &Element, ctx: &mut crate::walker::VisitContext<'_>) {
         let key = FragmentKey::Element(el.id);
 
         // Compute content_type + has_dynamic for this element's fragment
-        if let Some(lf) = data.fragments.lowered.get(&key) {
+        if let Some(lf) = ctx.data.fragments.lowered.get(&key) {
             let cs = classify_items(&lf.items, self.source);
-            let has_dynamic = lf.items.iter().any(|item| item_is_dynamic(item, &data.dynamic_nodes));
-            data.fragments.content_types.insert(key, cs);
+            let has_dynamic = lf.items.iter().any(|item| item_is_dynamic(item, &ctx.data.dynamic_nodes));
+            ctx.data.fragments.content_types.insert(key, cs);
             if has_dynamic {
-                data.fragments.has_dynamic_children.insert(key);
+                ctx.data.fragments.has_dynamic_children.insert(key);
             }
         }
 
         // Compute needs_var (same logic as former NeedsVarVisitor)
-        if element_needs_var(el, data) {
-            data.element_flags.needs_var.insert(el.id);
+        if element_needs_var(el, ctx.data) {
+            ctx.data.element_flags.needs_var.insert(el.id);
         }
     }
 }

--- a/crates/svelte_analyze/src/element_flags.rs
+++ b/crates/svelte_analyze/src/element_flags.rs
@@ -1,13 +1,12 @@
 //! ElementFlagsVisitor — precompute element attribute flags in one walker pass.
 
-use oxc_semantic::ScopeId;
 use svelte_ast::{
     Attribute, BindDirective, ClassDirective, ComponentNode, Element, ExpressionAttribute,
     NodeId, SpreadAttribute, StyleDirective, SvelteElement, UseDirective,
 };
 use svelte_span::Span;
 
-use crate::data::{AnalysisData, ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, EventHandlerMode};
+use crate::data::{ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, EventHandlerMode};
 use crate::walker::TemplateVisitor;
 
 pub(crate) struct ElementFlagsVisitor<'src> {
@@ -27,37 +26,37 @@ impl<'src> ElementFlagsVisitor<'src> {
 }
 
 impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
-    fn visit_element(&mut self, el: &Element, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_element(&mut self, el: &Element, ctx: &mut crate::walker::VisitContext<'_>) {
         self.current_element_id = Some(el.id);
         self.current_element_name = Some(el.name.clone());
         // String/Boolean attributes aren't dispatched by the walker, so handle them here
         for attr in &el.attributes {
             match attr {
                 Attribute::StringAttribute(sa) if sa.name == "class" => {
-                    data.element_flags.static_class.insert(el.id, self.source_text(sa.value_span).to_string());
+                    ctx.data.element_flags.static_class.insert(el.id, self.source_text(sa.value_span).to_string());
                 }
                 Attribute::StringAttribute(sa) if sa.name == "style" => {
-                    data.element_flags.static_style.insert(el.id, self.source_text(sa.value_span).to_string());
+                    ctx.data.element_flags.static_style.insert(el.id, self.source_text(sa.value_span).to_string());
                 }
                 _ => {}
             }
         }
     }
 
-    fn leave_element(&mut self, _el: &Element, _scope: ScopeId, _data: &mut AnalysisData) {
+    fn leave_element(&mut self, _el: &Element, _ctx: &mut crate::walker::VisitContext<'_>) {
         self.current_element_id = None;
         self.current_element_name = None;
     }
 
-    fn visit_spread_attribute(&mut self, _attr: &SpreadAttribute, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_spread_attribute(&mut self, _attr: &SpreadAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
         if let Some(el_id) = self.current_element_id {
-            data.element_flags.has_spread.insert(el_id);
+            ctx.data.element_flags.has_spread.insert(el_id);
         }
     }
 
-    fn visit_class_directive(&mut self, cd: &ClassDirective, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_class_directive(&mut self, cd: &ClassDirective, ctx: &mut crate::walker::VisitContext<'_>) {
         if let Some(el_id) = self.current_element_id {
-            data.element_flags.class_directive_info
+            ctx.data.element_flags.class_directive_info
                 .get_or_default(el_id)
                 .push(ClassDirectiveInfo {
                     id: cd.id,
@@ -67,21 +66,21 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
         }
     }
 
-    fn visit_style_directive(&mut self, sd: &StyleDirective, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_style_directive(&mut self, sd: &StyleDirective, ctx: &mut crate::walker::VisitContext<'_>) {
         if let Some(el_id) = self.current_element_id {
-            data.element_flags.style_directives
+            ctx.data.element_flags.style_directives
                 .get_or_default(el_id)
                 .push(sd.clone());
         }
     }
 
-    fn visit_expression_attribute(&mut self, ea: &ExpressionAttribute, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_expression_attribute(&mut self, ea: &ExpressionAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
         if let Some(el_id) = self.current_element_id {
             if ea.name == "class" {
-                data.element_flags.class_attr_id.insert(el_id, ea.id);
+                ctx.data.element_flags.class_attr_id.insert(el_id, ea.id);
             }
             if ea.name == "value" && self.current_element_name.as_deref() == Some("input") {
-                data.element_flags.needs_input_defaults.insert(el_id);
+                ctx.data.element_flags.needs_input_defaults.insert(el_id);
             }
             if ea.event_name.is_some() {
                 let raw = ea.event_name.as_deref().unwrap();
@@ -96,28 +95,29 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
                 } else {
                     EventHandlerMode::Direct { capture, passive }
                 };
-                data.element_flags.event_handler_mode.insert(ea.id, mode);
+                ctx.data.element_flags.event_handler_mode.insert(ea.id, mode);
             }
         }
     }
 
-    fn visit_bind_directive(&mut self, bd: &BindDirective, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_bind_directive(&mut self, bd: &BindDirective, ctx: &mut crate::walker::VisitContext<'_>) {
         if let Some(el_id) = self.current_element_id {
             if self.current_element_name.as_deref() == Some("input")
                 && matches!(bd.name.as_str(), "value" | "checked" | "group")
             {
-                data.element_flags.needs_input_defaults.insert(el_id);
+                ctx.data.element_flags.needs_input_defaults.insert(el_id);
             }
         }
     }
 
-    fn visit_use_directive(&mut self, _dir: &UseDirective, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_use_directive(&mut self, _dir: &UseDirective, ctx: &mut crate::walker::VisitContext<'_>) {
         if let Some(el_id) = self.current_element_id {
-            data.element_flags.has_use_directive.insert(el_id);
+            ctx.data.element_flags.has_use_directive.insert(el_id);
         }
     }
 
-    fn visit_component_node(&mut self, cn: &ComponentNode, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut crate::walker::VisitContext<'_>) {
+        let data = &mut *ctx.data;
         for attr in &cn.attributes {
             let kind = match attr {
                 Attribute::StringAttribute(a) => ComponentPropKind::String {
@@ -184,9 +184,9 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
     fn visit_svelte_element(
         &mut self,
         el: &SvelteElement,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
+        let data = &mut *ctx.data;
         for attr in &el.attributes {
             match attr {
                 Attribute::ClassDirective(cd) => {

--- a/crates/svelte_analyze/src/hoistable.rs
+++ b/crates/svelte_analyze/src/hoistable.rs
@@ -2,7 +2,7 @@
 //!
 //! A snippet is hoistable if its body doesn't reference any script-declared variables.
 
-use oxc_semantic::{ScopeId, SymbolId};
+use oxc_semantic::SymbolId;
 use rustc_hash::FxHashSet;
 use svelte_ast::{
     AnimateDirective, AttachTag, BindDirective, ClassDirective, ComponentNode,
@@ -66,8 +66,7 @@ impl TemplateVisitor for HoistableSnippetsVisitor {
     fn visit_snippet_block(
         &mut self,
         block: &SnippetBlock,
-        _scope: ScopeId,
-        _data: &mut AnalysisData,
+        _ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         if self.top_level_ids.contains(&block.id) {
             self.current_root = Some(block.id);
@@ -77,12 +76,11 @@ impl TemplateVisitor for HoistableSnippetsVisitor {
     fn leave_snippet_block(
         &mut self,
         block: &SnippetBlock,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         if self.top_level_ids.contains(&block.id) {
             if !self.tainted.contains(&block.id) {
-                data.snippets.hoistable.insert(block.id);
+                ctx.data.snippets.hoistable.insert(block.id);
             }
             self.current_root = None;
         }
@@ -91,74 +89,71 @@ impl TemplateVisitor for HoistableSnippetsVisitor {
     fn visit_expression_tag(
         &mut self,
         tag: &ExpressionTag,
-        _scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        self.check_expr(&tag.id, data);
+        self.check_expr(&tag.id, ctx.data);
     }
 
-    fn visit_render_tag(&mut self, tag: &RenderTag, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_expr(&tag.id, data);
+    fn visit_render_tag(&mut self, tag: &RenderTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_expr(&tag.id, ctx.data);
     }
 
-    fn visit_html_tag(&mut self, tag: &HtmlTag, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_expr(&tag.id, data);
+    fn visit_html_tag(&mut self, tag: &HtmlTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_expr(&tag.id, ctx.data);
     }
 
-    fn visit_if_block(&mut self, block: &IfBlock, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_expr(&block.id, data);
+    fn visit_if_block(&mut self, block: &IfBlock, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_expr(&block.id, ctx.data);
     }
 
     fn visit_each_block(
         &mut self,
         block: &EachBlock,
-        _parent_scope: ScopeId,
-        _body_scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        self.check_expr(&block.id, data);
+        self.check_expr(&block.id, ctx.data);
     }
 
-    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(attr.id, data);
+    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(attr.id, ctx.data);
     }
-    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(attr.id, data);
+    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(attr.id, ctx.data);
     }
-    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(attr.id, data);
+    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(attr.id, ctx.data);
     }
-    fn visit_shorthand(&mut self, attr: &Shorthand, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(attr.id, data);
+    fn visit_shorthand(&mut self, attr: &Shorthand, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(attr.id, ctx.data);
     }
-    fn visit_class_directive(&mut self, dir: &ClassDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_class_directive(&mut self, dir: &ClassDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_style_directive(&mut self, dir: &StyleDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_style_directive(&mut self, dir: &StyleDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_bind_directive(&mut self, dir: &BindDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_bind_directive(&mut self, dir: &BindDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_use_directive(&mut self, dir: &UseDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_use_directive(&mut self, dir: &UseDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_on_directive_legacy(&mut self, dir: &OnDirectiveLegacy, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_on_directive_legacy(&mut self, dir: &OnDirectiveLegacy, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_transition_directive(&mut self, dir: &TransitionDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_transition_directive(&mut self, dir: &TransitionDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_animate_directive(&mut self, dir: &AnimateDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(dir.id, data);
+    fn visit_animate_directive(&mut self, dir: &AnimateDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(dir.id, ctx.data);
     }
-    fn visit_attach_tag(&mut self, tag: &AttachTag, _scope: ScopeId, data: &mut AnalysisData) {
-        self.check_attr_expr(tag.id, data);
+    fn visit_attach_tag(&mut self, tag: &AttachTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.check_attr_expr(tag.id, ctx.data);
     }
 
-    fn visit_component_node(&mut self, cn: &ComponentNode, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut crate::walker::VisitContext<'_>) {
         for attr in &cn.attributes {
-            self.check_attr_expr(attr.id(), data);
+            self.check_attr_expr(attr.id(), ctx.data);
         }
     }
 }

--- a/crates/svelte_analyze/src/js_analyze.rs
+++ b/crates/svelte_analyze/src/js_analyze.rs
@@ -251,7 +251,7 @@ pub(crate) fn extract_all_expressions(
 ) {
     let root = data.scoping.root_scope_id();
     let mut visitor = ExpressionExtractor { parsed };
-    let mut ctx = crate::walker::VisitContext::new(root, data);
+    let mut ctx = crate::walker::VisitContext::with_parsed(root, data, parsed);
     crate::walker::walk_template(&component.fragment, &mut ctx, &mut [&mut visitor]);
 
     // Extract CE config (not template-related)

--- a/crates/svelte_analyze/src/js_analyze.rs
+++ b/crates/svelte_analyze/src/js_analyze.rs
@@ -250,7 +250,11 @@ pub(crate) fn extract_all_expressions(
     data: &mut AnalysisData,
 ) {
     let root = data.scoping.root_scope_id();
-    let mut visitor = ExpressionExtractor { parsed, pending_render_tag: None };
+    let mut visitor = ExpressionExtractor {
+        pending_render_tag: None,
+        pending_shorthand: None,
+        pending_clsx: false,
+    };
     let mut ctx = crate::walker::VisitContext::with_parsed(root, data, parsed);
     crate::walker::walk_template(&component.fragment, &mut ctx, &mut [&mut visitor]);
 
@@ -267,13 +271,14 @@ pub(crate) fn extract_all_expressions(
     }
 }
 
-struct ExpressionExtractor<'a, 'b> {
-    parsed: &'b ParserResult<'a>,
+struct ExpressionExtractor {
     pending_render_tag: Option<NodeId>,
+    pending_shorthand: Option<(NodeId, String)>,
+    pending_clsx: bool,
 }
 
-impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
-    // --- Generic expression hook replaces 16 boilerplate visit methods ---
+impl crate::walker::TemplateVisitor for ExpressionExtractor {
+    // --- Offset storage ---
 
     fn visit_expression(
         &mut self,
@@ -282,19 +287,60 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
         ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         if ctx.parent().map_or(false, |p| p.kind.is_attr()) {
-            // Attribute expression — skip if already populated (e.g. concat merge)
             if !ctx.data.attr_expr_offsets.contains_key(node_id) {
-                insert_attr_expr_info(self.parsed, ctx.data, node_id, span.start);
+                ctx.data.attr_expr_offsets.insert(node_id, span.start);
             }
-        } else {
-            // Template node expression — skip if already populated (e.g. EachBlock key after collection)
-            if !ctx.data.node_expr_offsets.contains_key(node_id) {
-                insert_node_expr_info(self.parsed, ctx.data, node_id, span.start);
+        } else if !ctx.data.node_expr_offsets.contains_key(node_id) {
+            ctx.data.node_expr_offsets.insert(node_id, span.start);
+        }
+    }
+
+    // --- Parsed expression analysis ---
+
+    fn visit_js_expression(
+        &mut self,
+        node_id: svelte_ast::NodeId,
+        expr: &Expression<'_>,
+        ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
+        // Store ExpressionInfo (replaces insert_node_expr_info / insert_attr_expr_info)
+        if ctx.parent().map_or(false, |p| p.kind.is_attr()) {
+            if !ctx.data.attr_expressions.contains_key(node_id) {
+                ctx.data.attr_expressions.insert(node_id, analyze_expression(expr));
+            }
+        } else if !ctx.data.expressions.contains_key(node_id) {
+            ctx.data.expressions.insert(node_id, analyze_expression(expr));
+        }
+
+        // Render tag: classify arguments
+        if self.pending_render_tag.take() == Some(node_id) {
+            classify_render_tag_args(expr, ctx.data, node_id);
+        }
+
+        // Shorthand detection (set by visit_expression_attribute / visit_class_directive / visit_style_directive)
+        if let Some((attr_id, name)) = self.pending_shorthand.take() {
+            if let Expression::Identifier(ident) = expr {
+                if ident.name.as_str() == name {
+                    ctx.data.element_flags.expression_shorthand.insert(attr_id);
+                }
+            }
+        }
+
+        // Clsx detection for class={expr}
+        if self.pending_clsx {
+            self.pending_clsx = false;
+            if !matches!(
+                expr,
+                Expression::StringLiteral(_)
+                    | Expression::TemplateLiteral(_)
+                    | Expression::BinaryExpression(_)
+            ) {
+                ctx.data.element_flags.needs_clsx.insert(node_id);
             }
         }
     }
 
-    // --- Methods kept for extra logic beyond basic expression analysis ---
+    // --- Hooks that set pending state for visit_js_expression ---
 
     fn visit_render_tag(
         &mut self,
@@ -304,53 +350,24 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
         self.pending_render_tag = Some(tag.id);
     }
 
-    fn visit_js_expression(
-        &mut self,
-        node_id: svelte_ast::NodeId,
-        expr: &Expression<'_>,
-        ctx: &mut crate::walker::VisitContext<'_>,
-    ) {
-        if self.pending_render_tag.take() == Some(node_id) {
-            classify_render_tag_args(expr, ctx.data, node_id);
-        }
-    }
-
     fn visit_const_tag(
         &mut self,
         tag: &svelte_ast::ConstTag,
         ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        // ConstTag is a statement — visit_expression doesn't fire for it.
+        // ConstTag is a statement — visit_expression/visit_js_expression don't fire.
         // Store offset so codegen can look up the parsed statement.
-        insert_node_expr_info(self.parsed, ctx.data, tag.id, tag.expression_span.start);
+        ctx.data.node_expr_offsets.insert(tag.id, tag.expression_span.start);
     }
 
     fn visit_expression_attribute(
         &mut self,
         attr: &svelte_ast::ExpressionAttribute,
-        ctx: &mut crate::walker::VisitContext<'_>,
+        _ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        // Detect semantic shorthand: expression is a simple identifier matching attr name
-        if let Some(Expression::Identifier(ident)) =
-            self.parsed.exprs.get(&attr.expression_span.start)
-        {
-            if ident.name.as_str() == attr.name {
-                ctx.data.element_flags.expression_shorthand.insert(attr.id);
-            }
-        }
-        // class={[...]} or class={{...}} or class={x} need clsx to resolve
+        self.pending_shorthand = Some((attr.id, attr.name.clone()));
         if attr.name == "class" {
-            if let Some(expr) = self.parsed.exprs.get(&attr.expression_span.start) {
-                let needs = !matches!(
-                    expr,
-                    Expression::StringLiteral(_)
-                        | Expression::TemplateLiteral(_)
-                        | Expression::BinaryExpression(_)
-                );
-                if needs {
-                    ctx.data.element_flags.needs_clsx.insert(attr.id);
-                }
-            }
+            self.pending_clsx = true;
         }
     }
 
@@ -359,22 +376,20 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
         attr: &svelte_ast::ConcatenationAttribute,
         ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        // Merge all dynamic parts into one ExpressionInfo before visit_expression fires per-part
-        insert_concat_expr_info(self.parsed, ctx.data, attr.id, &attr.parts);
+        // Merge all dynamic parts into one ExpressionInfo before per-part visit_js_expression
+        if let Some(parsed) = ctx.parsed() {
+            insert_concat_expr_info(parsed, ctx.data, attr.id, &attr.parts);
+        }
     }
 
     fn visit_class_directive(
         &mut self,
         dir: &svelte_ast::ClassDirective,
-        ctx: &mut crate::walker::VisitContext<'_>,
+        _ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        // Shorthand class:name has no expression_span — visit_expression won't fire
-        if let Some(span) = dir.expression_span {
-            if let Some(Expression::Identifier(ident)) = self.parsed.exprs.get(&span.start) {
-                if ident.name.as_str() == dir.name {
-                    ctx.data.element_flags.expression_shorthand.insert(dir.id);
-                }
-            }
+        // Only non-shorthand directives have an expression to check
+        if dir.expression_span.is_some() {
+            self.pending_shorthand = Some((dir.id, dir.name.clone()));
         }
     }
 
@@ -385,47 +400,16 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
     ) {
         use svelte_ast::StyleDirectiveValue;
         match &dir.value {
-            StyleDirectiveValue::Expression(span) => {
-                if let Some(Expression::Identifier(ident)) = self.parsed.exprs.get(&span.start) {
-                    if ident.name.as_str() == dir.name {
-                        ctx.data.element_flags.expression_shorthand.insert(dir.id);
-                    }
-                }
+            StyleDirectiveValue::Expression(_) => {
+                self.pending_shorthand = Some((dir.id, dir.name.clone()));
             }
             StyleDirectiveValue::Concatenation(parts) => {
-                // Merge before visit_expression fires per-part
-                insert_concat_expr_info(self.parsed, ctx.data, dir.id, parts);
+                if let Some(parsed) = ctx.parsed() {
+                    insert_concat_expr_info(parsed, ctx.data, dir.id, parts);
+                }
             }
             StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
         }
-    }
-}
-
-/// Look up a parsed expression by offset and store ExpressionInfo for a template node.
-fn insert_node_expr_info(
-    parsed: &ParserResult<'_>,
-    data: &mut AnalysisData,
-    node_id: NodeId,
-    offset: u32,
-) {
-    data.node_expr_offsets.insert(node_id, offset);
-    if let Some(expr) = parsed.exprs.get(&offset) {
-        let info = analyze_expression(expr);
-        data.expressions.insert(node_id, info);
-    }
-}
-
-/// Look up a parsed expression by offset and store ExpressionInfo for an attribute.
-fn insert_attr_expr_info(
-    parsed: &ParserResult<'_>,
-    data: &mut AnalysisData,
-    attr_id: NodeId,
-    offset: u32,
-) {
-    data.attr_expr_offsets.insert(attr_id, offset);
-    if let Some(expr) = parsed.exprs.get(&offset) {
-        let info = analyze_expression(expr);
-        data.attr_expressions.insert(attr_id, info);
     }
 }
 

--- a/crates/svelte_analyze/src/js_analyze.rs
+++ b/crates/svelte_analyze/src/js_analyze.rs
@@ -250,7 +250,7 @@ pub(crate) fn extract_all_expressions(
     data: &mut AnalysisData,
 ) {
     let root = data.scoping.root_scope_id();
-    let mut visitor = ExpressionExtractor { parsed };
+    let mut visitor = ExpressionExtractor { parsed, pending_render_tag: None };
     let mut ctx = crate::walker::VisitContext::with_parsed(root, data, parsed);
     crate::walker::walk_template(&component.fragment, &mut ctx, &mut [&mut visitor]);
 
@@ -269,6 +269,7 @@ pub(crate) fn extract_all_expressions(
 
 struct ExpressionExtractor<'a, 'b> {
     parsed: &'b ParserResult<'a>,
+    pending_render_tag: Option<NodeId>,
 }
 
 impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
@@ -298,9 +299,20 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
     fn visit_render_tag(
         &mut self,
         tag: &svelte_ast::RenderTag,
+        _ctx: &mut crate::walker::VisitContext<'_>,
+    ) {
+        self.pending_render_tag = Some(tag.id);
+    }
+
+    fn visit_js_expression(
+        &mut self,
+        node_id: svelte_ast::NodeId,
+        expr: &Expression<'_>,
         ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        classify_render_tag_args(self.parsed, ctx.data, tag);
+        if self.pending_render_tag.take() == Some(node_id) {
+            classify_render_tag_args(expr, ctx.data, node_id);
+        }
     }
 
     fn visit_const_tag(
@@ -447,18 +459,17 @@ fn insert_concat_expr_info(
 
 /// Extract render tag argument metadata (has_call flags, ident names) from a parsed CallExpression.
 fn classify_render_tag_args(
-    parsed: &ParserResult<'_>,
+    expr: &Expression<'_>,
     data: &mut AnalysisData,
-    tag: &svelte_ast::RenderTag,
+    tag_id: NodeId,
 ) {
-    let offset = tag.expression_span.start;
-    if let Some(Expression::CallExpression(call)) = parsed.exprs.get(&offset) {
+    if let Expression::CallExpression(call) = expr {
         let flags: Vec<bool> = call
             .arguments
             .iter()
             .map(|arg| expression_has_call(arg.to_expression()))
             .collect();
-        data.render_tag_arg_has_call.insert(tag.id, flags);
+        data.render_tag_arg_has_call.insert(tag_id, flags);
 
         let idents: Vec<Option<String>> = call
             .arguments
@@ -471,7 +482,7 @@ fn classify_render_tag_args(
                 }
             })
             .collect();
-        data.render_tag_arg_idents.insert(tag.id, idents);
+        data.render_tag_arg_idents.insert(tag_id, idents);
     }
 }
 

--- a/crates/svelte_analyze/src/js_analyze.rs
+++ b/crates/svelte_analyze/src/js_analyze.rs
@@ -65,7 +65,8 @@ pub(crate) fn classify_render_tags(
 ) {
     let root = data.scoping.root_scope_id();
     let mut visitor = RenderTagClassifier { parsed };
-    crate::walker::walk_template(&component.fragment, data, root, &mut [&mut visitor]);
+    let mut ctx = crate::walker::VisitContext::new(root, data);
+    crate::walker::walk_template(&component.fragment, &mut ctx, &mut [&mut visitor]);
 }
 
 struct RenderTagClassifier<'a, 'b> {
@@ -76,15 +77,14 @@ impl crate::walker::TemplateVisitor for RenderTagClassifier<'_, '_> {
     fn visit_render_tag(
         &mut self,
         tag: &svelte_ast::RenderTag,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         let offset = tag.expression_span.start;
         if matches!(
             self.parsed.exprs.get(&offset),
             Some(Expression::ChainExpression(_))
         ) {
-            data.render_tag_is_chain.insert(tag.id);
+            ctx.data.render_tag_is_chain.insert(tag.id);
             if let Some(Expression::ChainExpression(chain)) = self.parsed.exprs.remove(&offset) {
                 if let oxc_ast::ast::ChainElement::CallExpression(call) = chain.unbox().expression {
                     self.parsed
@@ -95,7 +95,7 @@ impl crate::walker::TemplateVisitor for RenderTagClassifier<'_, '_> {
         }
         if let Some(Expression::CallExpression(call)) = self.parsed.exprs.get(&offset) {
             if let Expression::Identifier(ident) = &call.callee {
-                data.render_tag_callee_name
+                ctx.data.render_tag_callee_name
                     .insert(tag.id, ident.name.to_string());
             }
         }
@@ -117,7 +117,8 @@ pub(crate) fn prepare_template_bindings(
 ) {
     let root = data.scoping.root_scope_id();
     let mut visitor = BindingPreparer { parsed };
-    crate::walker::walk_template(&component.fragment, data, root, &mut [&mut visitor]);
+    let mut ctx = crate::walker::VisitContext::new(root, data);
+    crate::walker::walk_template(&component.fragment, &mut ctx, &mut [&mut visitor]);
 }
 
 struct BindingPreparer<'a, 'b> {
@@ -128,17 +129,16 @@ impl crate::walker::TemplateVisitor for BindingPreparer<'_, '_> {
     fn visit_await_block(
         &mut self,
         block: &svelte_ast::AwaitBlock,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         if let Some(val_span) = block.value_span {
             if let Some(info) = extract_await_binding_info(self.parsed, val_span.start) {
-                data.await_bindings.values.insert(block.id, info);
+                ctx.data.await_bindings.values.insert(block.id, info);
             }
         }
         if let Some(err_span) = block.error_span {
             if let Some(info) = extract_await_binding_info(self.parsed, err_span.start) {
-                data.await_bindings.errors.insert(block.id, info);
+                ctx.data.await_bindings.errors.insert(block.id, info);
             }
         }
     }
@@ -251,7 +251,8 @@ pub(crate) fn extract_all_expressions(
 ) {
     let root = data.scoping.root_scope_id();
     let mut visitor = ExpressionExtractor { parsed };
-    crate::walker::walk_template(&component.fragment, data, root, &mut [&mut visitor]);
+    let mut ctx = crate::walker::VisitContext::new(root, data);
+    crate::walker::walk_template(&component.fragment, &mut ctx, &mut [&mut visitor]);
 
     // Extract CE config (not template-related)
     if let Some(svelte_ast::CustomElementConfig::Expression(span)) = component
@@ -271,118 +272,58 @@ struct ExpressionExtractor<'a, 'b> {
 }
 
 impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
-    fn visit_expression_tag(
+    // --- Generic expression hook replaces 16 boilerplate visit methods ---
+
+    fn visit_expression(
         &mut self,
-        tag: &svelte_ast::ExpressionTag,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        node_id: svelte_ast::NodeId,
+        span: svelte_span::Span,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        insert_node_expr_info(self.parsed, data, tag.id, tag.expression_span.start);
+        if ctx.parent().map_or(false, |p| p.kind.is_attr()) {
+            // Attribute expression — skip if already populated (e.g. concat merge)
+            if !ctx.data.attr_expr_offsets.contains_key(node_id) {
+                insert_attr_expr_info(self.parsed, ctx.data, node_id, span.start);
+            }
+        } else {
+            // Template node expression — skip if already populated (e.g. EachBlock key after collection)
+            if !ctx.data.node_expr_offsets.contains_key(node_id) {
+                insert_node_expr_info(self.parsed, ctx.data, node_id, span.start);
+            }
+        }
     }
 
-    fn visit_if_block(
-        &mut self,
-        block: &svelte_ast::IfBlock,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_node_expr_info(self.parsed, data, block.id, block.test_span.start);
-    }
-
-    fn visit_each_block(
-        &mut self,
-        block: &svelte_ast::EachBlock,
-        _parent_scope: oxc_semantic::ScopeId,
-        _body_scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_node_expr_info(self.parsed, data, block.id, block.expression_span.start);
-    }
+    // --- Methods kept for extra logic beyond basic expression analysis ---
 
     fn visit_render_tag(
         &mut self,
         tag: &svelte_ast::RenderTag,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        insert_node_expr_info(self.parsed, data, tag.id, tag.expression_span.start);
-        classify_render_tag_args(self.parsed, data, tag);
-    }
-
-    fn visit_html_tag(
-        &mut self,
-        tag: &svelte_ast::HtmlTag,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_node_expr_info(self.parsed, data, tag.id, tag.expression_span.start);
-    }
-
-    fn visit_key_block(
-        &mut self,
-        block: &svelte_ast::KeyBlock,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_node_expr_info(self.parsed, data, block.id, block.expression_span.start);
-    }
-
-    fn visit_await_block(
-        &mut self,
-        block: &svelte_ast::AwaitBlock,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        // Binding info already extracted by prepare_template_bindings
-        insert_node_expr_info(self.parsed, data, block.id, block.expression_span.start);
+        classify_render_tag_args(self.parsed, ctx.data, tag);
     }
 
     fn visit_const_tag(
         &mut self,
         tag: &svelte_ast::ConstTag,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        insert_node_expr_info(self.parsed, data, tag.id, tag.expression_span.start);
+        // ConstTag is a statement — visit_expression doesn't fire for it.
+        // Store offset so codegen can look up the parsed statement.
+        insert_node_expr_info(self.parsed, ctx.data, tag.id, tag.expression_span.start);
     }
-
-    fn visit_snippet_block(
-        &mut self,
-        _block: &svelte_ast::SnippetBlock,
-        _scope: oxc_semantic::ScopeId,
-        _data: &mut AnalysisData,
-    ) {
-        // Snippet params transferred by transfer_snippet_params before this pass
-    }
-
-    fn visit_svelte_element(
-        &mut self,
-        el: &svelte_ast::SvelteElement,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        if !el.static_tag {
-            insert_node_expr_info(self.parsed, data, el.id, el.tag_span.start);
-        }
-    }
-
-    // --- Attribute visits ---
 
     fn visit_expression_attribute(
         &mut self,
         attr: &svelte_ast::ExpressionAttribute,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        let attr_id = attr.id;
-        insert_attr_expr_info(self.parsed, data, attr_id, attr.expression_span.start);
-
         // Detect semantic shorthand: expression is a simple identifier matching attr name
         if let Some(Expression::Identifier(ident)) =
             self.parsed.exprs.get(&attr.expression_span.start)
         {
             if ident.name.as_str() == attr.name {
-                data.element_flags.expression_shorthand.insert(attr_id);
+                ctx.data.element_flags.expression_shorthand.insert(attr.id);
             }
         }
         // class={[...]} or class={{...}} or class={x} need clsx to resolve
@@ -395,7 +336,7 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
                         | Expression::BinaryExpression(_)
                 );
                 if needs {
-                    data.element_flags.needs_clsx.insert(attr_id);
+                    ctx.data.element_flags.needs_clsx.insert(attr.id);
                 }
             }
         }
@@ -404,23 +345,22 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
     fn visit_concatenation_attribute(
         &mut self,
         attr: &svelte_ast::ConcatenationAttribute,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
-        insert_concat_expr_info(self.parsed, data, attr.id, &attr.parts);
+        // Merge all dynamic parts into one ExpressionInfo before visit_expression fires per-part
+        insert_concat_expr_info(self.parsed, ctx.data, attr.id, &attr.parts);
     }
 
     fn visit_class_directive(
         &mut self,
         dir: &svelte_ast::ClassDirective,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
+        // Shorthand class:name has no expression_span — visit_expression won't fire
         if let Some(span) = dir.expression_span {
-            insert_attr_expr_info(self.parsed, data, dir.id, span.start);
             if let Some(Expression::Identifier(ident)) = self.parsed.exprs.get(&span.start) {
                 if ident.name.as_str() == dir.name {
-                    data.element_flags.expression_shorthand.insert(dir.id);
+                    ctx.data.element_flags.expression_shorthand.insert(dir.id);
                 }
             }
         }
@@ -429,106 +369,23 @@ impl crate::walker::TemplateVisitor for ExpressionExtractor<'_, '_> {
     fn visit_style_directive(
         &mut self,
         dir: &svelte_ast::StyleDirective,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut crate::walker::VisitContext<'_>,
     ) {
         use svelte_ast::StyleDirectiveValue;
         match &dir.value {
             StyleDirectiveValue::Expression(span) => {
-                insert_attr_expr_info(self.parsed, data, dir.id, span.start);
                 if let Some(Expression::Identifier(ident)) = self.parsed.exprs.get(&span.start) {
                     if ident.name.as_str() == dir.name {
-                        data.element_flags.expression_shorthand.insert(dir.id);
+                        ctx.data.element_flags.expression_shorthand.insert(dir.id);
                     }
                 }
             }
             StyleDirectiveValue::Concatenation(parts) => {
-                insert_concat_expr_info(self.parsed, data, dir.id, parts);
+                // Merge before visit_expression fires per-part
+                insert_concat_expr_info(self.parsed, ctx.data, dir.id, parts);
             }
             StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
         }
-    }
-
-    fn visit_bind_directive(
-        &mut self,
-        dir: &svelte_ast::BindDirective,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        if let Some(span) = dir.expression_span {
-            insert_attr_expr_info(self.parsed, data, dir.id, span.start);
-        }
-    }
-
-    fn visit_spread_attribute(
-        &mut self,
-        attr: &svelte_ast::SpreadAttribute,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_attr_expr_info(self.parsed, data, attr.id, attr.expression_span.start);
-    }
-
-    fn visit_shorthand(
-        &mut self,
-        attr: &svelte_ast::Shorthand,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_attr_expr_info(self.parsed, data, attr.id, attr.expression_span.start);
-    }
-
-    fn visit_use_directive(
-        &mut self,
-        dir: &svelte_ast::UseDirective,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        if let Some(span) = dir.expression_span {
-            insert_attr_expr_info(self.parsed, data, dir.id, span.start);
-        }
-    }
-
-    fn visit_on_directive_legacy(
-        &mut self,
-        dir: &svelte_ast::OnDirectiveLegacy,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        if let Some(span) = dir.expression_span {
-            insert_attr_expr_info(self.parsed, data, dir.id, span.start);
-        }
-    }
-
-    fn visit_transition_directive(
-        &mut self,
-        dir: &svelte_ast::TransitionDirective,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        if let Some(span) = dir.expression_span {
-            insert_attr_expr_info(self.parsed, data, dir.id, span.start);
-        }
-    }
-
-    fn visit_animate_directive(
-        &mut self,
-        dir: &svelte_ast::AnimateDirective,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        if let Some(span) = dir.expression_span {
-            insert_attr_expr_info(self.parsed, data, dir.id, span.start);
-        }
-    }
-
-    fn visit_attach_tag(
-        &mut self,
-        tag: &svelte_ast::AttachTag,
-        _scope: oxc_semantic::ScopeId,
-        data: &mut AnalysisData,
-    ) {
-        insert_attr_expr_info(self.parsed, data, tag.id, tag.expression_span.start);
     }
 }
 

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -106,10 +106,10 @@ pub fn analyze_with_options<'a>(
             parsed: &parsed,
         };
         let mut v2 = resolve_references::make_visitor(component, scoping_built);
+        let mut ctx = walker::VisitContext::new(root, &mut data);
         walker::walk_template(
             &component.fragment,
-            &mut data,
-            root,
+            &mut ctx,
             &mut [&mut v1, &mut v2],
         );
     }
@@ -152,10 +152,10 @@ pub fn analyze_with_options<'a>(
         let mut v5 = content_types::ContentAndVarVisitor {
             source: &component.source,
         };
+        let mut ctx = walker::VisitContext::new(root, &mut data);
         walker::walk_template(
             &component.fragment,
-            &mut data,
-            root,
+            &mut ctx,
             &mut [&mut v1, &mut v2, &mut v3, &mut v4, &mut v5],
         );
     }

--- a/crates/svelte_analyze/src/reactivity.rs
+++ b/crates/svelte_analyze/src/reactivity.rs
@@ -1,4 +1,3 @@
-use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, AwaitBlock, BindDirective, ClassDirective,
     ConcatenationAttribute, ComponentNode, ConstTag, EachBlock,
@@ -72,140 +71,140 @@ impl ReactivityVisitor {
 }
 
 impl TemplateVisitor for ReactivityVisitor {
-    fn visit_expression_tag(&mut self, tag: &ExpressionTag, _scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&tag.id, data) {
-            data.dynamic_nodes.insert(tag.id);
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&tag.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(tag.id);
         }
     }
 
-    fn visit_render_tag(&mut self, tag: &RenderTag, _scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&tag.id, data) {
-            data.dynamic_nodes.insert(tag.id);
+    fn visit_render_tag(&mut self, tag: &RenderTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&tag.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(tag.id);
         }
     }
 
-    fn visit_html_tag(&mut self, tag: &HtmlTag, _scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&tag.id, data) {
-            data.dynamic_nodes.insert(tag.id);
+    fn visit_html_tag(&mut self, tag: &HtmlTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&tag.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(tag.id);
         }
     }
 
-    fn visit_const_tag(&mut self, tag: &ConstTag, _scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&tag.id, data) {
-            data.dynamic_nodes.insert(tag.id);
+    fn visit_const_tag(&mut self, tag: &ConstTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&tag.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(tag.id);
         }
     }
 
-    fn visit_element(&mut self, el: &Element, _scope: ScopeId, _data: &mut AnalysisData) {
+    fn visit_element(&mut self, el: &Element, _ctx: &mut crate::walker::VisitContext<'_>) {
         self.current_element_id = Some(el.id);
     }
 
-    fn leave_element(&mut self, _el: &Element, _scope: ScopeId, _data: &mut AnalysisData) {
+    fn leave_element(&mut self, _el: &Element, _ctx: &mut crate::walker::VisitContext<'_>) {
         self.current_element_id = None;
     }
 
-    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, _scope: ScopeId, data: &mut AnalysisData) {
-        if attr_id_is_dynamic(attr.id, data) {
-            data.element_flags.dynamic_attrs.insert(attr.id);
-            self.mark_element_needs_ref(data);
+    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
+        if attr_id_is_dynamic(attr.id, ctx.data) {
+            ctx.data.element_flags.dynamic_attrs.insert(attr.id);
+            self.mark_element_needs_ref(ctx.data);
         }
     }
 
-    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, _scope: ScopeId, data: &mut AnalysisData) {
-        if attr_id_is_dynamic(attr.id, data) {
-            data.element_flags.dynamic_attrs.insert(attr.id);
-            self.mark_element_needs_ref(data);
+    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
+        if attr_id_is_dynamic(attr.id, ctx.data) {
+            ctx.data.element_flags.dynamic_attrs.insert(attr.id);
+            self.mark_element_needs_ref(ctx.data);
         }
     }
 
-    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, _scope: ScopeId, data: &mut AnalysisData) {
-        if attr_id_is_dynamic(attr.id, data) {
-            data.element_flags.dynamic_attrs.insert(attr.id);
-            self.mark_element_needs_ref(data);
+    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, ctx: &mut crate::walker::VisitContext<'_>) {
+        if attr_id_is_dynamic(attr.id, ctx.data) {
+            ctx.data.element_flags.dynamic_attrs.insert(attr.id);
+            self.mark_element_needs_ref(ctx.data);
         }
     }
 
-    fn visit_shorthand(&mut self, attr: &Shorthand, _scope: ScopeId, data: &mut AnalysisData) {
-        if attr_id_is_dynamic(attr.id, data) {
-            data.element_flags.dynamic_attrs.insert(attr.id);
-            self.mark_element_needs_ref(data);
+    fn visit_shorthand(&mut self, attr: &Shorthand, ctx: &mut crate::walker::VisitContext<'_>) {
+        if attr_id_is_dynamic(attr.id, ctx.data) {
+            ctx.data.element_flags.dynamic_attrs.insert(attr.id);
+            self.mark_element_needs_ref(ctx.data);
         }
     }
 
-    fn visit_class_directive(&mut self, dir: &ClassDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        if attr_id_is_dynamic(dir.id, data) {
-            data.element_flags.dynamic_attrs.insert(dir.id);
-            self.mark_element_needs_ref(data);
+    fn visit_class_directive(&mut self, dir: &ClassDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        if attr_id_is_dynamic(dir.id, ctx.data) {
+            ctx.data.element_flags.dynamic_attrs.insert(dir.id);
+            self.mark_element_needs_ref(ctx.data);
             if let Some(el_id) = self.current_element_id {
-                data.element_flags.has_dynamic_class_directives.insert(el_id);
+                ctx.data.element_flags.has_dynamic_class_directives.insert(el_id);
             }
         }
     }
 
-    fn visit_style_directive(&mut self, dir: &StyleDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        if attr_id_is_dynamic(dir.id, data) {
-            data.element_flags.dynamic_attrs.insert(dir.id);
-            self.mark_element_needs_ref(data);
+    fn visit_style_directive(&mut self, dir: &StyleDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        if attr_id_is_dynamic(dir.id, ctx.data) {
+            ctx.data.element_flags.dynamic_attrs.insert(dir.id);
+            self.mark_element_needs_ref(ctx.data);
         }
     }
 
-    fn visit_bind_directive(&mut self, _dir: &BindDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.mark_element_needs_ref(data);
+    fn visit_bind_directive(&mut self, _dir: &BindDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.mark_element_needs_ref(ctx.data);
     }
 
-    fn visit_use_directive(&mut self, _dir: &UseDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.mark_element_needs_ref(data);
+    fn visit_use_directive(&mut self, _dir: &UseDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.mark_element_needs_ref(ctx.data);
     }
 
-    fn visit_transition_directive(&mut self, _dir: &TransitionDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.mark_element_needs_ref(data);
+    fn visit_transition_directive(&mut self, _dir: &TransitionDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.mark_element_needs_ref(ctx.data);
     }
 
-    fn visit_animate_directive(&mut self, _dir: &AnimateDirective, _scope: ScopeId, data: &mut AnalysisData) {
-        self.mark_element_needs_ref(data);
+    fn visit_animate_directive(&mut self, _dir: &AnimateDirective, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.mark_element_needs_ref(ctx.data);
     }
 
-    fn visit_attach_tag(&mut self, _tag: &AttachTag, _scope: ScopeId, data: &mut AnalysisData) {
-        self.mark_element_needs_ref(data);
+    fn visit_attach_tag(&mut self, _tag: &AttachTag, ctx: &mut crate::walker::VisitContext<'_>) {
+        self.mark_element_needs_ref(ctx.data);
     }
 
-    fn visit_if_block(&mut self, block: &IfBlock, _scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&block.id, data) {
-            data.dynamic_nodes.insert(block.id);
+    fn visit_if_block(&mut self, block: &IfBlock, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&block.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(block.id);
         }
     }
 
-    fn visit_each_block(&mut self, block: &EachBlock, _parent_scope: ScopeId, _body_scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&block.id, data) {
-            data.dynamic_nodes.insert(block.id);
+    fn visit_each_block(&mut self, block: &EachBlock, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&block.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(block.id);
         }
     }
 
-    fn visit_key_block(&mut self, block: &KeyBlock, _scope: ScopeId, data: &mut AnalysisData) {
-        if self.expr_is_dynamic(&block.id, data) {
-            data.dynamic_nodes.insert(block.id);
+    fn visit_key_block(&mut self, block: &KeyBlock, ctx: &mut crate::walker::VisitContext<'_>) {
+        if self.expr_is_dynamic(&block.id, ctx.data) {
+            ctx.data.dynamic_nodes.insert(block.id);
         }
     }
 
-    fn visit_await_block(&mut self, block: &AwaitBlock, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_await_block(&mut self, block: &AwaitBlock, ctx: &mut crate::walker::VisitContext<'_>) {
         // Await blocks are always dynamic
-        data.dynamic_nodes.insert(block.id);
+        ctx.data.dynamic_nodes.insert(block.id);
     }
 
-    fn visit_component_node(&mut self, cn: &ComponentNode, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut crate::walker::VisitContext<'_>) {
         for attr in &cn.attributes {
-            if component_attr_is_dynamic(attr, data) {
-                data.element_flags.dynamic_attrs.insert(attr.id());
+            if component_attr_is_dynamic(attr, ctx.data) {
+                ctx.data.element_flags.dynamic_attrs.insert(attr.id());
             }
         }
     }
 
-    fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, _scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, ctx: &mut crate::walker::VisitContext<'_>) {
         // Boundary attributes use the same has_state semantics as component props —
         // reactive expressions get getters so the boundary can re-read reactively.
         for attr in &boundary.attributes {
-            if component_attr_is_dynamic(attr, data) {
-                data.element_flags.dynamic_attrs.insert(attr.id());
+            if component_attr_is_dynamic(attr, ctx.data) {
+                ctx.data.element_flags.dynamic_attrs.insert(attr.id());
             }
         }
     }

--- a/crates/svelte_analyze/src/resolve_references.rs
+++ b/crates/svelte_analyze/src/resolve_references.rs
@@ -8,7 +8,7 @@ use svelte_ast::{
 };
 
 use crate::data::AnalysisData;
-use crate::walker::TemplateVisitor;
+use crate::walker::{TemplateVisitor, VisitContext};
 
 use svelte_ast::Component;
 
@@ -67,90 +67,87 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
     fn visit_expression_tag(
         &mut self,
         tag: &ExpressionTag,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
-        resolve_expr_refs(tag.id, scope, data);
+        resolve_expr_refs(tag.id, ctx.scope, ctx.data);
     }
 
-    fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_expr_refs(block.id, scope, data);
+    fn visit_if_block(&mut self, block: &IfBlock, ctx: &mut VisitContext<'_>) {
+        resolve_expr_refs(block.id, ctx.scope, ctx.data);
     }
 
     fn visit_each_block(
         &mut self,
         block: &EachBlock,
-        parent_scope: ScopeId,
-        _body_scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         // Collection expression belongs to parent scope, not the each-block's child scope.
-        resolve_expr_refs(block.id, parent_scope, data);
+        resolve_expr_refs(block.id, ctx.scope, ctx.data);
     }
 
-    fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_expr_refs(block.id, scope, data);
+    fn visit_key_block(&mut self, block: &KeyBlock, ctx: &mut VisitContext<'_>) {
+        resolve_expr_refs(block.id, ctx.scope, ctx.data);
     }
 
-    fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_expr_refs(tag.id, scope, data);
+    fn visit_render_tag(&mut self, tag: &RenderTag, ctx: &mut VisitContext<'_>) {
+        resolve_expr_refs(tag.id, ctx.scope, ctx.data);
 
         // Store the scope for this render tag so we can resolve dynamic callees later
         // (after props analysis populates is_prop_source).
-        if let Some(name) = data.render_tag_callee_name.get(tag.id) {
-            if let Some(sym_id) = data.scoping.find_binding(scope, name) {
-                data.render_tag_callee_sym.insert(tag.id, sym_id);
+        if let Some(name) = ctx.data.render_tag_callee_name.get(tag.id) {
+            if let Some(sym_id) = ctx.data.scoping.find_binding(ctx.scope, name) {
+                ctx.data.render_tag_callee_sym.insert(tag.id, sym_id);
             }
         }
     }
 
-    fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_expr_refs(tag.id, scope, data);
+    fn visit_html_tag(&mut self, tag: &HtmlTag, ctx: &mut VisitContext<'_>) {
+        resolve_expr_refs(tag.id, ctx.scope, ctx.data);
     }
 
-    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(attr.id, scope, data);
+    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(attr.id, ctx.scope, ctx.data);
     }
-    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(attr.id, scope, data);
+    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(attr.id, ctx.scope, ctx.data);
     }
-    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(attr.id, scope, data);
+    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(attr.id, ctx.scope, ctx.data);
     }
-    fn visit_shorthand(&mut self, attr: &Shorthand, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(attr.id, scope, data);
+    fn visit_shorthand(&mut self, attr: &Shorthand, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(attr.id, ctx.scope, ctx.data);
     }
-    fn visit_class_directive(&mut self, dir: &ClassDirective, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
+    fn visit_class_directive(&mut self, dir: &ClassDirective, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
     }
-    fn visit_style_directive(&mut self, dir: &StyleDirective, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
+    fn visit_style_directive(&mut self, dir: &StyleDirective, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
     }
-    fn visit_bind_directive(&mut self, dir: &BindDirective, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
-        self.resolve_bind(dir, scope, data);
+    fn visit_bind_directive(&mut self, dir: &BindDirective, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
+        self.resolve_bind(dir, ctx.scope, ctx.data);
     }
-    fn visit_use_directive(&mut self, dir: &UseDirective, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
+    fn visit_use_directive(&mut self, dir: &UseDirective, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
     }
-    fn visit_on_directive_legacy(&mut self, dir: &OnDirectiveLegacy, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
+    fn visit_on_directive_legacy(&mut self, dir: &OnDirectiveLegacy, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
     }
-    fn visit_transition_directive(&mut self, dir: &TransitionDirective, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
+    fn visit_transition_directive(&mut self, dir: &TransitionDirective, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
     }
-    fn visit_animate_directive(&mut self, dir: &AnimateDirective, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(dir.id, scope, data);
+    fn visit_animate_directive(&mut self, dir: &AnimateDirective, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(dir.id, ctx.scope, ctx.data);
     }
-    fn visit_attach_tag(&mut self, tag: &AttachTag, scope: ScopeId, data: &mut AnalysisData) {
-        resolve_attr_refs(tag.id, scope, data);
+    fn visit_attach_tag(&mut self, tag: &AttachTag, ctx: &mut VisitContext<'_>) {
+        resolve_attr_refs(tag.id, ctx.scope, ctx.data);
     }
 
-    fn visit_component_node(&mut self, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {
+    fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut VisitContext<'_>) {
         for attr in &cn.attributes {
-            resolve_attr_refs(attr.id(), scope, data);
+            resolve_attr_refs(attr.id(), ctx.scope, ctx.data);
             if let Attribute::BindDirective(dir) = attr {
-                self.resolve_bind(dir, scope, data);
+                self.resolve_bind(dir, ctx.scope, ctx.data);
             }
         }
     }
@@ -158,18 +155,17 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
     fn visit_svelte_element(
         &mut self,
         el: &SvelteElement,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         // Resolve tag expression references (skip for static string tags)
         if !el.static_tag {
-            resolve_expr_refs(el.id, scope, data);
+            resolve_expr_refs(el.id, ctx.scope, ctx.data);
         }
         // Walk attributes — resolve expression refs and bind directives
         for attr in &el.attributes {
-            resolve_attr_refs(attr.id(), scope, data);
+            resolve_attr_refs(attr.id(), ctx.scope, ctx.data);
             if let Attribute::BindDirective(dir) = attr {
-                self.resolve_bind(dir, scope, data);
+                self.resolve_bind(dir, ctx.scope, ctx.data);
             }
         }
     }
@@ -177,13 +173,12 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
     fn visit_svelte_window(
         &mut self,
         w: &SvelteWindow,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         for attr in &w.attributes {
-            resolve_attr_refs(attr.id(), scope, data);
+            resolve_attr_refs(attr.id(), ctx.scope, ctx.data);
             if let Attribute::BindDirective(dir) = attr {
-                self.resolve_bind(dir, scope, data);
+                self.resolve_bind(dir, ctx.scope, ctx.data);
             }
         }
     }
@@ -191,13 +186,12 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
     fn visit_svelte_document(
         &mut self,
         doc: &SvelteDocument,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         for attr in &doc.attributes {
-            resolve_attr_refs(attr.id(), scope, data);
+            resolve_attr_refs(attr.id(), ctx.scope, ctx.data);
             if let Attribute::BindDirective(dir) = attr {
-                self.resolve_bind(dir, scope, data);
+                self.resolve_bind(dir, ctx.scope, ctx.data);
             }
         }
     }
@@ -205,22 +199,20 @@ impl TemplateVisitor for ResolveReferencesVisitor<'_> {
     fn visit_svelte_body(
         &mut self,
         body: &SvelteBody,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         for attr in &body.attributes {
-            resolve_attr_refs(attr.id(), scope, data);
+            resolve_attr_refs(attr.id(), ctx.scope, ctx.data);
         }
     }
 
     fn visit_svelte_boundary(
         &mut self,
         boundary: &SvelteBoundary,
-        scope: ScopeId,
-        data: &mut AnalysisData,
+        ctx: &mut VisitContext<'_>,
     ) {
         for attr in &boundary.attributes {
-            resolve_attr_refs(attr.id(), scope, data);
+            resolve_attr_refs(attr.id(), ctx.scope, ctx.data);
         }
     }
 }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -114,6 +114,13 @@ impl<'a> VisitContext<'a> {
         }
     }
 
+    /// Parsed JS expressions/statements, if set.
+    /// Returns a copy of the inner reference — does NOT borrow self,
+    /// so callers can use `ctx.data` mutably alongside the result.
+    pub fn parsed(&self) -> Option<&'a ParserResult<'a>> {
+        self.parsed
+    }
+
     /// Immediate parent node/attribute, if any.
     pub fn parent(&self) -> Option<ParentRef> {
         self.parents.last().copied()

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,3 +1,4 @@
+use oxc_ast::ast::{Expression, Statement};
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, AwaitBlock, BindDirective, ClassDirective,
@@ -9,7 +10,7 @@ use svelte_ast::{
 };
 use svelte_span::Span;
 
-use crate::data::{AnalysisData, FragmentKey};
+use crate::data::{AnalysisData, FragmentKey, ParserResult};
 
 // ---------------------------------------------------------------------------
 // ParentKind / ParentRef
@@ -78,11 +79,15 @@ pub(crate) struct ParentRef {
 
 /// Context passed to all TemplateVisitor methods.
 ///
-/// Bundles scope, mutable analysis data, and a parent stack so visitors
-/// don't need to track parent context manually.
+/// Bundles scope, mutable analysis data, an optional parsed-expression store,
+/// and a parent stack so visitors don't need to track parent context manually.
 pub(crate) struct VisitContext<'a> {
     pub scope: ScopeId,
     pub data: &'a mut AnalysisData,
+    /// Parsed JS expressions/statements. When set, the walker dispatches
+    /// `visit_js_expression` / `visit_js_statement` after looking up the
+    /// parsed AST node by span offset.
+    parsed: Option<&'a ParserResult<'a>>,
     parents: Vec<ParentRef>,
 }
 
@@ -91,6 +96,20 @@ impl<'a> VisitContext<'a> {
         Self {
             scope,
             data,
+            parsed: None,
+            parents: Vec::new(),
+        }
+    }
+
+    pub fn with_parsed(
+        scope: ScopeId,
+        data: &'a mut AnalysisData,
+        parsed: &'a ParserResult<'a>,
+    ) -> Self {
+        Self {
+            scope,
+            data,
+            parsed: Some(parsed),
             parents: Vec::new(),
         }
     }
@@ -167,6 +186,10 @@ pub(crate) trait TemplateVisitor {
     fn visit_statement(&mut self, node_id: NodeId, span: Span, ctx: &mut VisitContext<'_>) {}
     fn leave_statement(&mut self, node_id: NodeId, span: Span, ctx: &mut VisitContext<'_>) {}
 
+    // --- Parsed JS AST visits (only fire when VisitContext has parsed expressions) ---
+    fn visit_js_expression(&mut self, node_id: NodeId, expr: &Expression<'_>, ctx: &mut VisitContext<'_>) {}
+    fn visit_js_statement(&mut self, node_id: NodeId, stmt: &Statement<'_>, ctx: &mut VisitContext<'_>) {}
+
     // --- Leave hooks ---
     fn leave_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {}
     fn leave_each_block(&mut self, block: &EachBlock, ctx: &mut VisitContext<'_>) {}
@@ -184,7 +207,12 @@ fn dispatch_expr(
     span: Span,
     ctx: &mut VisitContext<'_>,
 ) {
+    // Copy parsed ref out so we can pass ctx mutably alongside expr
+    let parsed = ctx.parsed;
     for v in visitors.iter_mut() { v.visit_expression(id, span, ctx); }
+    if let Some(expr) = parsed.and_then(|p| p.exprs.get(&span.start)) {
+        for v in visitors.iter_mut() { v.visit_js_expression(id, expr, ctx); }
+    }
     for v in visitors.iter_mut() { v.leave_expression(id, span, ctx); }
 }
 
@@ -207,7 +235,11 @@ fn dispatch_stmt(
     span: Span,
     ctx: &mut VisitContext<'_>,
 ) {
+    let parsed = ctx.parsed;
     for v in visitors.iter_mut() { v.visit_statement(id, span, ctx); }
+    if let Some(stmt) = parsed.and_then(|p| p.stmts.get(&span.start)) {
+        for v in visitors.iter_mut() { v.visit_js_statement(id, stmt, ctx); }
+    }
     for v in visitors.iter_mut() { v.leave_statement(id, span, ctx); }
 }
 

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -1,12 +1,13 @@
 use oxc_semantic::ScopeId;
 use svelte_ast::{
     AnimateDirective, AttachTag, Attribute, AwaitBlock, BindDirective, ClassDirective,
-    ConcatenationAttribute, ComponentNode, ConstTag, DebugTag, EachBlock, Element,
-    ExpressionAttribute, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node,
+    ConcatPart, ConcatenationAttribute, ComponentNode, ConstTag, DebugTag, EachBlock, Element,
+    ExpressionAttribute, ExpressionTag, Fragment, HtmlTag, IfBlock, KeyBlock, Node, NodeId,
     OnDirectiveLegacy, RenderTag, Shorthand, SnippetBlock, SpreadAttribute, StyleDirective,
-    SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow,
+    StyleDirectiveValue, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow,
     TransitionDirective, UseDirective,
 };
+use svelte_span::Span;
 
 use crate::data::{AnalysisData, FragmentKey};
 
@@ -57,6 +58,12 @@ pub(crate) trait TemplateVisitor {
     fn visit_animate_directive(&mut self, dir: &AnimateDirective, scope: ScopeId, data: &mut AnalysisData) {}
     fn visit_attach_tag(&mut self, tag: &AttachTag, scope: ScopeId, data: &mut AnalysisData) {}
 
+    // --- Expression / Statement visits ---
+    fn visit_expression(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
+    fn leave_expression(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_statement(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
+    fn leave_statement(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
+
     // --- Leave hooks ---
     fn leave_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
     fn leave_each_block(&mut self, block: &EachBlock, parent_scope: ScopeId, body_scope: ScopeId, data: &mut AnalysisData) {}
@@ -66,6 +73,75 @@ pub(crate) trait TemplateVisitor {
 // ---------------------------------------------------------------------------
 // Walk
 // ---------------------------------------------------------------------------
+
+/// Dispatch `visit_expression` + `leave_expression` for a single span.
+#[inline]
+fn dispatch_expr(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Span,
+    scope: ScopeId,
+    data: &mut AnalysisData,
+) {
+    for v in visitors.iter_mut() { v.visit_expression(id, span, scope, data); }
+    for v in visitors.iter_mut() { v.leave_expression(id, span, scope, data); }
+}
+
+/// Dispatch `visit_expression` + `leave_expression` for an optional span.
+#[inline]
+fn dispatch_opt_expr(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Option<Span>,
+    scope: ScopeId,
+    data: &mut AnalysisData,
+) {
+    if let Some(span) = span {
+        dispatch_expr(visitors, id, span, scope, data);
+    }
+}
+
+/// Dispatch `visit_statement` + `leave_statement` for a single span.
+#[inline]
+fn dispatch_stmt(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Span,
+    scope: ScopeId,
+    data: &mut AnalysisData,
+) {
+    for v in visitors.iter_mut() { v.visit_statement(id, span, scope, data); }
+    for v in visitors.iter_mut() { v.leave_statement(id, span, scope, data); }
+}
+
+/// Dispatch `visit_statement` + `leave_statement` for an optional span.
+#[inline]
+fn dispatch_opt_stmt(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Option<Span>,
+    scope: ScopeId,
+    data: &mut AnalysisData,
+) {
+    if let Some(span) = span {
+        dispatch_stmt(visitors, id, span, scope, data);
+    }
+}
+
+/// Dispatch `visit_expression` + `leave_expression` for each dynamic part in a concatenation.
+fn dispatch_concat_exprs(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    parts: &[ConcatPart],
+    scope: ScopeId,
+    data: &mut AnalysisData,
+) {
+    for part in parts {
+        if let ConcatPart::Dynamic(span) = part {
+            dispatch_expr(visitors, id, *span, scope, data);
+        }
+    }
+}
 
 /// Walk a template fragment, dispatching to all visitors at each node.
 ///
@@ -81,6 +157,7 @@ pub(crate) fn walk_template(
         match node {
             Node::ExpressionTag(tag) => {
                 for v in visitors.iter_mut() { v.visit_expression_tag(tag, scope, data); }
+                dispatch_expr(visitors, tag.id, tag.expression_span, scope, data);
             }
             Node::Element(el) => {
                 for v in visitors.iter_mut() { v.visit_element(el, scope, data); }
@@ -90,6 +167,7 @@ pub(crate) fn walk_template(
             }
             Node::IfBlock(block) => {
                 for v in visitors.iter_mut() { v.visit_if_block(block, scope, data); }
+                dispatch_expr(visitors, block.id, block.test_span, scope, data);
                 let cons_scope = data.scoping.fragment_scope(&FragmentKey::IfConsequent(block.id)).unwrap_or(scope);
                 walk_template(&block.consequent, data, cons_scope, visitors);
                 if let Some(alt) = &block.alternate {
@@ -100,6 +178,9 @@ pub(crate) fn walk_template(
             Node::EachBlock(block) => {
                 let body_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
                 for v in visitors.iter_mut() { v.visit_each_block(block, scope, body_scope, data); }
+                dispatch_expr(visitors, block.id, block.expression_span, scope, data);
+                dispatch_stmt(visitors, block.id, block.context_span, body_scope, data);
+                dispatch_opt_expr(visitors, block.id, block.key_span, body_scope, data);
                 walk_template(&block.body, data, body_scope, visitors);
                 if let Some(fb) = &block.fallback {
                     walk_template(fb, data, scope, visitors);
@@ -109,6 +190,7 @@ pub(crate) fn walk_template(
             Node::SnippetBlock(block) => {
                 let body_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
                 for v in visitors.iter_mut() { v.visit_snippet_block(block, scope, data); }
+                dispatch_opt_stmt(visitors, block.id, block.params_span, body_scope, data);
                 walk_template(&block.body, data, body_scope, visitors);
                 for v in visitors.iter_mut() { v.leave_snippet_block(block, scope, data); }
             }
@@ -119,18 +201,22 @@ pub(crate) fn walk_template(
             }
             Node::RenderTag(tag) => {
                 for v in visitors.iter_mut() { v.visit_render_tag(tag, scope, data); }
+                dispatch_expr(visitors, tag.id, tag.expression_span, scope, data);
             }
             Node::HtmlTag(tag) => {
                 for v in visitors.iter_mut() { v.visit_html_tag(tag, scope, data); }
+                dispatch_expr(visitors, tag.id, tag.expression_span, scope, data);
             }
             Node::ConstTag(tag) => {
                 for v in visitors.iter_mut() { v.visit_const_tag(tag, scope, data); }
+                dispatch_stmt(visitors, tag.id, tag.expression_span, scope, data);
             }
             Node::DebugTag(tag) => {
                 for v in visitors.iter_mut() { v.visit_debug_tag(tag, scope, data); }
             }
             Node::KeyBlock(block) => {
                 for v in visitors.iter_mut() { v.visit_key_block(block, scope, data); }
+                dispatch_expr(visitors, block.id, block.expression_span, scope, data);
                 let child_scope = data.scoping.fragment_scope(&FragmentKey::KeyBlockBody(block.id)).unwrap_or(scope);
                 walk_template(&block.fragment, data, child_scope, visitors);
             }
@@ -140,6 +226,9 @@ pub(crate) fn walk_template(
             }
             Node::SvelteElement(el) => {
                 for v in visitors.iter_mut() { v.visit_svelte_element(el, scope, data); }
+                if !el.static_tag {
+                    dispatch_expr(visitors, el.id, el.tag_span, scope, data);
+                }
                 walk_attributes(&el.attributes, scope, data, visitors);
                 let child_scope = data.scoping.fragment_scope(&FragmentKey::SvelteElementBody(el.id)).unwrap_or(scope);
                 walk_template(&el.fragment, data, child_scope, visitors);
@@ -164,6 +253,7 @@ pub(crate) fn walk_template(
             }
             Node::AwaitBlock(block) => {
                 for v in visitors.iter_mut() { v.visit_await_block(block, scope, data); }
+                dispatch_expr(visitors, block.id, block.expression_span, scope, data);
                 if let Some(ref p) = block.pending {
                     let pending_scope = data.scoping.fragment_scope(&FragmentKey::AwaitPending(block.id)).unwrap_or(scope);
                     walk_template(p, data, pending_scope, visitors);
@@ -182,7 +272,7 @@ pub(crate) fn walk_template(
     }
 }
 
-/// Walk attributes, dispatching per-variant visit to all visitors.
+/// Walk attributes, dispatching per-variant visit and expression/statement hooks to all visitors.
 fn walk_attributes(
     attrs: &[Attribute],
     scope: ScopeId,
@@ -191,18 +281,62 @@ fn walk_attributes(
 ) {
     for attr in attrs {
         match attr {
-            Attribute::ExpressionAttribute(a) => { for v in visitors.iter_mut() { v.visit_expression_attribute(a, scope, data); } }
-            Attribute::ConcatenationAttribute(a) => { for v in visitors.iter_mut() { v.visit_concatenation_attribute(a, scope, data); } }
-            Attribute::SpreadAttribute(a) => { for v in visitors.iter_mut() { v.visit_spread_attribute(a, scope, data); } }
-            Attribute::Shorthand(a) => { for v in visitors.iter_mut() { v.visit_shorthand(a, scope, data); } }
-            Attribute::ClassDirective(a) => { for v in visitors.iter_mut() { v.visit_class_directive(a, scope, data); } }
-            Attribute::StyleDirective(a) => { for v in visitors.iter_mut() { v.visit_style_directive(a, scope, data); } }
-            Attribute::BindDirective(a) => { for v in visitors.iter_mut() { v.visit_bind_directive(a, scope, data); } }
-            Attribute::UseDirective(a) => { for v in visitors.iter_mut() { v.visit_use_directive(a, scope, data); } }
-            Attribute::OnDirectiveLegacy(a) => { for v in visitors.iter_mut() { v.visit_on_directive_legacy(a, scope, data); } }
-            Attribute::TransitionDirective(a) => { for v in visitors.iter_mut() { v.visit_transition_directive(a, scope, data); } }
-            Attribute::AnimateDirective(a) => { for v in visitors.iter_mut() { v.visit_animate_directive(a, scope, data); } }
-            Attribute::AttachTag(a) => { for v in visitors.iter_mut() { v.visit_attach_tag(a, scope, data); } }
+            Attribute::ExpressionAttribute(a) => {
+                for v in visitors.iter_mut() { v.visit_expression_attribute(a, scope, data); }
+                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::ConcatenationAttribute(a) => {
+                for v in visitors.iter_mut() { v.visit_concatenation_attribute(a, scope, data); }
+                dispatch_concat_exprs(visitors, a.id, &a.parts, scope, data);
+            }
+            Attribute::SpreadAttribute(a) => {
+                for v in visitors.iter_mut() { v.visit_spread_attribute(a, scope, data); }
+                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::Shorthand(a) => {
+                for v in visitors.iter_mut() { v.visit_shorthand(a, scope, data); }
+                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::ClassDirective(a) => {
+                for v in visitors.iter_mut() { v.visit_class_directive(a, scope, data); }
+                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::StyleDirective(a) => {
+                for v in visitors.iter_mut() { v.visit_style_directive(a, scope, data); }
+                match &a.value {
+                    StyleDirectiveValue::Expression(span) => {
+                        dispatch_expr(visitors, a.id, *span, scope, data);
+                    }
+                    StyleDirectiveValue::Concatenation(parts) => {
+                        dispatch_concat_exprs(visitors, a.id, parts, scope, data);
+                    }
+                    StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
+                }
+            }
+            Attribute::BindDirective(a) => {
+                for v in visitors.iter_mut() { v.visit_bind_directive(a, scope, data); }
+                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::UseDirective(a) => {
+                for v in visitors.iter_mut() { v.visit_use_directive(a, scope, data); }
+                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::OnDirectiveLegacy(a) => {
+                for v in visitors.iter_mut() { v.visit_on_directive_legacy(a, scope, data); }
+                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::TransitionDirective(a) => {
+                for v in visitors.iter_mut() { v.visit_transition_directive(a, scope, data); }
+                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::AnimateDirective(a) => {
+                for v in visitors.iter_mut() { v.visit_animate_directive(a, scope, data); }
+                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+            }
+            Attribute::AttachTag(a) => {
+                for v in visitors.iter_mut() { v.visit_attach_tag(a, scope, data); }
+                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+            }
             Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_) => {}
         }
     }

--- a/crates/svelte_analyze/src/walker.rs
+++ b/crates/svelte_analyze/src/walker.rs
@@ -12,6 +12,109 @@ use svelte_span::Span;
 use crate::data::{AnalysisData, FragmentKey};
 
 // ---------------------------------------------------------------------------
+// ParentKind / ParentRef
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ParentKind {
+    // Template nodes
+    Element,
+    IfBlock,
+    EachBlock,
+    SnippetBlock,
+    ComponentNode,
+    KeyBlock,
+    SvelteHead,
+    SvelteElement,
+    SvelteWindow,
+    SvelteDocument,
+    SvelteBody,
+    SvelteBoundary,
+    AwaitBlock,
+    // Attributes
+    ExpressionAttribute,
+    ConcatenationAttribute,
+    SpreadAttribute,
+    Shorthand,
+    ClassDirective,
+    StyleDirective,
+    BindDirective,
+    UseDirective,
+    OnDirectiveLegacy,
+    TransitionDirective,
+    AnimateDirective,
+    AttachTag,
+}
+
+impl ParentKind {
+    pub fn is_attr(&self) -> bool {
+        matches!(
+            self,
+            Self::ExpressionAttribute
+                | Self::ConcatenationAttribute
+                | Self::SpreadAttribute
+                | Self::Shorthand
+                | Self::ClassDirective
+                | Self::StyleDirective
+                | Self::BindDirective
+                | Self::UseDirective
+                | Self::OnDirectiveLegacy
+                | Self::TransitionDirective
+                | Self::AnimateDirective
+                | Self::AttachTag
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ParentRef {
+    pub id: NodeId,
+    pub kind: ParentKind,
+}
+
+// ---------------------------------------------------------------------------
+// VisitContext
+// ---------------------------------------------------------------------------
+
+/// Context passed to all TemplateVisitor methods.
+///
+/// Bundles scope, mutable analysis data, and a parent stack so visitors
+/// don't need to track parent context manually.
+pub(crate) struct VisitContext<'a> {
+    pub scope: ScopeId,
+    pub data: &'a mut AnalysisData,
+    parents: Vec<ParentRef>,
+}
+
+impl<'a> VisitContext<'a> {
+    pub fn new(scope: ScopeId, data: &'a mut AnalysisData) -> Self {
+        Self {
+            scope,
+            data,
+            parents: Vec::new(),
+        }
+    }
+
+    /// Immediate parent node/attribute, if any.
+    pub fn parent(&self) -> Option<ParentRef> {
+        self.parents.last().copied()
+    }
+
+    /// Ancestors from innermost to outermost.
+    pub fn ancestors(&self) -> impl Iterator<Item = &ParentRef> {
+        self.parents.iter().rev()
+    }
+
+    fn push(&mut self, r: ParentRef) {
+        self.parents.push(r);
+    }
+
+    fn pop(&mut self) {
+        self.parents.pop();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // TemplateVisitor trait
 // ---------------------------------------------------------------------------
 
@@ -19,253 +122,299 @@ use crate::data::{AnalysisData, FragmentKey};
 ///
 /// Each analysis pass implements only the visit methods it cares about.
 /// All methods have default no-op implementations. The `walk_template` function
-/// handles structural recursion and scope tracking — visitors never need to
-/// recurse manually.
+/// handles structural recursion, scope tracking, and parent stack — visitors
+/// never need to recurse manually.
 ///
 /// Pass multiple visitors as `&mut [&mut dyn TemplateVisitor]` to walk once.
 #[allow(unused_variables)]
 pub(crate) trait TemplateVisitor {
     // --- Node visits ---
-    fn visit_expression_tag(&mut self, tag: &ExpressionTag, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_render_tag(&mut self, tag: &RenderTag, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_html_tag(&mut self, tag: &HtmlTag, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_const_tag(&mut self, tag: &ConstTag, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_debug_tag(&mut self, tag: &DebugTag, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_if_block(&mut self, block: &IfBlock, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_each_block(&mut self, block: &EachBlock, parent_scope: ScopeId, body_scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_key_block(&mut self, block: &KeyBlock, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_component_node(&mut self, cn: &ComponentNode, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_svelte_element(&mut self, el: &SvelteElement, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_svelte_window(&mut self, w: &SvelteWindow, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_svelte_document(&mut self, doc: &SvelteDocument, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_svelte_body(&mut self, body: &SvelteBody, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_await_block(&mut self, block: &AwaitBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_expression_tag(&mut self, tag: &ExpressionTag, ctx: &mut VisitContext<'_>) {}
+    fn visit_render_tag(&mut self, tag: &RenderTag, ctx: &mut VisitContext<'_>) {}
+    fn visit_html_tag(&mut self, tag: &HtmlTag, ctx: &mut VisitContext<'_>) {}
+    fn visit_const_tag(&mut self, tag: &ConstTag, ctx: &mut VisitContext<'_>) {}
+    fn visit_debug_tag(&mut self, tag: &DebugTag, ctx: &mut VisitContext<'_>) {}
+    fn visit_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {}
+    fn visit_if_block(&mut self, block: &IfBlock, ctx: &mut VisitContext<'_>) {}
+    fn visit_each_block(&mut self, block: &EachBlock, ctx: &mut VisitContext<'_>) {}
+    fn visit_snippet_block(&mut self, block: &SnippetBlock, ctx: &mut VisitContext<'_>) {}
+    fn visit_key_block(&mut self, block: &KeyBlock, ctx: &mut VisitContext<'_>) {}
+    fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut VisitContext<'_>) {}
+    fn visit_svelte_element(&mut self, el: &SvelteElement, ctx: &mut VisitContext<'_>) {}
+    fn visit_svelte_window(&mut self, w: &SvelteWindow, ctx: &mut VisitContext<'_>) {}
+    fn visit_svelte_document(&mut self, doc: &SvelteDocument, ctx: &mut VisitContext<'_>) {}
+    fn visit_svelte_body(&mut self, body: &SvelteBody, ctx: &mut VisitContext<'_>) {}
+    fn visit_svelte_boundary(&mut self, boundary: &SvelteBoundary, ctx: &mut VisitContext<'_>) {}
+    fn visit_await_block(&mut self, block: &AwaitBlock, ctx: &mut VisitContext<'_>) {}
 
     // --- Attribute visits (dispatched for ALL nodes with attributes) ---
-    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_shorthand(&mut self, attr: &Shorthand, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_class_directive(&mut self, dir: &ClassDirective, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_style_directive(&mut self, dir: &StyleDirective, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_bind_directive(&mut self, dir: &BindDirective, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_use_directive(&mut self, dir: &UseDirective, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_on_directive_legacy(&mut self, dir: &OnDirectiveLegacy, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_transition_directive(&mut self, dir: &TransitionDirective, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_animate_directive(&mut self, dir: &AnimateDirective, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_attach_tag(&mut self, tag: &AttachTag, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_expression_attribute(&mut self, attr: &ExpressionAttribute, ctx: &mut VisitContext<'_>) {}
+    fn visit_concatenation_attribute(&mut self, attr: &ConcatenationAttribute, ctx: &mut VisitContext<'_>) {}
+    fn visit_spread_attribute(&mut self, attr: &SpreadAttribute, ctx: &mut VisitContext<'_>) {}
+    fn visit_shorthand(&mut self, attr: &Shorthand, ctx: &mut VisitContext<'_>) {}
+    fn visit_class_directive(&mut self, dir: &ClassDirective, ctx: &mut VisitContext<'_>) {}
+    fn visit_style_directive(&mut self, dir: &StyleDirective, ctx: &mut VisitContext<'_>) {}
+    fn visit_bind_directive(&mut self, dir: &BindDirective, ctx: &mut VisitContext<'_>) {}
+    fn visit_use_directive(&mut self, dir: &UseDirective, ctx: &mut VisitContext<'_>) {}
+    fn visit_on_directive_legacy(&mut self, dir: &OnDirectiveLegacy, ctx: &mut VisitContext<'_>) {}
+    fn visit_transition_directive(&mut self, dir: &TransitionDirective, ctx: &mut VisitContext<'_>) {}
+    fn visit_animate_directive(&mut self, dir: &AnimateDirective, ctx: &mut VisitContext<'_>) {}
+    fn visit_attach_tag(&mut self, tag: &AttachTag, ctx: &mut VisitContext<'_>) {}
 
     // --- Expression / Statement visits ---
-    fn visit_expression(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
-    fn leave_expression(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
-    fn visit_statement(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
-    fn leave_statement(&mut self, node_id: NodeId, span: Span, scope: ScopeId, data: &mut AnalysisData) {}
+    fn visit_expression(&mut self, node_id: NodeId, span: Span, ctx: &mut VisitContext<'_>) {}
+    fn leave_expression(&mut self, node_id: NodeId, span: Span, ctx: &mut VisitContext<'_>) {}
+    fn visit_statement(&mut self, node_id: NodeId, span: Span, ctx: &mut VisitContext<'_>) {}
+    fn leave_statement(&mut self, node_id: NodeId, span: Span, ctx: &mut VisitContext<'_>) {}
 
     // --- Leave hooks ---
-    fn leave_element(&mut self, el: &Element, scope: ScopeId, data: &mut AnalysisData) {}
-    fn leave_each_block(&mut self, block: &EachBlock, parent_scope: ScopeId, body_scope: ScopeId, data: &mut AnalysisData) {}
-    fn leave_snippet_block(&mut self, block: &SnippetBlock, scope: ScopeId, data: &mut AnalysisData) {}
+    fn leave_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {}
+    fn leave_each_block(&mut self, block: &EachBlock, ctx: &mut VisitContext<'_>) {}
+    fn leave_snippet_block(&mut self, block: &SnippetBlock, ctx: &mut VisitContext<'_>) {}
+}
+
+// ---------------------------------------------------------------------------
+// Walk helpers
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn dispatch_expr(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Span,
+    ctx: &mut VisitContext<'_>,
+) {
+    for v in visitors.iter_mut() { v.visit_expression(id, span, ctx); }
+    for v in visitors.iter_mut() { v.leave_expression(id, span, ctx); }
+}
+
+#[inline]
+fn dispatch_opt_expr(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Option<Span>,
+    ctx: &mut VisitContext<'_>,
+) {
+    if let Some(span) = span {
+        dispatch_expr(visitors, id, span, ctx);
+    }
+}
+
+#[inline]
+fn dispatch_stmt(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Span,
+    ctx: &mut VisitContext<'_>,
+) {
+    for v in visitors.iter_mut() { v.visit_statement(id, span, ctx); }
+    for v in visitors.iter_mut() { v.leave_statement(id, span, ctx); }
+}
+
+#[inline]
+fn dispatch_opt_stmt(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    span: Option<Span>,
+    ctx: &mut VisitContext<'_>,
+) {
+    if let Some(span) = span {
+        dispatch_stmt(visitors, id, span, ctx);
+    }
+}
+
+fn dispatch_concat_exprs(
+    visitors: &mut [&mut dyn TemplateVisitor],
+    id: NodeId,
+    parts: &[ConcatPart],
+    ctx: &mut VisitContext<'_>,
+) {
+    for part in parts {
+        if let ConcatPart::Dynamic(span) = part {
+            dispatch_expr(visitors, id, *span, ctx);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Walk
 // ---------------------------------------------------------------------------
 
-/// Dispatch `visit_expression` + `leave_expression` for a single span.
-#[inline]
-fn dispatch_expr(
-    visitors: &mut [&mut dyn TemplateVisitor],
-    id: NodeId,
-    span: Span,
-    scope: ScopeId,
-    data: &mut AnalysisData,
-) {
-    for v in visitors.iter_mut() { v.visit_expression(id, span, scope, data); }
-    for v in visitors.iter_mut() { v.leave_expression(id, span, scope, data); }
-}
-
-/// Dispatch `visit_expression` + `leave_expression` for an optional span.
-#[inline]
-fn dispatch_opt_expr(
-    visitors: &mut [&mut dyn TemplateVisitor],
-    id: NodeId,
-    span: Option<Span>,
-    scope: ScopeId,
-    data: &mut AnalysisData,
-) {
-    if let Some(span) = span {
-        dispatch_expr(visitors, id, span, scope, data);
-    }
-}
-
-/// Dispatch `visit_statement` + `leave_statement` for a single span.
-#[inline]
-fn dispatch_stmt(
-    visitors: &mut [&mut dyn TemplateVisitor],
-    id: NodeId,
-    span: Span,
-    scope: ScopeId,
-    data: &mut AnalysisData,
-) {
-    for v in visitors.iter_mut() { v.visit_statement(id, span, scope, data); }
-    for v in visitors.iter_mut() { v.leave_statement(id, span, scope, data); }
-}
-
-/// Dispatch `visit_statement` + `leave_statement` for an optional span.
-#[inline]
-fn dispatch_opt_stmt(
-    visitors: &mut [&mut dyn TemplateVisitor],
-    id: NodeId,
-    span: Option<Span>,
-    scope: ScopeId,
-    data: &mut AnalysisData,
-) {
-    if let Some(span) = span {
-        dispatch_stmt(visitors, id, span, scope, data);
-    }
-}
-
-/// Dispatch `visit_expression` + `leave_expression` for each dynamic part in a concatenation.
-fn dispatch_concat_exprs(
-    visitors: &mut [&mut dyn TemplateVisitor],
-    id: NodeId,
-    parts: &[ConcatPart],
-    scope: ScopeId,
-    data: &mut AnalysisData,
-) {
-    for part in parts {
-        if let ConcatPart::Dynamic(span) = part {
-            dispatch_expr(visitors, id, *span, scope, data);
-        }
-    }
-}
-
 /// Walk a template fragment, dispatching to all visitors at each node.
 ///
-/// Scope tracking is built-in: EachBlock bodies use their child scope,
-/// EachBlock fallbacks use the parent scope.
+/// Scope tracking and parent stack are managed via `ctx`. Visitors never need
+/// to recurse manually.
 pub(crate) fn walk_template(
     fragment: &Fragment,
-    data: &mut AnalysisData,
-    scope: ScopeId,
+    ctx: &mut VisitContext<'_>,
     visitors: &mut [&mut dyn TemplateVisitor],
 ) {
     for node in &fragment.nodes {
         match node {
             Node::ExpressionTag(tag) => {
-                for v in visitors.iter_mut() { v.visit_expression_tag(tag, scope, data); }
-                dispatch_expr(visitors, tag.id, tag.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_expression_tag(tag, ctx); }
+                dispatch_expr(visitors, tag.id, tag.expression_span, ctx);
             }
             Node::Element(el) => {
-                for v in visitors.iter_mut() { v.visit_element(el, scope, data); }
-                walk_attributes(&el.attributes, scope, data, visitors);
-                walk_template(&el.fragment, data, scope, visitors);
-                for v in visitors.iter_mut() { v.leave_element(el, scope, data); }
+                for v in visitors.iter_mut() { v.visit_element(el, ctx); }
+                ctx.push(ParentRef { id: el.id, kind: ParentKind::Element });
+                walk_attributes(&el.attributes, ctx, visitors);
+                walk_template(&el.fragment, ctx, visitors);
+                ctx.pop();
+                for v in visitors.iter_mut() { v.leave_element(el, ctx); }
             }
             Node::IfBlock(block) => {
-                for v in visitors.iter_mut() { v.visit_if_block(block, scope, data); }
-                dispatch_expr(visitors, block.id, block.test_span, scope, data);
-                let cons_scope = data.scoping.fragment_scope(&FragmentKey::IfConsequent(block.id)).unwrap_or(scope);
-                walk_template(&block.consequent, data, cons_scope, visitors);
+                for v in visitors.iter_mut() { v.visit_if_block(block, ctx); }
+                dispatch_expr(visitors, block.id, block.test_span, ctx);
+                ctx.push(ParentRef { id: block.id, kind: ParentKind::IfBlock });
+                let saved = ctx.scope;
+                let cons_scope = ctx.data.scoping.fragment_scope(&FragmentKey::IfConsequent(block.id)).unwrap_or(saved);
+                ctx.scope = cons_scope;
+                walk_template(&block.consequent, ctx, visitors);
                 if let Some(alt) = &block.alternate {
-                    let alt_scope = data.scoping.fragment_scope(&FragmentKey::IfAlternate(block.id)).unwrap_or(scope);
-                    walk_template(alt, data, alt_scope, visitors);
+                    let alt_scope = ctx.data.scoping.fragment_scope(&FragmentKey::IfAlternate(block.id)).unwrap_or(saved);
+                    ctx.scope = alt_scope;
+                    walk_template(alt, ctx, visitors);
                 }
+                ctx.scope = saved;
+                ctx.pop();
             }
             Node::EachBlock(block) => {
-                let body_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
-                for v in visitors.iter_mut() { v.visit_each_block(block, scope, body_scope, data); }
-                dispatch_expr(visitors, block.id, block.expression_span, scope, data);
-                dispatch_stmt(visitors, block.id, block.context_span, body_scope, data);
-                dispatch_opt_expr(visitors, block.id, block.key_span, body_scope, data);
-                walk_template(&block.body, data, body_scope, visitors);
+                let body_scope = ctx.data.scoping.node_scope(block.id).unwrap_or(ctx.scope);
+                for v in visitors.iter_mut() { v.visit_each_block(block, ctx); }
+                dispatch_expr(visitors, block.id, block.expression_span, ctx);
+                ctx.push(ParentRef { id: block.id, kind: ParentKind::EachBlock });
+                let saved = ctx.scope;
+                ctx.scope = body_scope;
+                dispatch_stmt(visitors, block.id, block.context_span, ctx);
+                dispatch_opt_expr(visitors, block.id, block.key_span, ctx);
+                walk_template(&block.body, ctx, visitors);
+                ctx.scope = saved;
                 if let Some(fb) = &block.fallback {
-                    walk_template(fb, data, scope, visitors);
+                    walk_template(fb, ctx, visitors);
                 }
-                for v in visitors.iter_mut() { v.leave_each_block(block, scope, body_scope, data); }
+                ctx.pop();
+                for v in visitors.iter_mut() { v.leave_each_block(block, ctx); }
             }
             Node::SnippetBlock(block) => {
-                let body_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
-                for v in visitors.iter_mut() { v.visit_snippet_block(block, scope, data); }
-                dispatch_opt_stmt(visitors, block.id, block.params_span, body_scope, data);
-                walk_template(&block.body, data, body_scope, visitors);
-                for v in visitors.iter_mut() { v.leave_snippet_block(block, scope, data); }
+                let body_scope = ctx.data.scoping.node_scope(block.id).unwrap_or(ctx.scope);
+                for v in visitors.iter_mut() { v.visit_snippet_block(block, ctx); }
+                ctx.push(ParentRef { id: block.id, kind: ParentKind::SnippetBlock });
+                let saved = ctx.scope;
+                ctx.scope = body_scope;
+                dispatch_opt_stmt(visitors, block.id, block.params_span, ctx);
+                walk_template(&block.body, ctx, visitors);
+                ctx.scope = saved;
+                ctx.pop();
+                for v in visitors.iter_mut() { v.leave_snippet_block(block, ctx); }
             }
             Node::ComponentNode(cn) => {
-                for v in visitors.iter_mut() { v.visit_component_node(cn, scope, data); }
-                walk_attributes(&cn.attributes, scope, data, visitors);
-                walk_template(&cn.fragment, data, scope, visitors);
+                for v in visitors.iter_mut() { v.visit_component_node(cn, ctx); }
+                ctx.push(ParentRef { id: cn.id, kind: ParentKind::ComponentNode });
+                walk_attributes(&cn.attributes, ctx, visitors);
+                walk_template(&cn.fragment, ctx, visitors);
+                ctx.pop();
             }
             Node::RenderTag(tag) => {
-                for v in visitors.iter_mut() { v.visit_render_tag(tag, scope, data); }
-                dispatch_expr(visitors, tag.id, tag.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_render_tag(tag, ctx); }
+                dispatch_expr(visitors, tag.id, tag.expression_span, ctx);
             }
             Node::HtmlTag(tag) => {
-                for v in visitors.iter_mut() { v.visit_html_tag(tag, scope, data); }
-                dispatch_expr(visitors, tag.id, tag.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_html_tag(tag, ctx); }
+                dispatch_expr(visitors, tag.id, tag.expression_span, ctx);
             }
             Node::ConstTag(tag) => {
-                for v in visitors.iter_mut() { v.visit_const_tag(tag, scope, data); }
-                dispatch_stmt(visitors, tag.id, tag.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_const_tag(tag, ctx); }
+                dispatch_stmt(visitors, tag.id, tag.expression_span, ctx);
             }
             Node::DebugTag(tag) => {
-                for v in visitors.iter_mut() { v.visit_debug_tag(tag, scope, data); }
+                for v in visitors.iter_mut() { v.visit_debug_tag(tag, ctx); }
             }
             Node::KeyBlock(block) => {
-                for v in visitors.iter_mut() { v.visit_key_block(block, scope, data); }
-                dispatch_expr(visitors, block.id, block.expression_span, scope, data);
-                let child_scope = data.scoping.fragment_scope(&FragmentKey::KeyBlockBody(block.id)).unwrap_or(scope);
-                walk_template(&block.fragment, data, child_scope, visitors);
+                for v in visitors.iter_mut() { v.visit_key_block(block, ctx); }
+                dispatch_expr(visitors, block.id, block.expression_span, ctx);
+                ctx.push(ParentRef { id: block.id, kind: ParentKind::KeyBlock });
+                let saved = ctx.scope;
+                let child_scope = ctx.data.scoping.fragment_scope(&FragmentKey::KeyBlockBody(block.id)).unwrap_or(saved);
+                ctx.scope = child_scope;
+                walk_template(&block.fragment, ctx, visitors);
+                ctx.scope = saved;
+                ctx.pop();
             }
             Node::SvelteHead(head) => {
-                let child_scope = data.scoping.fragment_scope(&FragmentKey::SvelteHeadBody(head.id)).unwrap_or(scope);
-                walk_template(&head.fragment, data, child_scope, visitors);
+                ctx.push(ParentRef { id: head.id, kind: ParentKind::SvelteHead });
+                let saved = ctx.scope;
+                let child_scope = ctx.data.scoping.fragment_scope(&FragmentKey::SvelteHeadBody(head.id)).unwrap_or(saved);
+                ctx.scope = child_scope;
+                walk_template(&head.fragment, ctx, visitors);
+                ctx.scope = saved;
+                ctx.pop();
             }
             Node::SvelteElement(el) => {
-                for v in visitors.iter_mut() { v.visit_svelte_element(el, scope, data); }
+                for v in visitors.iter_mut() { v.visit_svelte_element(el, ctx); }
+                ctx.push(ParentRef { id: el.id, kind: ParentKind::SvelteElement });
                 if !el.static_tag {
-                    dispatch_expr(visitors, el.id, el.tag_span, scope, data);
+                    dispatch_expr(visitors, el.id, el.tag_span, ctx);
                 }
-                walk_attributes(&el.attributes, scope, data, visitors);
-                let child_scope = data.scoping.fragment_scope(&FragmentKey::SvelteElementBody(el.id)).unwrap_or(scope);
-                walk_template(&el.fragment, data, child_scope, visitors);
+                walk_attributes(&el.attributes, ctx, visitors);
+                let saved = ctx.scope;
+                let child_scope = ctx.data.scoping.fragment_scope(&FragmentKey::SvelteElementBody(el.id)).unwrap_or(saved);
+                ctx.scope = child_scope;
+                walk_template(&el.fragment, ctx, visitors);
+                ctx.scope = saved;
+                ctx.pop();
             }
             Node::SvelteWindow(w) => {
-                for v in visitors.iter_mut() { v.visit_svelte_window(w, scope, data); }
-                walk_attributes(&w.attributes, scope, data, visitors);
+                for v in visitors.iter_mut() { v.visit_svelte_window(w, ctx); }
+                ctx.push(ParentRef { id: w.id, kind: ParentKind::SvelteWindow });
+                walk_attributes(&w.attributes, ctx, visitors);
+                ctx.pop();
             }
             Node::SvelteDocument(d) => {
-                for v in visitors.iter_mut() { v.visit_svelte_document(d, scope, data); }
-                walk_attributes(&d.attributes, scope, data, visitors);
+                for v in visitors.iter_mut() { v.visit_svelte_document(d, ctx); }
+                ctx.push(ParentRef { id: d.id, kind: ParentKind::SvelteDocument });
+                walk_attributes(&d.attributes, ctx, visitors);
+                ctx.pop();
             }
             Node::SvelteBody(b) => {
-                for v in visitors.iter_mut() { v.visit_svelte_body(b, scope, data); }
-                walk_attributes(&b.attributes, scope, data, visitors);
+                for v in visitors.iter_mut() { v.visit_svelte_body(b, ctx); }
+                ctx.push(ParentRef { id: b.id, kind: ParentKind::SvelteBody });
+                walk_attributes(&b.attributes, ctx, visitors);
+                ctx.pop();
             }
             Node::SvelteBoundary(b) => {
-                for v in visitors.iter_mut() { v.visit_svelte_boundary(b, scope, data); }
-                walk_attributes(&b.attributes, scope, data, visitors);
-                let child_scope = data.scoping.fragment_scope(&FragmentKey::SvelteBoundaryBody(b.id)).unwrap_or(scope);
-                walk_template(&b.fragment, data, child_scope, visitors);
+                for v in visitors.iter_mut() { v.visit_svelte_boundary(b, ctx); }
+                ctx.push(ParentRef { id: b.id, kind: ParentKind::SvelteBoundary });
+                walk_attributes(&b.attributes, ctx, visitors);
+                let saved = ctx.scope;
+                let child_scope = ctx.data.scoping.fragment_scope(&FragmentKey::SvelteBoundaryBody(b.id)).unwrap_or(saved);
+                ctx.scope = child_scope;
+                walk_template(&b.fragment, ctx, visitors);
+                ctx.scope = saved;
+                ctx.pop();
             }
             Node::AwaitBlock(block) => {
-                for v in visitors.iter_mut() { v.visit_await_block(block, scope, data); }
-                dispatch_expr(visitors, block.id, block.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_await_block(block, ctx); }
+                dispatch_expr(visitors, block.id, block.expression_span, ctx);
+                ctx.push(ParentRef { id: block.id, kind: ParentKind::AwaitBlock });
+                let saved = ctx.scope;
                 if let Some(ref p) = block.pending {
-                    let pending_scope = data.scoping.fragment_scope(&FragmentKey::AwaitPending(block.id)).unwrap_or(scope);
-                    walk_template(p, data, pending_scope, visitors);
+                    let pending_scope = ctx.data.scoping.fragment_scope(&FragmentKey::AwaitPending(block.id)).unwrap_or(saved);
+                    ctx.scope = pending_scope;
+                    walk_template(p, ctx, visitors);
                 }
                 if let Some(ref t) = block.then {
-                    let then_scope = data.scoping.node_scope(block.id).unwrap_or(scope);
-                    walk_template(t, data, then_scope, visitors);
+                    let then_scope = ctx.data.scoping.node_scope(block.id).unwrap_or(saved);
+                    ctx.scope = then_scope;
+                    walk_template(t, ctx, visitors);
                 }
                 if let Some(ref c) = block.catch {
-                    let catch_scope = data.scoping.await_catch_scope(block.id).unwrap_or(scope);
-                    walk_template(c, data, catch_scope, visitors);
+                    let catch_scope = ctx.data.scoping.await_catch_scope(block.id).unwrap_or(saved);
+                    ctx.scope = catch_scope;
+                    walk_template(c, ctx, visitors);
                 }
+                ctx.scope = saved;
+                ctx.pop();
             }
             Node::Text(_) | Node::Comment(_) | Node::Error(_) => {}
         }
@@ -275,67 +424,90 @@ pub(crate) fn walk_template(
 /// Walk attributes, dispatching per-variant visit and expression/statement hooks to all visitors.
 fn walk_attributes(
     attrs: &[Attribute],
-    scope: ScopeId,
-    data: &mut AnalysisData,
+    ctx: &mut VisitContext<'_>,
     visitors: &mut [&mut dyn TemplateVisitor],
 ) {
     for attr in attrs {
         match attr {
             Attribute::ExpressionAttribute(a) => {
-                for v in visitors.iter_mut() { v.visit_expression_attribute(a, scope, data); }
-                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_expression_attribute(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::ExpressionAttribute });
+                dispatch_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::ConcatenationAttribute(a) => {
-                for v in visitors.iter_mut() { v.visit_concatenation_attribute(a, scope, data); }
-                dispatch_concat_exprs(visitors, a.id, &a.parts, scope, data);
+                for v in visitors.iter_mut() { v.visit_concatenation_attribute(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::ConcatenationAttribute });
+                dispatch_concat_exprs(visitors, a.id, &a.parts, ctx);
+                ctx.pop();
             }
             Attribute::SpreadAttribute(a) => {
-                for v in visitors.iter_mut() { v.visit_spread_attribute(a, scope, data); }
-                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_spread_attribute(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::SpreadAttribute });
+                dispatch_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::Shorthand(a) => {
-                for v in visitors.iter_mut() { v.visit_shorthand(a, scope, data); }
-                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_shorthand(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::Shorthand });
+                dispatch_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::ClassDirective(a) => {
-                for v in visitors.iter_mut() { v.visit_class_directive(a, scope, data); }
-                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_class_directive(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::ClassDirective });
+                dispatch_opt_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::StyleDirective(a) => {
-                for v in visitors.iter_mut() { v.visit_style_directive(a, scope, data); }
+                for v in visitors.iter_mut() { v.visit_style_directive(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::StyleDirective });
                 match &a.value {
                     StyleDirectiveValue::Expression(span) => {
-                        dispatch_expr(visitors, a.id, *span, scope, data);
+                        dispatch_expr(visitors, a.id, *span, ctx);
                     }
                     StyleDirectiveValue::Concatenation(parts) => {
-                        dispatch_concat_exprs(visitors, a.id, parts, scope, data);
+                        dispatch_concat_exprs(visitors, a.id, parts, ctx);
                     }
                     StyleDirectiveValue::Shorthand | StyleDirectiveValue::String(_) => {}
                 }
+                ctx.pop();
             }
             Attribute::BindDirective(a) => {
-                for v in visitors.iter_mut() { v.visit_bind_directive(a, scope, data); }
-                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_bind_directive(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::BindDirective });
+                dispatch_opt_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::UseDirective(a) => {
-                for v in visitors.iter_mut() { v.visit_use_directive(a, scope, data); }
-                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_use_directive(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::UseDirective });
+                dispatch_opt_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::OnDirectiveLegacy(a) => {
-                for v in visitors.iter_mut() { v.visit_on_directive_legacy(a, scope, data); }
-                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_on_directive_legacy(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::OnDirectiveLegacy });
+                dispatch_opt_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::TransitionDirective(a) => {
-                for v in visitors.iter_mut() { v.visit_transition_directive(a, scope, data); }
-                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_transition_directive(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::TransitionDirective });
+                dispatch_opt_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::AnimateDirective(a) => {
-                for v in visitors.iter_mut() { v.visit_animate_directive(a, scope, data); }
-                dispatch_opt_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_animate_directive(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::AnimateDirective });
+                dispatch_opt_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::AttachTag(a) => {
-                for v in visitors.iter_mut() { v.visit_attach_tag(a, scope, data); }
-                dispatch_expr(visitors, a.id, a.expression_span, scope, data);
+                for v in visitors.iter_mut() { v.visit_attach_tag(a, ctx); }
+                ctx.push(ParentRef { id: a.id, kind: ParentKind::AttachTag });
+                dispatch_expr(visitors, a.id, a.expression_span, ctx);
+                ctx.pop();
             }
             Attribute::StringAttribute(_) | Attribute::BooleanAttribute(_) => {}
         }


### PR DESCRIPTION
## Summary

Refactored the template visitor pattern to introduce a `VisitContext` struct that bundles scope, mutable analysis data, and a parent stack. This eliminates the need for visitors to manually track parent context and simplifies the visitor trait interface.

## Key Changes

- **Introduced `VisitContext`**: A new struct that encapsulates:
  - Current scope (`ScopeId`)
  - Mutable analysis data reference
  - Parent stack for tracking ancestor nodes/attributes
  - Methods: `parent()`, `ancestors()`, `push()`, `pop()`

- **Added parent tracking types**:
  - `ParentKind` enum: Distinguishes between template nodes and attributes
  - `ParentRef` struct: Combines node ID with parent kind
  - `is_attr()` helper: Identifies attribute-type parents

- **Updated `TemplateVisitor` trait**:
  - All visit methods now take `&mut VisitContext<'_>` instead of separate `scope` and `data` parameters
  - Removed dual-scope parameters from `visit_each_block` (now uses `ctx.scope`)
  - Added generic expression/statement visit hooks: `visit_expression()`, `leave_expression()`, `visit_statement()`, `leave_statement()`
  - These hooks replace 16+ boilerplate visit methods for individual node types

- **Enhanced `walk_template` function**:
  - Now manages parent stack automatically via `ctx.push()`/`ctx.pop()`
  - Dispatches expression/statement visits via new helper functions
  - Handles scope transitions for conditional/loop blocks internally

- **Updated all visitor implementations**:
  - `js_analyze.rs`: Simplified expression extraction using generic `visit_expression()` hook
  - `analyze_semantic.rs`: Updated arrow function scanning to use context
  - `reactivity.rs`: Simplified dynamic node detection
  - `resolve_references.rs`: Cleaner reference resolution
  - `hoistable.rs`, `bind_semantics.rs`, `element_flags.rs`, `content_types.rs`: Updated to new interface

## Implementation Details

- Parent stack is maintained during tree traversal, allowing visitors to query ancestors without manual tracking
- Expression/statement dispatch helpers (`dispatch_expr`, `dispatch_stmt`, etc.) handle optional spans and concatenation parts
- Scope management for conditional/loop blocks is now centralized in `walk_template` rather than distributed across visitors
- Backward compatible with existing visitor patterns—visitors can still implement specific node visit methods

https://claude.ai/code/session_01NEeDVXTvnvxEoS9ow8j1UW