### PR TITLE
Pre-compute snippet params and each block context names

### DIFF
--- a/crates/svelte_analyze/src/passes/template_side_tables.rs
+++ b/crates/svelte_analyze/src/passes/template_side_tables.rs
@@ -78,8 +78,7 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
             // Destructured context: name is always "$$item"
             ctx.data.each_blocks.context_names.insert(block.id, "$$item".to_string());
 
-            // Mark non-default destructured bindings as getters via OXC Visit.
-            // SemanticCollector already set symbol_id on BindingIdentifiers.
+            // Default bindings use $.derived_safe_equal (signals), non-default use getters.
             if let Some(parsed) = ctx.parsed() {
                 if let Some(stmt) = block.context_span.and_then(|cs| parsed.stmts.get(&cs.start)) {
                     let mut marker = DestructuredGetterMarker {
@@ -175,10 +174,11 @@ fn extract_snippet_param_names(stmt: &Statement<'_>) -> Vec<String> {
     let Some(Expression::ArrowFunctionExpression(arrow)) = &declarator.init else {
         return Vec::new();
     };
-    arrow.params.items.iter()
-        .filter_map(|p| p.pattern.get_binding_identifier())
-        .map(|id| id.name.to_string())
-        .collect()
+    let mut names = Vec::new();
+    for param in &arrow.params.items {
+        collect_binding_names(&param.pattern, &mut names);
+    }
+    names
 }
 
 /// OXC Visit that marks arrow function param bindings as snippet params.

--- a/crates/svelte_analyze/src/passes/template_side_tables.rs
+++ b/crates/svelte_analyze/src/passes/template_side_tables.rs
@@ -75,6 +75,9 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
         let is_destructured = ctx.data.each_blocks.is_destructured.contains(&block.id);
 
         if is_destructured {
+            // Destructured context: name is always "$$item"
+            ctx.data.each_blocks.context_names.insert(block.id, "$$item".to_string());
+
             // Mark non-default destructured bindings as getters via OXC Visit.
             // SemanticCollector already set symbol_id on BindingIdentifiers.
             if let Some(parsed) = ctx.parsed() {
@@ -93,6 +96,8 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
                 .map(|ident| ident.name.as_str());
 
             if let Some(ctx_name) = ctx_name {
+                ctx.data.each_blocks.context_names.insert(block.id, ctx_name.to_string());
+
                 if let Some(ctx_sym) = ctx.data.scoping.find_binding(child_scope, ctx_name) {
                     ctx.data.scoping.mark_each_block_var(ctx_sym);
 
@@ -133,11 +138,17 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
         if let Some(name_sym) = ctx.data.scoping.find_binding(ctx.scope, name) {
             ctx.data.scoping.mark_snippet_name(name_sym);
         }
-        // Mark snippet params — dispatch_stmt already ran, so symbol_ids are set
+        // Mark snippet params and collect param names
         if let Some(parsed) = ctx.parsed() {
             if let Some(stmt) = parsed.stmts.get(&block.expression_span.start) {
                 let mut marker = SnippetParamMarker { scoping: &mut ctx.data.scoping };
                 marker.visit_statement(stmt);
+
+                // Extract param names from parsed arrow for codegen
+                let param_names = extract_snippet_param_names(stmt);
+                if !param_names.is_empty() {
+                    ctx.data.snippets.params.insert(block.id, param_names);
+                }
             }
         }
     }
@@ -155,6 +166,19 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
             }
         }
     }
+}
+
+/// Extract param names from `const name = (a, b) => {}` parsed statement.
+fn extract_snippet_param_names(stmt: &Statement<'_>) -> Vec<String> {
+    let Statement::VariableDeclaration(decl) = stmt else { return Vec::new() };
+    let Some(declarator) = decl.declarations.first() else { return Vec::new() };
+    let Some(Expression::ArrowFunctionExpression(arrow)) = &declarator.init else {
+        return Vec::new();
+    };
+    arrow.params.items.iter()
+        .filter_map(|p| p.pattern.get_binding_identifier())
+        .map(|id| id.name.to_string())
+        .collect()
 }
 
 /// OXC Visit that marks arrow function param bindings as snippet params.

--- a/crates/svelte_analyze/src/types/data.rs
+++ b/crates/svelte_analyze/src/types/data.rs
@@ -416,6 +416,8 @@ pub struct SnippetData {
     pub(crate) hoistable: NodeBitSet,
     /// Key: ComponentNode NodeId → snippet NodeIds declared in its fragment
     pub(crate) component_snippets: NodeTable<Vec<NodeId>>,
+    /// Pre-computed param names from the parsed `const name = (a, b) => {}` arrow.
+    pub(crate) params: NodeTable<Vec<String>>,
 }
 
 impl SnippetData {
@@ -423,6 +425,7 @@ impl SnippetData {
         Self {
             hoistable: NodeBitSet::new(node_count),
             component_snippets: NodeTable::new(node_count),
+            params: NodeTable::new(node_count),
         }
     }
 
@@ -433,6 +436,9 @@ impl SnippetData {
         self.component_snippets
             .get(id)
             .map_or(&[], |v| v.as_slice())
+    }
+    pub fn params(&self, id: NodeId) -> &[String] {
+        self.params.get(id).map_or(&[], |v| v.as_slice())
     }
 }
 
@@ -510,6 +516,8 @@ pub struct EachBlockData {
     pub(crate) key_is_item: NodeBitSet,
     /// Body contains an element with an `animate:` directive.
     pub(crate) has_animate: NodeBitSet,
+    /// Context variable name: simple identifier name or `"$$item"` for destructured.
+    pub(crate) context_names: NodeTable<String>,
 }
 
 impl EachBlockData {
@@ -523,6 +531,7 @@ impl EachBlockData {
             body_uses_index: NodeBitSet::new(node_count),
             key_is_item: NodeBitSet::new(node_count),
             has_animate: NodeBitSet::new(node_count),
+            context_names: NodeTable::new(node_count),
         }
     }
 
@@ -551,6 +560,9 @@ impl EachBlockData {
     }
     pub fn has_animate(&self, id: NodeId) -> bool {
         self.has_animate.contains(&id)
+    }
+    pub fn context_name(&self, id: NodeId) -> &str {
+        self.context_names.get(id).map_or("$$item", |s| s.as_str())
     }
 }
 

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -172,7 +172,7 @@ impl<'a> Ctx<'a> {
 
     /// Build `$.async(anchor, blockers, async_values, callback)` statement.
     /// Common pattern used by if/each/key/html blocks when expression is async.
-    pub fn emit_async_block(
+    pub fn gen_async_block(
         &mut self,
         id: NodeId,
         anchor: oxc_ast::ast::Expression<'a>,

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -172,7 +172,7 @@ impl<'a> Ctx<'a> {
 
     /// Build `$.async(anchor, blockers, async_values, callback)` statement.
     /// Common pattern used by if/each/key/html blocks when expression is async.
-    pub fn gen_async_block(
+    pub(crate) fn gen_async_block(
         &mut self,
         id: NodeId,
         anchor: oxc_ast::ast::Expression<'a>,

--- a/crates/svelte_codegen_client/src/template/bind.rs
+++ b/crates/svelte_codegen_client/src/template/bind.rs
@@ -529,21 +529,21 @@ pub(crate) fn gen_bind_directive<'a>(
         stmt = ctx.b.call_stmt("$.effect", [Arg::Expr(effect_body)]);
 
         if !bind_blockers.is_empty() {
-            stmt = wrap_run_after_blockers(ctx, stmt, &bind_blockers);
+            stmt = gen_run_after_blockers(ctx, stmt, &bind_blockers);
         }
         return Some(BindPlacement::Init(stmt));
     }
 
     // Wrap in $.run_after_blockers if bind target has blockers
     if !bind_blockers.is_empty() {
-        stmt = wrap_run_after_blockers(ctx, stmt, &bind_blockers);
+        stmt = gen_run_after_blockers(ctx, stmt, &bind_blockers);
     }
 
     Some(BindPlacement::AfterUpdate(stmt))
 }
 
 /// Wrap a statement in `$.run_after_blockers(blockers, () => { stmt })`.
-fn wrap_run_after_blockers<'a>(ctx: &mut Ctx<'a>, stmt: Statement<'a>, blockers: &[u32]) -> Statement<'a> {
+fn gen_run_after_blockers<'a>(ctx: &mut Ctx<'a>, stmt: Statement<'a>, blockers: &[u32]) -> Statement<'a> {
     let blockers_arr = ctx.b.promises_array(blockers);
     let thunk = ctx.b.thunk_block(vec![stmt]);
     ctx.b.call_stmt("$.run_after_blockers", [

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -46,12 +46,7 @@ pub(crate) fn gen_each_block<'a>(
         var_decl.declarations.remove(0).id
     });
 
-    let context_name = context_pattern.as_ref()
-        .and_then(|p| match p {
-            BindingPattern::BindingIdentifier(ident) => Some(ident.name.to_string()),
-            _ => None,
-        })
-        .unwrap_or_else(|| "$$item".to_string());
+    let context_name = ctx.analysis.each_blocks.context_name(block_id).to_string();
 
     let key_is_item = ctx.each_key_is_item(block_id);
 
@@ -196,7 +191,7 @@ pub(crate) fn gen_each_block<'a>(
         let each_stmt = super::add_svelte_meta(ctx, each_call, span_start, "each");
 
         let async_thunk = if has_await { async_collection_thunk } else { None };
-        body.push(ctx.emit_async_block(block_id, anchor, has_await, async_thunk, "$$collection", vec![each_stmt]));
+        body.push(ctx.gen_async_block(block_id, anchor, has_await, async_thunk, "$$collection", vec![each_stmt]));
     } else {
         let mut each_args: Vec<Arg<'a, '_>> = vec![
             Arg::Expr(anchor),

--- a/crates/svelte_codegen_client/src/template/events.rs
+++ b/crates/svelte_codegen_client/src/template/events.rs
@@ -70,7 +70,7 @@ pub(crate) fn gen_use_directive<'a>(
 
     let blockers = ctx.analysis.attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
-        stmt = wrap_run_after_blockers(ctx, stmt, &blockers);
+        stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
 
     init.push(stmt);
@@ -94,7 +94,7 @@ pub(crate) fn gen_attach_tag<'a>(
 
     let blockers = ctx.analysis.attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
-        stmt = wrap_run_after_blockers(ctx, stmt, &blockers);
+        stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
 
     init.push(stmt);
@@ -140,7 +140,7 @@ pub(crate) fn gen_transition_directive<'a>(
 
     let blockers = ctx.analysis.attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
-        stmt = wrap_run_after_blockers(ctx, stmt, &blockers);
+        stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
 
     after_update.push(stmt);
@@ -175,7 +175,7 @@ pub(crate) fn gen_animate_directive<'a>(
 
     let blockers = ctx.analysis.attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
-        stmt = wrap_run_after_blockers(ctx, stmt, &blockers);
+        stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
 
     after_update.push(stmt);
@@ -186,7 +186,7 @@ pub(crate) fn gen_animate_directive<'a>(
 // ---------------------------------------------------------------------------
 
 /// Wrap a statement in `$.run_after_blockers(blockers, () => { stmt })`.
-fn wrap_run_after_blockers<'a>(ctx: &mut Ctx<'a>, stmt: Statement<'a>, blockers: &[u32]) -> Statement<'a> {
+fn gen_run_after_blockers<'a>(ctx: &mut Ctx<'a>, stmt: Statement<'a>, blockers: &[u32]) -> Statement<'a> {
     let blockers_arr = ctx.b.promises_array(blockers);
     let thunk = ctx.b.thunk_block(vec![stmt]);
     ctx.b.call_stmt("$.run_after_blockers", [

--- a/crates/svelte_codegen_client/src/template/html_tag.rs
+++ b/crates/svelte_codegen_client/src/template/html_tag.rs
@@ -45,7 +45,7 @@ pub(crate) fn gen_html_tag<'a>(
         let html_stmt = ctx.b.call_stmt("$.html", html_args);
 
         let async_thunk = if has_await { Some(ctx.b.async_thunk(expression)) } else { None };
-        stmts.push(ctx.emit_async_block(id, anchor_expr, has_await, async_thunk, "$$html", vec![html_stmt]));
+        stmts.push(ctx.gen_async_block(id, anchor_expr, has_await, async_thunk, "$$html", vec![html_stmt]));
     } else {
         let thunk = super::expression::build_node_thunk(ctx, id);
 

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -144,7 +144,7 @@ pub(crate) fn gen_if_block<'a>(
         stmts.push(super::add_svelte_meta(ctx, if_call, span_start, "if"));
 
         let async_thunk = if has_await { Some(ctx.b.async_thunk(expression.unwrap())) } else { None };
-        vec![ctx.emit_async_block(block_id, anchor, has_await, async_thunk, "$$condition", stmts)]
+        vec![ctx.gen_async_block(block_id, anchor, has_await, async_thunk, "$$condition", stmts)]
     } else {
         let if_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor), Arg::Arrow(render_fn)];
         let if_call = ctx.b.call_expr("$.if", if_args);

--- a/crates/svelte_codegen_client/src/template/key_block.rs
+++ b/crates/svelte_codegen_client/src/template/key_block.rs
@@ -36,7 +36,7 @@ pub(crate) fn gen_key_block<'a>(
         let key_stmt = super::add_svelte_meta(ctx, key_call, span_start, "key");
 
         let async_thunk = if has_await { Some(ctx.b.async_thunk(expression)) } else { None };
-        stmts.push(ctx.emit_async_block(id, anchor, has_await, async_thunk, "$$key", vec![key_stmt]));
+        stmts.push(ctx.gen_async_block(id, anchor, has_await, async_thunk, "$$key", vec![key_stmt]));
     } else {
         let key_thunk = super::expression::build_node_thunk(ctx, id);
 

--- a/crates/svelte_codegen_client/src/template/snippet.rs
+++ b/crates/svelte_codegen_client/src/template/snippet.rs
@@ -21,7 +21,7 @@ pub(crate) fn gen_snippet_block<'a>(
     let block = ctx.snippet_block(id);
     let name = block.name(ctx.source).to_string();
 
-    let param_names: Vec<String> = extract_snippet_param_names(ctx, block.expression_span.start);
+    let param_names: Vec<String> = ctx.analysis.snippets.params(id).to_vec();
 
     // Set snippet params so expression codegen wraps them as thunk calls.
     // Save and restore to handle nested snippets correctly.
@@ -38,26 +38,6 @@ pub(crate) fn gen_snippet_block<'a>(
     let arrow = ctx.b.arrow(params, all_stmts);
 
     ctx.b.const_stmt(&name, oxc_ast::ast::Expression::ArrowFunctionExpression(ctx.b.alloc(arrow)))
-}
-
-/// Extract param names from parsed `const name = (a, b) => {}` arrow.
-fn extract_snippet_param_names(ctx: &Ctx<'_>, offset: u32) -> Vec<String> {
-    use oxc_ast::ast::{Expression, Statement};
-    ctx.parsed.stmts.get(&offset)
-        .and_then(|stmt| match stmt {
-            Statement::VariableDeclaration(decl) => decl.declarations.first(),
-            _ => None,
-        })
-        .and_then(|d| match d.init.as_ref()? {
-            Expression::ArrowFunctionExpression(arrow) => Some(
-                arrow.params.items.iter()
-                    .filter_map(|p| p.pattern.get_binding_identifier())
-                    .map(|id| id.name.to_string())
-                    .collect(),
-            ),
-            _ => None,
-        })
-        .unwrap_or_default()
 }
 
 /// Build FormalParameters: `($$anchor, name = $.noop, ...)`


### PR DESCRIPTION
## Summary
This PR refactors the analysis and codegen pipeline to pre-compute and cache snippet parameter names and each block context variable names during the analysis phase, rather than extracting them on-demand during codegen.

## Key Changes

- **Snippet parameter extraction moved to analysis phase**: Added `extract_snippet_param_names()` function in `template_side_tables.rs` that parses snippet arrow functions and stores parameter names in `SnippetData.params` table during the `visit_snippet_block()` pass.

- **Each block context names pre-computed**: Added `context_names` table to `EachBlockData` that stores either the simple identifier name or `"$$item"` for destructured patterns, populated during `visit_each_block()`.

- **Simplified codegen**: Removed `extract_snippet_param_names()` function from `snippet.rs` and replaced it with a direct lookup via `ctx.analysis.snippets.params(id)`. Similarly, each block codegen now uses `ctx.analysis.each_blocks.context_name(id)` instead of pattern matching.

- **Function renames for clarity**: Renamed `wrap_run_after_blockers()` to `gen_run_after_blockers()` in `events.rs` and `bind.rs` to better reflect that it generates code rather than wrapping existing code. Renamed `emit_async_block()` to `gen_async_block()` in `context.rs` for consistency.

## Implementation Details

- The `extract_snippet_param_names()` helper uses `collect_binding_names()` to handle destructured parameters correctly.
- Each block context names default to `"$$item"` for destructured patterns via the `context_name()` accessor method.
- All pre-computed data is stored in `NodeTable` structures keyed by `NodeId` for O(1) lookup during codegen.

https://claude.ai/code/session_01Dm44xBvT6VmLNaVRwxoSKK