### PR TITLE
Refactor snippet param extraction to use OXC visitor pattern

### DIFF
--- a/crates/svelte_analyze/src/passes/template_side_tables.rs
+++ b/crates/svelte_analyze/src/passes/template_side_tables.rs
@@ -143,10 +143,11 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
                 let mut marker = SnippetParamMarker { scoping: &mut ctx.data.scoping };
                 marker.visit_statement(stmt);
 
-                // Extract param names from parsed arrow for codegen
-                let param_names = extract_snippet_param_names(stmt);
-                if !param_names.is_empty() {
-                    ctx.data.snippets.params.insert(block.id, param_names);
+                // Collect param names for codegen via OXC visitor
+                let mut collector = SnippetParamNameCollector { names: Vec::new() };
+                collector.visit_statement(stmt);
+                if !collector.names.is_empty() {
+                    ctx.data.snippets.params.insert(block.id, collector.names);
                 }
             }
         }
@@ -167,18 +168,28 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
     }
 }
 
-/// Extract param names from `const name = (a, b) => {}` parsed statement.
-fn extract_snippet_param_names(stmt: &Statement<'_>) -> Vec<String> {
-    let Statement::VariableDeclaration(decl) = stmt else { return Vec::new() };
-    let Some(declarator) = decl.declarations.first() else { return Vec::new() };
-    let Some(Expression::ArrowFunctionExpression(arrow)) = &declarator.init else {
-        return Vec::new();
-    };
-    let mut names = Vec::new();
-    for param in &arrow.params.items {
-        collect_binding_names(&param.pattern, &mut names);
+/// OXC Visit that collects param names from `const name = (a, b) => {}`.
+/// Mirrors `SnippetParamMarker` descent but collects names instead of marking symbols.
+struct SnippetParamNameCollector {
+    names: Vec<String>,
+}
+
+impl<'a> Visit<'a> for SnippetParamNameCollector {
+    fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
+        self.names.push(ident.name.to_string());
     }
-    names
+
+    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        // Skip decl.id — snippet name is not a param
+        if let Some(init) = &decl.init {
+            self.visit_expression(init);
+        }
+    }
+
+    fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'a>) {
+        // Only visit params — skip body to avoid collecting inner bindings
+        self.visit_formal_parameters(&arrow.params);
+    }
 }
 
 /// OXC Visit that marks arrow function param bindings as snippet params.


### PR DESCRIPTION
## Summary
Replaced the manual AST traversal function `extract_snippet_param_names` with a proper OXC `Visit` implementation (`SnippetParamNameCollector`) for collecting snippet parameter names.

## Key Changes
- Removed `extract_snippet_param_names()` function that manually pattern-matched and traversed the AST
- Introduced `SnippetParamNameCollector` struct implementing the `Visit<'a>` trait to collect parameter names using OXC's visitor pattern
- Updated the visitor to only traverse relevant nodes:
  - Skips the snippet name binding in `visit_variable_declarator`
  - Only visits parameters in `visit_arrow_function_expression`, avoiding inner bindings in the function body
  - Collects names via `visit_binding_identifier`

## Implementation Details
The new approach mirrors the existing `SnippetParamMarker` visitor pattern, ensuring consistency in how the codebase traverses snippet parameter AST nodes. By using OXC's visitor infrastructure, the code is more maintainable and less error-prone than manual pattern matching.

https://claude.ai/code/session_01MrKJuincaqZopYXhTQWyxA