### PR TITLE
Add compiler tests for effect cleanup and call expressions

### DIFF
--- a/tasks/compiler_tests/cases2/call_expr_local_method_dynamic/case-rust.js
+++ b/tasks/compiler_tests/cases2/call_expr_local_method_dynamic/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let obj = { count: 0 };
+	const get_count = () => obj.count;
+	$.user_effect(() => {
+		obj.count += 1;
+	});
+	var p = root();
+	p.textContent = obj.toString();
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/call_expr_local_method_dynamic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/call_expr_local_method_dynamic/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let obj = { count: 0 };
+	const get_count = () => obj.count;
+	$.user_effect(() => {
+		obj.count += 1;
+	});
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(($0) => $.set_text(text, $0), [() => obj.toString()]);
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/call_expr_local_method_dynamic/case.svelte
+++ b/tasks/compiler_tests/cases2/call_expr_local_method_dynamic/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	let obj = { count: 0 };
+
+	const get_count = () => obj.count;
+
+	$effect(() => {
+		obj.count += 1;
+	});
+</script>
+
+<p>{obj.toString()}</p>

--- a/tasks/compiler_tests/cases2/call_expr_nested_fn_dynamic/case-rust.js
+++ b/tasks/compiler_tests/cases2/call_expr_nested_fn_dynamic/case-rust.js
@@ -1,0 +1,10 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p></p>`);
+export default function App($$anchor) {
+	let value = 42;
+	const double = (n) => n * 2;
+	const get_value = () => value;
+	var p = root();
+	p.textContent = double(get_value());
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/call_expr_nested_fn_dynamic/case-svelte.js
+++ b/tasks/compiler_tests/cases2/call_expr_nested_fn_dynamic/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let value = 42;
+	const double = (n) => n * 2;
+	const get_value = () => value;
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(($0) => $.set_text(text, $0), [() => double(get_value())]);
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/call_expr_nested_fn_dynamic/case.svelte
+++ b/tasks/compiler_tests/cases2/call_expr_nested_fn_dynamic/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let value = 42;
+
+	const double = (n) => n * 2;
+
+	const get_value = () => value;
+</script>
+
+<p>{double(get_value())}</p>

--- a/tasks/compiler_tests/cases2/effect_cleanup_return/case-rust.js
+++ b/tasks/compiler_tests/cases2/effect_cleanup_return/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.state(0);
+	$.user_effect(() => {
+		const interval = setInterval(() => {
+			$.set(count, $.get(count) + 1);
+		}, 1e3);
+		return () => {
+			clearInterval(interval);
+		};
+	});
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(count)));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/effect_cleanup_return/case-svelte.js
+++ b/tasks/compiler_tests/cases2/effect_cleanup_return/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let count = $.state(0);
+	$.user_effect(() => {
+		const interval = setInterval(() => {
+			$.set(count, $.get(count) + 1);
+		}, 1e3);
+		return () => {
+			clearInterval(interval);
+		};
+	});
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(count)));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/effect_cleanup_return/case.svelte
+++ b/tasks/compiler_tests/cases2/effect_cleanup_return/case.svelte
@@ -1,0 +1,15 @@
+<script>
+	let count = $state(0);
+
+	$effect(() => {
+		const interval = setInterval(() => {
+			count += 1;
+		}, 1000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
+</script>
+
+<p>{count}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1852,3 +1852,20 @@ fn props_identifier_basic() {
 fn props_identifier_await_expression() {
     assert_compiler("props_identifier_await_expression");
 }
+
+#[rstest]
+#[ignore = "bug: call expressions on local vars not classified as dynamic (analysis)"]
+fn call_expr_local_method_dynamic() {
+    assert_compiler("call_expr_local_method_dynamic");
+}
+
+#[rstest]
+#[ignore = "bug: nested call expressions on local vars not classified as dynamic (analysis)"]
+fn call_expr_nested_fn_dynamic() {
+    assert_compiler("call_expr_nested_fn_dynamic");
+}
+
+#[rstest]
+fn effect_cleanup_return() {
+    assert_compiler("effect_cleanup_return");
+}


### PR DESCRIPTION
## Summary
This PR adds three new compiler test cases to the Svelte v3 compiler test suite, covering effect cleanup functions and dynamic call expression handling.

## Key Changes
- **effect_cleanup_return**: Added test case validating that effect cleanup functions (returned from `$effect`) are properly compiled. Tests the pattern of returning a cleanup function from an effect that manages an interval.

- **call_expr_local_method_dynamic**: Added test case for call expressions on local object methods. Marked as ignored due to a known bug where call expressions on local variables are not properly classified as dynamic during analysis.

- **call_expr_nested_fn_dynamic**: Added test case for nested function calls. Also marked as ignored due to the same dynamic classification bug affecting nested call expressions on local variables.

## Implementation Details
- Each test case includes both Svelte source (`case.svelte`) and expected compiled output for both Rust (`case-rust.js`) and Svelte (`case-svelte.js`) compiler targets
- The `effect_cleanup_return` test is enabled and validates proper compilation of cleanup functions
- Two tests are marked with `#[ignore]` annotations documenting the specific analysis bugs they expose
- Tests follow the existing pattern in `test_v3.rs` using the `assert_compiler` macro

https://claude.ai/code/session_01GGQruWUUKB3RyEspYhG4HY