### PR TITLE
Support identifier pattern for $props() rune

### DIFF
--- a/.claude/commands/fix-boundary.md
+++ b/.claude/commands/fix-boundary.md
@@ -1,0 +1,92 @@
+---
+description: Fix a boundary/data flow violation from BOUNDARY_REVIEW.md. Use after /review-boundaries produces a report.
+argument-hint: "[#N | all]"
+allowed-tools: Bash, Read, Grep, Glob, Agent, LSP, Edit, Write
+---
+
+# Fix Boundary Violation: $ARGUMENTS
+
+Implement a fix for a finding from the last `/review-boundaries` run.
+
+## Step 1: Locate the review
+
+Read `BOUNDARY_REVIEW.md` from the project root. If the file does not exist, stop and tell the user to run `/review-boundaries` first.
+
+If `$ARGUMENTS` is `all` — process all findings in order, lowest number first. Skip ~~strikethrough~~ findings.
+If `$ARGUMENTS` is `#N` or `N` — process that finding only.
+
+## Step 2: Understand the finding
+
+For each target finding, read:
+1. All files listed in **Evidence** — understand the full current logic
+2. `CODEBASE_MAP.md` — type signatures, module structure
+3. The upstream crate's relevant files (data.rs, scope.rs, etc.) — understand what already exists
+4. If the fix touches a new area — read `GOTCHAS.md`
+
+## Step 3: Plan
+
+Produce a concrete plan following the finding's **Class**:
+
+**Class 1-2 (Re-parsing / String classification):**
+- Often requires parser changes (new AST field) or analyze changes (new enum/accessor)
+- Plan: add type upstream → populate in correct phase → replace downstream usage
+- Order: parser/analyze first, then codegen consumers
+
+**Class 3 (AST re-traversal):**
+- Add pre-computed data in analyze → expose accessor → replace iteration in codegen
+- Order: analyze side-table → accessor → codegen simplification
+
+**Class 4 (Raw handoff):**
+- Add enum or accessor in analyze → replace multi-flag decision in codegen
+- Order: enum definition → analyze computation → codegen match
+
+**Class 5 (Late knowledge):**
+- Preserve the discarded data upstream → pass through to downstream
+- Order: extend upstream type → populate → read downstream
+
+**Class 6 (Types that lie):**
+- Split type, add Option, or rename to reflect actual semantics
+- Order: type change → update all consumers
+
+For each change:
+- Which files are affected and in what order
+- What types/functions change and how
+- What gets deleted vs what gets added
+
+**Present the plan and wait for approval before writing any code.**
+
+## Step 4: Implement
+
+Apply the approved plan. Order: upstream types → computation → downstream consumers.
+
+After each file change, verify it compiles: `cargo check -p <crate>`.
+
+**Critical invariant: JavaScript output must not change.** These are pure refactors — generated JS must be identical. Snapshot tests are your proof.
+
+After all changes: run `just test-all`.
+
+If tests fail: diff expected vs actual JS output. Fix and retry. **Stop after 3 failed attempts** — report what you tried.
+
+## Step 5: Verify & Update
+
+Run `just test-all` — all tests must pass.
+
+Update `BOUNDARY_REVIEW.md`: mark implemented findings with ~~strikethrough~~, add a one-line note:
+```
+~~### #3 — Event name re-derived in codegen~~
+*Fixed: added `stripped_name` field to `EventHandlerMode`, removed `strip_capture_event` calls in codegen.*
+```
+
+Summarize:
+- Which findings were implemented
+- Which were skipped (and why)
+- What was added (accessor / enum / AST field)
+- What was removed from codegen
+
+## Rules
+
+- **Plan first.** Never write code without user-approved plan.
+- **Upstream before downstream.** Always change the provider before the consumer.
+- **No JS output changes.** These are refactors. Snapshot tests must pass unchanged.
+- **One finding at a time** (when running `all`). Run tests between findings.
+- **Stop after 3 failures.** Report what you tried, do not loop.

--- a/.claude/commands/fix-simplify.md
+++ b/.claude/commands/fix-simplify.md
@@ -1,0 +1,85 @@
+---
+description: Fix a simplification opportunity from SIMPLIFY_REVIEW.md. Use after /review-simplify produces a report.
+argument-hint: "[#N | all]"
+allowed-tools: Bash, Read, Grep, Glob, Agent, LSP, Edit, Write
+---
+
+# Fix Simplification: $ARGUMENTS
+
+Implement a simplification from the last `/review-simplify` run.
+
+## Step 1: Locate the review
+
+Read `SIMPLIFY_REVIEW.md` from the project root. If the file does not exist, stop and tell the user to run `/review-simplify` first.
+
+If `$ARGUMENTS` is `all` — process all findings in order, highest impact first. Skip ~~strikethrough~~ findings.
+If `$ARGUMENTS` is `#N` or `N` — process that finding only.
+
+## Step 2: Understand the finding
+
+For each target finding, read:
+1. All files listed in **Files** — understand the full current logic
+2. If Level 1 (cross-layer): read both the upstream and downstream code
+3. If the finding references a helper that already exists — read it to confirm it's reusable
+
+## Step 3: Plan
+
+Produce a concrete plan based on the finding's **Level**:
+
+**Level 1 (Cross-layer):**
+- Add pre-computed data upstream (analyze accessor, parser AST field)
+- Simplify downstream consumers
+- Order: upstream first, then downstream
+
+**Level 2 (Within-crate):**
+- Extract helper, inline abstraction, remove dead weight, or flatten nesting
+- Usually contained to 1-2 files
+- Verify the extraction doesn't create a god-function or add obscuring parameters
+
+**Level 3 (Cross-file):**
+- Identify the canonical location for the shared logic
+- Extract to a shared module or the file that already has the most complete version
+- Update all call sites
+
+For each change:
+- Which files are affected
+- What gets extracted/inlined/deleted
+- Whether any public API changes
+
+**Present the plan and wait for approval before writing any code.**
+
+## Step 4: Implement
+
+Apply the approved plan.
+
+**Preserve functionality.** Change HOW, never WHAT. Generated JS must be identical.
+
+After each meaningful change, verify: `cargo check -p <crate>`.
+
+After all changes: run `just test-all`.
+
+If tests fail: you changed behavior, not just structure. Investigate the diff. Fix and retry. **Stop after 3 failed attempts.**
+
+## Step 5: Verify & Update
+
+Run `just test-all` — all tests must pass.
+
+Update `SIMPLIFY_REVIEW.md`: mark implemented findings with ~~strikethrough~~, add a one-line note:
+```
+~~### #1 — Directive dispatch duplicated between element.rs and attributes.rs~~
+*Fixed: extracted `process_directive_attrs` helper, called from both spread and non-spread paths.*
+```
+
+Summarize:
+- Which findings were implemented
+- Which were skipped (and why)
+- What was extracted/inlined/deleted
+- Lines of code removed (approximate)
+
+## Rules
+
+- **Plan first.** Never write code without user-approved plan.
+- **No JS output changes.** These are refactors. Snapshot tests must pass unchanged.
+- **Balance check in plan.** If during planning you realize the simplification creates more complexity than it removes — skip it and explain why.
+- **One finding at a time** (when running `all`). Run tests between findings.
+- **Stop after 3 failures.** Report what you tried, do not loop.

--- a/.claude/commands/review-boundaries.md
+++ b/.claude/commands/review-boundaries.md
@@ -1,0 +1,159 @@
+---
+description: Find phase boundary and data flow violations across compiler layers. Use when tech debt accumulated, after porting features, or periodically for hygiene.
+argument-hint: "[crate-or-path | empty=all-codegen]"
+allowed-tools: Bash, Read, Grep, Glob, Agent, LSP, Write
+---
+
+# Boundary & Data Flow Review: $ARGUMENTS
+
+Find places where code violates phase boundaries or data flows through the wrong path.
+
+## Scope
+
+Determined by `$ARGUMENTS`:
+- **No argument** → `svelte_codegen_client` + `svelte_transform` (most common violation sites)
+- **Crate name** (e.g. `codegen`, `transform`, `analyze`) → that crate only
+- **File path** → that file only
+
+## Step 1: Gather context
+
+Read before reviewing:
+1. `CODEBASE_MAP.md` — type signatures, AnalysisData fields, module structure
+2. `crates/svelte_analyze/src/data.rs` — what accessors/enums already exist
+3. `crates/svelte_codegen_client/src/context.rs` — what Ctx shortcuts exist
+
+**You must know what analyze already provides before claiming something is missing.**
+
+## Step 2: Review
+
+For each file in scope, look for these violation classes. Each class has a definition, signals, and a calibration example showing the boundary between violation and acceptable code.
+
+### Class 1: Re-parsing
+
+Codegen/transform creates a new parser or extracts structure from source text that the parser should have delivered as AST.
+
+**Signals:**
+- `oxc_parser::Parser::new()` in codegen/transform
+- Building a new allocator + parsing from string slices
+
+**IS a violation:** `parse_ce_expression` in codegen creates a new OXC parser to parse custom element config from source text.
+**NOT a violation:** `source_text(span)` to read a string literal value — this is span reading, not parsing. Flag only if the result is then split/parsed further.
+
+### Class 2: String classification
+
+Codegen/transform uses string comparisons on tag names, attribute names, or identifier names to make classification decisions that analyze should pre-compute.
+
+**Signals:**
+- `tag_name == "input"`, `a.name == "style"`, `a.name == "class"`
+- `name.starts_with('$')` to detect stores
+- `.as_str() == "..."` for identifier classification
+
+**IS a violation:** `tag_name == "input" && a.name == "value"` to decide `$.set_value` vs `$.set_attribute` — classification decision, should be an enum from analyze.
+**NOT a violation:** String comparisons in the parser itself, or in analyze during classification passes. Also not a violation: string literals used to construct JS output (e.g. `"$.get"`).
+
+### Class 3: AST re-traversal
+
+Codegen/transform iterates children with find/filter/any to collect data that analyze should have pre-computed into a side table.
+
+**Signals:**
+- `.iter().find(|a| matches!(a, ...))` in codegen for DATA COLLECTION
+- `.iter().filter_map(...)` + `.iter().any(...)` on same collection
+- Walking member expression chains to find root identifier
+
+**IS a violation:** `el.attributes.iter().find(class attr).filter_map(class directives).any(dynamic check)` — three traversals to collect info analyze should provide as `ClassOutputInfo`.
+**NOT a violation:** Iterating children for OUTPUT GENERATION (e.g. `for child in fragment.nodes` to emit each child's JS). Codegen must walk the tree to produce output — that's its job.
+
+### Class 4: Raw handoff
+
+Analyze collects facts but doesn't draw conclusions. Downstream combines 2+ flags into a decision without a named enum/accessor.
+
+**Signals:**
+- `let needs_X = flag_a || (flag_b && flag_c)` in codegen/transform
+- Multi-branch `if/else if/else` where each branch produces a different output shape
+- `ctx.analysis.foo(id).and_then(|x| x.bar).and_then(|r| r.baz)` — deep chaining into AnalysisData
+
+**IS a violation:** `let needs_memo = has_call || (is_non_simple && is_dynamic)` combining 3 flags into one of 4 output modes — should be `AttrOutputMode` enum.
+**NOT a violation:** Single flag read: `if ctx.analysis.is_dynamic(id)`. Also not: combining a pre-computed flag with a post-transform value (e.g. `kind != StateRaw && should_proxy(&transformed_value)` — second operand depends on transform output).
+
+### Class 5: Late knowledge
+
+A downstream phase re-discovers something an upstream phase already knew. The knowledge exists but was discarded or not passed through.
+
+**Signals:**
+- Analyze computes a value, stores only a boolean, downstream re-derives the full value
+- Transform re-classifies identifiers that analyze already classified
+- Same function called in multiple phases (e.g. `detect_rune()` in both parser and analyze)
+
+**IS a violation:** Analyze strips "capture" suffix from event names to set `capture: bool`, discards stripped name. Codegen calls `strip_capture_event()` again.
+**NOT a violation:** Transform reading `ComponentScoping` accessors — that's consuming analyze output, not re-discovering.
+
+### Class 6: Types that lie
+
+A type permits states that the data flow never produces. Consumers handle impossible cases.
+
+**Signals:**
+- `Option<T>` that is always `Some` after a certain phase
+- Field with different semantics depending on which map it lives in
+- Name implies deep check, implementation is shallow
+
+**IS a violation:** `ExpressionInfo::has_state` always equals `is_dynamic` for template expressions but means something different for attr expressions — same field, different semantics per map.
+**NOT a violation:** `Option<ScopeId>` with `.unwrap_or(parent_scope)` — legitimate fallback.
+
+## Step 3: Verify each finding
+
+Before reporting a finding, you MUST:
+
+1. **Check existing accessors** — grep `data.rs`, `context.rs`, `scope.rs` for an accessor that already provides what you think is missing. If it exists, the finding is invalid.
+2. **Check consumers** — who reads the problematic code? If only one consumer in one place, impact is low. If 3+ consumers repeat the same pattern, impact is high.
+3. **Check if justified** — some patterns look like violations but are intentional (e.g. string check for unresolved globals like `$effect` where no SymbolId exists). If after investigation the pattern is justified — **drop it, do not include**.
+
+## Step 4: Aggregate
+
+After collecting findings across files:
+
+1. **Group by root cause** — if the same violation appears in 3 files, it's ONE finding with 3 occurrences, not 3 findings
+2. **Rank by downstream impact** — how many lines of code get simpler if this root cause is fixed?
+3. **Cross-reference** — does fixing finding A also fix finding B? Note dependencies.
+
+## Step 5: Report
+
+Save to `BOUNDARY_REVIEW.md` in project root (overwrite if exists).
+
+Format per finding:
+
+```
+### #N — [One-line title]
+
+**Class**: [1-6]
+**Impact**: critical | warning | suggestion
+**Occurrences**: N locations across M files
+**Evidence**:
+- `file:line` — [what happens here, quote the pattern]
+
+**Verified**: [what you checked — existing accessors, consumers, justification]
+
+**Root cause**: [why this violation exists — 1-2 sentences]
+
+**Fix**: [concrete change — what type/accessor to add where, what codegen code gets replaced]
+
+**Simplifies**: [what downstream code becomes unnecessary once fixed]
+```
+
+**Impact criteria:**
+- **critical** — wrong phase owns a decision; fix requires cross-crate changes; multiple downstream consumers affected
+- **warning** — data flows suboptimally; fix is contained; 2-3 occurrences
+- **suggestion** — minor; single occurrence; fix is small
+
+In chat, output summary only:
+- Total findings by impact
+- Top 3 titles
+- "Full report saved to BOUNDARY_REVIEW.md"
+
+## Rules
+
+- **Read-only.** Do not modify source files.
+- **No performance findings.** This review is about architecture, not speed.
+- **No style findings.** Naming, formatting, comment quality are out of scope.
+- **No codegen-internal duplication.** Similar match arms in codegen is a simplification opportunity, not a boundary violation. (That's `/review-simplify`.)
+- **Verified findings only.** Every finding must pass Step 3. Unverified findings are worse than no findings.
+- **Group by root cause.** 5 occurrences of one problem = 1 finding, not 5.

--- a/.claude/commands/review-simplify.md
+++ b/.claude/commands/review-simplify.md
@@ -1,0 +1,121 @@
+---
+description: Find simplification opportunities across compiler layers. Use when code feels overly complex, after multiple features were ported, or when a module is hard to read.
+argument-hint: "[crate-or-path | empty=codegen+transform]"
+allowed-tools: Bash, Read, Grep, Glob, Agent, LSP, Write
+---
+
+# Simplification Review: $ARGUMENTS
+
+Find places where code can be made simpler without changing behavior. Change HOW the code works, never WHAT it does.
+
+## Scope
+
+Determined by `$ARGUMENTS`:
+- **No argument** → `svelte_codegen_client` + `svelte_transform`
+- **Crate name** (e.g. `codegen`, `analyze`, `parser`) → that crate only
+- **File path** → that file only
+
+## Step 1: Gather context
+
+Read before reviewing:
+1. `CODEBASE_MAP.md` — module structure, existing helpers and abstractions
+2. `crates/svelte_analyze/src/data.rs` — what AnalysisData accessors exist
+3. `crates/svelte_codegen_client/src/context.rs` — what Ctx shortcuts exist
+
+## Step 2: Cross-layer scan (mandatory)
+
+**This step is mandatory and cannot be skipped.** It runs before within-crate review.
+
+For each file in scope, collect every `if/else if/else` chain, `match` with 3+ arms, and multi-accessor call (`ctx.analysis.foo() && ctx.analysis.bar()`). For each:
+
+1. **Count accessors** — how many analyze/scoping calls does this decision require?
+2. **Check repetition** — does the same decision pattern appear in other codegen/transform files? (grep for the accessor names)
+3. **Evaluate** — could analyze expose a single accessor/enum that replaces this multi-step decision?
+
+Record your findings. If zero cross-layer opportunities exist, you must show evidence: list the decisions you checked and why each is correctly in codegen (e.g. "single flag read", "depends on post-transform value", "output formatting choice").
+
+**"Looks well-structured" without listing what you checked is not acceptable.**
+
+### Level 1 signals
+
+**Parser → Analyze:**
+- Parser delivers raw spans where structured AST would eliminate analyze re-work
+- Parser doesn't pre-parse JS expressions that analyze needs to classify
+
+**Analyze → Transform/Codegen:**
+- Analyze stores raw facts where a pre-computed enum/accessor would eliminate downstream branching
+- Analyze answers exist but codegen doesn't use them (builds its own logic instead)
+- Multiple codegen files repeat the same multi-flag decision — analyze should own it
+
+**IS an opportunity:** Three codegen files each check `is_dynamic && has_call && !is_simple` to decide memoization — analyze should expose `needs_memo(id) -> bool`.
+**NOT an opportunity:** Codegen checks one analyze flag to pick between two output formats — that's codegen's job.
+
+## Step 3: Within-crate and cross-file review
+
+### Level 2: Within-crate simplification (from Step 3)
+
+**Signals:**
+- **Duplicated logic** — same pattern in 2+ functions/branches that could be unified. Only flag if unification doesn't require adding parameters that obscure intent.
+- **Unnecessary abstraction** — type/trait/helper exists for one call site. Inlining would be clearer.
+- **Dead weight** — parameter always receives same value, enum variant never handled differently from default, match arm identical to another.
+- **Deep nesting** — 3+ levels of if/match/for. Could be flattened with early returns or extracted match.
+
+### Level 3: Cross-file patterns within a crate
+
+Look for the same conceptual operation done in different ways across files in the same crate.
+
+**Signals:**
+- Two files handle the same attribute/node type with similar but slightly different logic
+- A helper exists in one file that another file would benefit from
+- The same visitor pattern is implemented independently in multiple places
+
+**IS an opportunity:** `element.rs` and `component.rs` both build attribute props with the same dynamic/static branching — could share a helper.
+**NOT an opportunity:** Two files handle different node types with genuinely different logic that happens to look similar structurally.
+
+## Step 4: Balance check
+
+For each potential finding, verify it passes the balance test:
+
+1. **Does unification actually simplify?** If the unified version needs 3+ parameters or a complex generic to handle all cases — the duplication is cheaper. Skip.
+2. **Does the change preserve readability?** Fewer lines ≠ simpler. A 10-line match with clear branches is simpler than a 5-line generic helper you need to read twice. Skip if readability decreases.
+3. **Is this over-engineering?** Creating an abstraction for 2 occurrences that may diverge later is premature. Flag only if 3+ occurrences or the pattern is clearly stable.
+4. **Would this create a god-function?** Combining too many concerns into one function/helper makes the code harder to understand. Skip.
+
+## Step 5: Report
+
+Save to `SIMPLIFY_REVIEW.md` in project root (overwrite if exists).
+
+Format per finding:
+
+```
+### #N — [One-line title]
+
+**Level**: [1: cross-layer | 2: within-crate | 3: cross-file]
+**Impact**: high | medium | low
+**Files**: [list of affected files]
+
+**Current state**: [what the code does now — quote the patterns]
+
+**Proposed change**: [concrete — what to extract/inline/unify and where]
+
+**Balance**: [why this simplification is worth it — what becomes easier to read/maintain]
+```
+
+**Impact criteria:**
+- **high** — removes significant branching or duplication; makes a module noticeably easier to read top-to-bottom; Level 1 cross-layer improvements
+- **medium** — cleaner but localized; removes a repeated pattern in 2-3 places
+- **low** — cosmetic; single occurrence; marginal readability gain
+
+In chat, output summary only:
+- Total findings by level and impact
+- Top 3 titles
+- "Full report saved to SIMPLIFY_REVIEW.md"
+
+## Rules
+
+- **Read-only.** Do not modify source files.
+- **Preserve functionality.** Change HOW, never WHAT. Every simplification must produce identical behavior.
+- **No boundary violations.** If the problem is "code in wrong phase" — that's `/review-boundaries`. Here we ask "can upstream do better so downstream is simpler", which is an opportunity, not a violation.
+- **No style-only findings.** Renaming, comment rewording, import reordering are out of scope.
+- **Balance over brevity.** Prefer explicit readable code over clever compact solutions. If in doubt, skip the finding.
+- **Cross-layer first.** Level 1 findings are the most valuable. Prioritize them.

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -159,6 +159,23 @@ pub fn analyze_with_options<'a>(
     }
 
     passes::post_resolve::run_post_resolve_passes(&mut data);
+
+    // Rest prop references in template expressions need context ($.push/$.pop).
+    // Must run after post_resolve which marks rest_prop symbols.
+    if !data.needs_context {
+        data.needs_context = data
+            .expressions
+            .values()
+            .chain(data.attr_expressions.values())
+            .any(|info| {
+                matches!(
+                    info.kind,
+                    crate::types::data::ExpressionKind::MemberExpression
+                        | crate::types::data::ExpressionKind::CallExpression { .. }
+                ) && info.ref_symbols.iter().any(|&sym| data.scoping.is_rest_prop(sym))
+            });
+    }
+
     resolve_render_tag_prop_sources(&mut data, &parsed);
     resolve_render_tag_dynamic(&mut data);
 

--- a/crates/svelte_analyze/src/passes/post_resolve.rs
+++ b/crates/svelte_analyze/src/passes/post_resolve.rs
@@ -104,7 +104,7 @@ fn analyze_props_declaration(data: &mut AnalysisData) {
 
     let has_bindable = decl.props.iter().any(|p| p.is_bindable);
 
-    data.props = Some(PropsAnalysis { props, has_bindable });
+    data.props = Some(PropsAnalysis { props, has_bindable, is_identifier_pattern: decl.is_identifier_pattern });
 }
 
 /// $.store_mutate needs component context ($.push/$.pop) — detect deep store mutations.

--- a/crates/svelte_analyze/src/types/data.rs
+++ b/crates/svelte_analyze/src/types/data.rs
@@ -1185,7 +1185,7 @@ impl LoweredTextPart {
 pub struct PropsAnalysis {
     pub props: Vec<PropAnalysis>,
     pub has_bindable: bool,
-    /// `const props = $props()` — identifier pattern, generates `const` instead of `let`
+    /// `const props = $props()` — identifier pattern, not destructured
     pub is_identifier_pattern: bool,
 }
 

--- a/crates/svelte_analyze/src/types/data.rs
+++ b/crates/svelte_analyze/src/types/data.rs
@@ -1185,6 +1185,8 @@ impl LoweredTextPart {
 pub struct PropsAnalysis {
     pub props: Vec<PropAnalysis>,
     pub has_bindable: bool,
+    /// `const props = $props()` — identifier pattern, generates `const` instead of `let`
+    pub is_identifier_pattern: bool,
 }
 
 pub struct PropAnalysis {

--- a/crates/svelte_analyze/src/types/script.rs
+++ b/crates/svelte_analyze/src/types/script.rs
@@ -18,6 +18,8 @@ pub struct PropInfo {
 #[derive(Debug, Clone)]
 pub struct PropsDeclaration {
     pub props: Vec<PropInfo>,
+    /// `const props = $props()` — identifier pattern, not destructured
+    pub is_identifier_pattern: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/svelte_analyze/src/utils/script_info.rs
+++ b/crates/svelte_analyze/src/utils/script_info.rs
@@ -273,6 +273,22 @@ fn collect_var_declarations(
                         (None, None, vec![], None)
                     };
 
+                // `const props = $props()` — treat as a single rest prop
+                if is_rune == Some(RuneKind::Props) {
+                    *props_declaration = Some(PropsDeclaration {
+                        props: vec![PropInfo {
+                            local_name: name.clone(),
+                            prop_name: name.clone(),
+                            default_span: None,
+                            default_text: None,
+                            is_bindable: false,
+                            is_rest: true,
+                            is_simple_default: true,
+                        }],
+                        is_identifier_pattern: true,
+                    });
+                }
+
                 declarations.push(DeclarationInfo {
                     name,
                     span: decl_span,
@@ -353,7 +369,7 @@ fn collect_var_declarations(
                         }
                     }
 
-                    *props_declaration = Some(PropsDeclaration { props });
+                    *props_declaration = Some(PropsDeclaration { props, is_identifier_pattern: false });
                 } else if matches!(rune, Some(RuneKind::State | RuneKind::StateRaw)) {
                     let mut names = Vec::new();
                     collect_binding_names(&declarator.id, &mut names);

--- a/crates/svelte_codegen_client/src/script/mod.rs
+++ b/crates/svelte_codegen_client/src/script/mod.rs
@@ -312,11 +312,13 @@ pub(super) enum PropKind {
 
 pub(super) struct PropsGenInfo {
     pub(super) props: Vec<PropGenItem>,
+    pub(super) is_identifier_pattern: bool,
 }
 
 impl PropsGenInfo {
     pub(super) fn from_analysis(pa: &PropsAnalysis) -> Self {
         PropsGenInfo {
+            is_identifier_pattern: pa.is_identifier_pattern,
             props: pa.props.iter().map(|p| PropGenItem {
                 local_name: p.local_name.clone(),
                 prop_name: p.prop_name.clone(),

--- a/crates/svelte_codegen_client/src/script/props.rs
+++ b/crates/svelte_codegen_client/src/script/props.rs
@@ -123,7 +123,6 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
             return vec![];
         }
 
-        // `const props = $props()` preserves `const`; destructured `let { ... } = $props()` uses `let`
         if props_gen.is_identifier_pattern {
             let (name, init) = declarators.remove(0);
             vec![self.b.const_stmt(name, init)]

--- a/crates/svelte_codegen_client/src/script/props.rs
+++ b/crates/svelte_codegen_client/src/script/props.rs
@@ -10,12 +10,15 @@ use super::{
 impl<'b, 'a> ScriptTransformer<'b, 'a> {
     pub(super) fn is_props_declaration(decl: &oxc_ast::ast::VariableDeclaration<'a>) -> bool {
         decl.declarations.iter().any(|d| {
-            if let oxc_ast::ast::BindingPattern::ObjectPattern(_) = &d.id {
-                if let Some(init) = &d.init {
-                    if let Expression::CallExpression(call) = init {
-                        if let Expression::Identifier(ident) = &call.callee {
-                            return ident.name.as_str() == "$props";
-                        }
+            let is_props_pattern = matches!(
+                &d.id,
+                oxc_ast::ast::BindingPattern::ObjectPattern(_)
+                    | oxc_ast::ast::BindingPattern::BindingIdentifier(_)
+            );
+            if is_props_pattern {
+                if let Some(Expression::CallExpression(call)) = &d.init {
+                    if let Expression::Identifier(ident) = &call.callee {
+                        return ident.name.as_str() == "$props";
                     }
                 }
             }
@@ -120,6 +123,12 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
             return vec![];
         }
 
-        vec![self.b.let_multi_stmt(declarators)]
+        // `const props = $props()` preserves `const`; destructured `let { ... } = $props()` uses `let`
+        if props_gen.is_identifier_pattern {
+            let (name, init) = declarators.remove(0);
+            vec![self.b.const_stmt(name, init)]
+        } else {
+            vec![self.b.let_multi_stmt(declarators)]
+        }
     }
 }

--- a/tasks/compiler_tests/cases2/props_identifier_await_expression/case-rust.js
+++ b/tasks/compiler_tests/cases2/props_identifier_await_expression/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy"
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => fetch(1, 2, 3, $$props.field1), ($$anchor) => {});
+	$.append($$anchor, fragment);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/props_identifier_await_expression/case-svelte.js
+++ b/tasks/compiler_tests/cases2/props_identifier_await_expression/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy"
+	]);
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => fetch(1, 2, 3, $$props.field1), ($$anchor) => {});
+	$.append($$anchor, fragment);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/props_identifier_await_expression/case.svelte
+++ b/tasks/compiler_tests/cases2/props_identifier_await_expression/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	const props = $props()
+</script>
+
+{#await fetch(1, 2, 3, props.field1)}
+{/await}

--- a/tasks/compiler_tests/cases2/props_identifier_basic/case-rust.js
+++ b/tasks/compiler_tests/cases2/props_identifier_basic/case-rust.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy"
+	]);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $$props.name));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/props_identifier_basic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/props_identifier_basic/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const props = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy"
+	]);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $$props.name));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/props_identifier_basic/case.svelte
+++ b/tasks/compiler_tests/cases2/props_identifier_basic/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	const props = $props()
+</script>
+
+<p>{props.name}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1844,13 +1844,11 @@ fn event_mixed_delegation() {
 }
 
 #[rstest]
-#[ignore = "missing: $props() with plain identifier not transformed (analyze)"]
 fn props_identifier_basic() {
     assert_compiler("props_identifier_basic");
 }
 
 #[rstest]
-#[ignore = "missing: $props() identifier in await expression not transformed (analyze)"]
 fn props_identifier_await_expression() {
     assert_compiler("props_identifier_await_expression");
 }

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1842,3 +1842,15 @@ fn if_else_chain_with_const() {
 fn event_mixed_delegation() {
     assert_compiler("event_mixed_delegation");
 }
+
+#[rstest]
+#[ignore = "missing: $props() with plain identifier not transformed (analyze)"]
+fn props_identifier_basic() {
+    assert_compiler("props_identifier_basic");
+}
+
+#[rstest]
+#[ignore = "missing: $props() identifier in await expression not transformed (analyze)"]
+fn props_identifier_await_expression() {
+    assert_compiler("props_identifier_await_expression");
+}


### PR DESCRIPTION
## Summary
Add support for the identifier pattern form of the `$props()` rune (`const props = $props()`), in addition to the existing destructured pattern support (`const { x, y } = $props()`). When using the identifier pattern, the entire props object is assigned to a single variable and treated as a rest prop.

## Key Changes

- **Props detection**: Extended `is_props_declaration()` to recognize both `ObjectPattern` and `BindingIdentifier` patterns when checking for `$props()` calls
- **Props analysis**: Added `is_identifier_pattern` flag to `PropsDeclaration` and `PropsAnalysis` to distinguish between identifier and destructured patterns
- **Code generation**: Modified props code generation to emit `const` statements for identifier patterns (preserving the `const` keyword) instead of `let` for destructured patterns
- **Context tracking**: Added logic to detect when rest prop references in template expressions need context (`$.push`/`$.pop`), running after post-resolve passes
- **Test cases**: Added two new test cases demonstrating identifier pattern usage with basic property access and await expressions

## Implementation Details

- The identifier pattern is treated internally as a single rest prop with `is_rest: true`
- The `is_identifier_pattern` flag is threaded through the analysis pipeline: `PropsDeclaration` → `PropsAnalysis` → `PropsGenInfo`
- Rest prop symbol detection in template expressions now properly triggers context requirement, ensuring `$.push()` and `$.pop()` are generated when needed

https://claude.ai/code/session_0115Z1rzrprTajinSkogoTkV