### PR TITLE
Add compiler test cases for await blocks with nested elements

### DIFF
--- a/tasks/compiler_tests/cases2/await_each_nested/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_each_nested/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<li> </li>`);
+var root_1 = $.from_html(`<ul></ul>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => items, null, ($$anchor, result) => {
+		var ul = root_1();
+		$.each(ul, 21, () => $.get(result), $.index, ($$anchor, item) => {
+			var li = root_2();
+			var text = $.child(li, true);
+			$.reset(li);
+			$.template_effect(() => $.set_text(text, $.get(item)));
+			$.append($$anchor, li);
+		});
+		$.reset(ul);
+		$.append($$anchor, ul);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_each_nested/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_each_nested/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<li> </li>`);
+var root_1 = $.from_html(`<ul></ul>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => items, null, ($$anchor, result) => {
+		var ul = root_1();
+		$.each(ul, 21, () => $.get(result), $.index, ($$anchor, item) => {
+			var li = root_2();
+			var text = $.child(li, true);
+			$.reset(li);
+			$.template_effect(() => $.set_text(text, $.get(item)));
+			$.append($$anchor, li);
+		});
+		$.reset(ul);
+		$.append($$anchor, ul);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_each_nested/case.svelte
+++ b/tasks/compiler_tests/cases2/await_each_nested/case.svelte
@@ -1,0 +1,7 @@
+{#await items then result}
+	<ul>
+		{#each result as item}
+			<li>{item}</li>
+		{/each}
+	</ul>
+{/await}

--- a/tasks/compiler_tests/cases2/await_then_text_before_element/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_then_text_before_element/case-svelte.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(` <div> </div>`, 1);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, ($$anchor, result) => {
+		var fragment_1 = root_1();
+		var text = $.first_child(fragment_1);
+		var div = $.sibling(text);
+		var text_1 = $.child(div, true);
+		$.reset(div);
+		$.template_effect(() => {
+			$.set_text(text, `text ${$.get(result).name ?? ""} `);
+			$.set_text(text_1, $.get(result).value);
+		});
+		$.append($$anchor, fragment_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_then_text_before_element/case.svelte
+++ b/tasks/compiler_tests/cases2/await_then_text_before_element/case.svelte
@@ -1,0 +1,4 @@
+{#await promise then result}
+	text {result.name}
+	<div>{result.value}</div>
+{/await}

--- a/tasks/compiler_tests/cases2/await_thunk_optimization/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_thunk_optimization/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, fetch, null, ($$anchor, result) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(result)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_thunk_optimization/case.svelte
+++ b/tasks/compiler_tests/cases2/await_thunk_optimization/case.svelte
@@ -1,0 +1,3 @@
+{#await fetch() then result}
+	<p>{result}</p>
+{/await}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1802,3 +1802,20 @@ fn attach_on_component_dynamic() {
 fn each_keyed_destructure() {
     assert_compiler("each_keyed_destructure");
 }
+
+#[rstest]
+#[ignore = "bug: spurious $.next() in non-root mixed fragment starting with text (codegen)"]
+fn await_then_text_before_element() {
+    assert_compiler("await_then_text_before_element");
+}
+
+#[rstest]
+#[ignore = "bug: thunk not optimized — () => fetch() should be fetch (codegen)"]
+fn await_thunk_optimization() {
+    assert_compiler("await_thunk_optimization");
+}
+
+#[rstest]
+fn await_each_nested() {
+    assert_compiler("await_each_nested");
+}


### PR DESCRIPTION
## Summary
This PR adds three new compiler test cases for Svelte's `{#await}` block functionality, covering scenarios with nested elements and text content.

## Key Changes
- **await_each_nested**: Tests `{#await}` blocks containing `{#each}` loops with nested HTML elements. Verifies correct code generation for awaiting a promise that resolves to an iterable, then rendering list items.
- **await_then_text_before_element**: Tests `{#await}` blocks with mixed text content and elements. Verifies correct handling of text nodes that appear before elements within the await block.
- **await_thunk_optimization**: Tests thunk optimization in await blocks. Currently marked as ignored due to a known codegen bug where `() => fetch()` should be optimized to just `fetch`.

## Notable Details
- Two test cases are marked with `#[ignore]` annotations documenting known bugs:
  - `await_then_text_before_element`: Spurious `$.next()` calls in non-root mixed fragments starting with text
  - `await_thunk_optimization`: Thunk expressions not being optimized in codegen
- The `await_each_nested` test case is fully enabled and passing
- Each test case includes both the source Svelte template and the expected compiled output for validation

https://claude.ai/code/session_01DbBaDgnZQCnEBcYwKJPH1X