### PR TITLE
Add compiler test cases for SVG and template_effect features

### DIFF
--- a/tasks/compiler_tests/cases2/svg_inner_template_from_svg/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svg_inner_template_from_svg/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_svg(`<circle></circle>`);
+var root = $.from_svg(`<svg></svg>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		1,
+		2,
+		3
+	]);
+	var svg = root();
+	$.each(svg, 21, () => items, $.index, ($$anchor, item) => {
+		var circle = root_1();
+		$.set_attribute(circle, "cy", 10);
+		$.set_attribute(circle, "r", 5);
+		$.template_effect(() => $.set_attribute(circle, "cx", $.get(item) * 10));
+		$.append($$anchor, circle);
+	});
+	$.reset(svg);
+	$.append($$anchor, svg);
+}

--- a/tasks/compiler_tests/cases2/svg_inner_template_from_svg/case.svelte
+++ b/tasks/compiler_tests/cases2/svg_inner_template_from_svg/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let items = $state([1, 2, 3]);
+</script>
+
+<svg>
+	{#each items as item}
+		<circle cx={item * 10} cy={10} r={5} />
+	{/each}
+</svg>

--- a/tasks/compiler_tests/cases2/svg_inner_whitespace_trimming/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svg_inner_whitespace_trimming/case-svelte.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_svg(`<svg><line></line><rect></rect></svg>`);
+export default function App($$anchor) {
+	let w = 100;
+	let h = 100;
+	var svg = root();
+	var line = $.child(svg);
+	$.set_attribute(line, "x1", 0);
+	$.set_attribute(line, "y1", 0);
+	$.set_attribute(line, "x2", w);
+	$.set_attribute(line, "y2", h);
+	var rect = $.sibling(line);
+	$.set_attribute(rect, "width", w);
+	$.set_attribute(rect, "height", h);
+	$.reset(svg);
+	$.append($$anchor, svg);
+}

--- a/tasks/compiler_tests/cases2/svg_inner_whitespace_trimming/case.svelte
+++ b/tasks/compiler_tests/cases2/svg_inner_whitespace_trimming/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let w = $state(100);
+	let h = $state(100);
+</script>
+
+<svg>
+	<line x1={0} y1={0} x2={w} y2={h} />
+	<rect width={w} height={h} />
+</svg>

--- a/tasks/compiler_tests/cases2/svg_text_preserves_whitespace/case-svelte.js
+++ b/tasks/compiler_tests/cases2/svg_text_preserves_whitespace/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_svg(`<svg><text></text></svg>`);
+export default function App($$anchor) {
+	let label = "hello";
+	var svg = root();
+	var text = $.child(svg);
+	$.set_attribute(text, "x", 10);
+	$.set_attribute(text, "y", 20);
+	text.textContent = "hello";
+	$.reset(svg);
+	$.append($$anchor, svg);
+}

--- a/tasks/compiler_tests/cases2/svg_text_preserves_whitespace/case.svelte
+++ b/tasks/compiler_tests/cases2/svg_text_preserves_whitespace/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	let label = $state('hello');
+</script>
+
+<svg>
+	<text x={10} y={20}>{label}</text>
+</svg>

--- a/tasks/compiler_tests/cases2/template_effect_call_deps/case-svelte.js
+++ b/tasks/compiler_tests/cases2/template_effect_call_deps/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+import { transform } from "./utils.js";
+var root = $.from_html(`<div class="output"> </div>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = 0;
+	const fn = $.derived(() => transform(value));
+	var div = root();
+	var text = $.child(div, true);
+	$.reset(div);
+	$.template_effect(($0) => $.set_text(text, $0), [() => $.get(fn)(value)]);
+	$.append($$anchor, div);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/template_effect_call_deps/case.svelte
+++ b/tasks/compiler_tests/cases2/template_effect_call_deps/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { transform } from './utils.js';
+	let value = $state(0);
+	const fn = $derived(transform(value));
+</script>
+
+<div class="output">{fn(value)}</div>

--- a/tasks/compiler_tests/cases2/template_effect_multiple_call_deps/case-svelte.js
+++ b/tasks/compiler_tests/cases2/template_effect_multiple_call_deps/case-svelte.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+import { scale } from "./utils.js";
+var root = $.from_svg(`<polyline></polyline>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let data = $.proxy([
+		10,
+		20,
+		30
+	]);
+	const x = $.derived(() => scale([0, data.length], [0, 100]));
+	const y = $.derived(() => scale([0, 30], [100, 0]));
+	var polyline = root();
+	$.template_effect(($0) => $.set_attribute(polyline, "points", $0), [() => data.map((d, i) => [$.get(x)(i), $.get(y)(d)]).join(" ")]);
+	$.append($$anchor, polyline);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/template_effect_multiple_call_deps/case.svelte
+++ b/tasks/compiler_tests/cases2/template_effect_multiple_call_deps/case.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { scale } from './utils.js';
+	let data = $state([10, 20, 30]);
+	const x = $derived(scale([0, data.length], [0, 100]));
+	const y = $derived(scale([0, 30], [100, 0]));
+</script>
+
+<polyline points={data.map((d, i) => [x(i), y(d)]).join(' ')} />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -825,6 +825,36 @@ fn state_class_constructor_proxy() {
     assert_compiler("state_class_constructor_proxy");
 }
 
+#[rstest]
+#[ignore = "missing: SVG whitespace trimming removes inter-element spaces (analyze)"]
+fn svg_inner_whitespace_trimming() {
+    assert_compiler("svg_inner_whitespace_trimming");
+}
+
+#[rstest]
+#[ignore = "missing: inner SVG templates use $.from_svg instead of $.from_html (codegen)"]
+fn svg_inner_template_from_svg() {
+    assert_compiler("svg_inner_template_from_svg");
+}
+
+#[rstest]
+#[ignore = "missing: template_effect extracts call expressions into dependency arrays (codegen)"]
+fn template_effect_call_deps() {
+    assert_compiler("template_effect_call_deps");
+}
+
+#[rstest]
+#[ignore = "missing: SVG text element whitespace preserved with from_svg (codegen)"]
+fn svg_text_preserves_whitespace() {
+    assert_compiler("svg_text_preserves_whitespace");
+}
+
+#[rstest]
+#[ignore = "missing: template_effect extracts complex map+call into dependency arrays (codegen)"]
+fn template_effect_multiple_call_deps() {
+    assert_compiler("template_effect_multiple_call_deps");
+}
+
 // ---------------------------------------------------------------------------
 // Module compilation tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds five new compiler test cases to validate upcoming features related to SVG handling and template effect dependency extraction. All tests are currently marked as ignored with descriptive messages indicating the missing compiler functionality.

## Key Changes
- **svg_inner_whitespace_trimming**: Tests that whitespace between SVG elements is properly trimmed during compilation, using `$.from_svg` for SVG template generation
- **svg_inner_template_from_svg**: Tests that inner SVG templates (within loops) correctly use `$.from_svg` instead of `$.from_html` for proper SVG element handling
- **svg_text_preserves_whitespace**: Tests that whitespace is preserved within SVG `<text>` elements when using `$.from_svg`
- **template_effect_call_deps**: Tests that simple function call expressions are extracted into dependency arrays for `$.template_effect`
- **template_effect_multiple_call_deps**: Tests that complex expressions combining map operations with function calls are properly extracted into dependency arrays

## Notable Implementation Details
- Each test case includes both the source Svelte component (`case.svelte`) and the expected compiled output (`case-svelte.js`)
- Tests demonstrate proper use of `$.from_svg` for SVG content and `$.from_html` for HTML content
- Template effect tests show the expected dependency array extraction pattern: `$.template_effect(($0) => ..., [() => expression])`
- All tests are marked with `#[ignore]` annotations explaining the specific compiler features they depend on

https://claude.ai/code/session_01J7m5Gnc4iB1JxZCbenAGfH