### PR TITLE
Add test cases for class fields with $state and $derived

### DIFF
--- a/tasks/compiler_tests/cases2/derived_class_field/case-svelte.js
+++ b/tasks/compiler_tests/cases2/derived_class_field/case-svelte.js
@@ -1,0 +1,35 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Box {
+		#width = $.state(0);
+		get width() {
+			return $.get(this.#width);
+		}
+		set width(value) {
+			$.set(this.#width, value, true);
+		}
+		#height = $.state(0);
+		get height() {
+			return $.get(this.#height);
+		}
+		set height(value) {
+			$.set(this.#height, value, true);
+		}
+		#area = $.derived(() => this.width * this.height);
+		get area() {
+			return $.get(this.#area);
+		}
+		set area(value) {
+			$.set(this.#area, value);
+		}
+	}
+	let box = new Box();
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, box.area));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/derived_class_field/case.svelte
+++ b/tasks/compiler_tests/cases2/derived_class_field/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	class Box {
+		width = $state(0);
+		height = $state(0);
+		area = $derived(this.width * this.height);
+	}
+	let box = new Box();
+</script>
+
+<p>{box.area}</p>

--- a/tasks/compiler_tests/cases2/state_class_field_constructor_assign/case-svelte.js
+++ b/tasks/compiler_tests/cases2/state_class_field_constructor_assign/case-svelte.js
@@ -1,0 +1,24 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	class Counter {
+		#count = $.state(0);
+		get count() {
+			return $.get(this.#count);
+		}
+		set count(value) {
+			$.set(this.#count, value, true);
+		}
+		constructor(initial) {
+			this.count = initial;
+		}
+	}
+	let c = new Counter(10);
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, c.count));
+	$.append($$anchor, p);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/state_class_field_constructor_assign/case.svelte
+++ b/tasks/compiler_tests/cases2/state_class_field_constructor_assign/case.svelte
@@ -1,0 +1,12 @@
+<script>
+	class Counter {
+		count = $state(0);
+
+		constructor(initial) {
+			this.count = initial;
+		}
+	}
+	let c = new Counter(10);
+</script>
+
+<p>{c.count}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -825,6 +825,18 @@ fn state_class_constructor_proxy() {
     assert_compiler("state_class_constructor_proxy");
 }
 
+#[rstest]
+#[ignore = "missing: $derived class field transform (transform)"]
+fn derived_class_field() {
+    assert_compiler("derived_class_field");
+}
+
+#[rstest]
+#[ignore = "bug: constructor assigns to private field instead of public setter (transform)"]
+fn state_class_field_constructor_assign() {
+    assert_compiler("state_class_field_constructor_assign");
+}
+
 // ---------------------------------------------------------------------------
 // Module compilation tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds two new test cases for the Svelte compiler to validate the handling of reactive class fields using `$state` and `$derived` runes.

## Changes
- **Added `state_class_field_constructor_assign` test case**: Tests that class fields declared with `$state()` can be properly assigned in constructors. The test case includes a `Counter` class with a reactive `count` field that is initialized via constructor parameter.
  - Includes both the source Svelte component and the expected compiled output
  - Currently marked as ignored due to a known bug where constructor assignments target the private field instead of the public setter

- **Added `derived_class_field` test case**: Tests that class fields declared with `$derived()` are properly compiled and reactive. The test case includes a `Box` class with reactive `width` and `height` fields and a derived `area` field that computes the product.
  - Includes both the source Svelte component and the expected compiled output
  - Currently marked as ignored due to missing `$derived` class field transform implementation

## Implementation Details
Both test cases follow the existing test structure with:
- A source `.svelte` file containing the component code
- A compiled `.js` file showing the expected output using Svelte's internal client API
- Test function entries in `test_v3.rs` with appropriate ignore annotations documenting the known issues

https://claude.ai/code/session_01JgASXXgpMNhErudVPdSFEn