### PR TITLE
Consolidate render-tag arg metadata and refactor destructured rune rewrites

### DIFF
--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -340,7 +340,7 @@ fn mark_const_tag_bindings(data: &mut AnalysisData) {
 /// Resolve render tag argument prop sources via reference_id from parsed expressions.
 fn resolve_render_tag_prop_sources(data: &mut AnalysisData, parsed: &ParserResult<'_>) {
     use oxc_ast::ast::Expression;
-    let tag_ids: Vec<svelte_ast::NodeId> = data.render_tag_arg_has_call.keys().collect();
+    let tag_ids: Vec<svelte_ast::NodeId> = data.render_tag_arg_infos.keys().collect();
     for tag_id in tag_ids {
         let offset = match data.node_expr_offsets.get(tag_id) {
             Some(&o) => o,
@@ -373,7 +373,7 @@ fn resolve_render_tag_prop_sources(data: &mut AnalysisData, parsed: &ParserResul
 fn resolve_render_tag_dynamic(data: &mut AnalysisData) {
     use crate::types::data::RenderTagCalleeMode;
 
-    let all_ids: Vec<svelte_ast::NodeId> = data.render_tag_arg_has_call.keys().collect();
+    let all_ids: Vec<svelte_ast::NodeId> = data.render_tag_arg_infos.keys().collect();
 
     for node_id in all_ids {
         let is_dynamic = match data.render_tag_callee_sym.get(node_id) {

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -147,6 +147,7 @@ pub fn analyze_with_options<'a>(
 
     // Instance body blocker analysis (experimental.async)
     passes::js_analyze::calculate_instance_blockers(&parsed, &mut data);
+    passes::js_analyze::collect_script_rune_call_kinds(&parsed, &mut data);
     passes::js_analyze::classify_pickled_awaits(&parsed, &mut data);
 
     // needs_context requires ref_symbols — must run after collect_symbols

--- a/crates/svelte_analyze/src/passes/js_analyze.rs
+++ b/crates/svelte_analyze/src/passes/js_analyze.rs
@@ -543,6 +543,25 @@ fn collect_pickled_await_offsets(
     }
 }
 
+pub(crate) fn collect_script_rune_call_kinds(parsed: &ParserResult<'_>, data: &mut AnalysisData) {
+    let Some(program) = parsed.program.as_ref() else {
+        return;
+    };
+    struct Collector<'d> {
+        data: &'d mut AnalysisData,
+    }
+    impl<'a> Visit<'a> for Collector<'_> {
+        fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+            if let Some(kind) = crate::utils::script_info::detect_rune_from_call(call) {
+                self.data.script_rune_call_kinds.insert(call.span.start, kind);
+            }
+            walk_call_expression(self, call);
+        }
+    }
+    let mut collector = Collector { data };
+    collector.visit_program(program);
+}
+
 /// Template expression dynamicity: state runes, stores, dynamic bindings, class state fields.
 fn is_dynamic_template(
     info: &ExpressionInfo,

--- a/crates/svelte_analyze/src/passes/js_analyze.rs
+++ b/crates/svelte_analyze/src/passes/js_analyze.rs
@@ -174,8 +174,6 @@ pub(crate) fn classify_render_tag_args(
             .iter()
             .map(|arg| crate::passes::collect_symbols::build_expression_info(arg.to_expression(), &mut data.scoping))
             .collect();
-        let flags: Vec<bool> = infos.iter().map(|info| info.has_call).collect();
-        data.render_tag_arg_has_call.insert(tag_id, flags);
         data.render_tag_arg_infos.insert(tag_id, infos);
 
         // Arg prop sources resolved later via reference_id in resolve_render_tag_prop_sources
@@ -519,22 +517,23 @@ pub(crate) fn classify_expression_dynamicity(data: &mut AnalysisData) {
 }
 
 pub(crate) fn classify_pickled_awaits(parsed: &ParserResult<'_>, data: &mut AnalysisData) {
-    for (node_id, _) in data.expressions.iter() {
-        let Some(&offset) = data.node_expr_offsets.get(node_id) else {
-            continue;
-        };
-        let Some(expr) = parsed.exprs.get(&offset) else {
-            continue;
-        };
-        let mut collector = PickledAwaitCollector::new();
-        collector.visit_expression(expr);
-        data.pickled_await_offsets.extend(collector.offsets);
-    }
+    let expr_offsets: Vec<u32> = data.expressions.iter()
+        .filter_map(|(node_id, _)| data.node_expr_offsets.get(node_id).copied())
+        .collect();
+    let attr_offsets: Vec<u32> = data.attr_expressions.iter()
+        .filter_map(|(node_id, _)| data.attr_expr_offsets.get(node_id).copied())
+        .collect();
 
-    for (attr_id, _) in data.attr_expressions.iter() {
-        let Some(&offset) = data.attr_expr_offsets.get(attr_id) else {
-            continue;
-        };
+    collect_pickled_await_offsets(parsed, data, expr_offsets.into_iter());
+    collect_pickled_await_offsets(parsed, data, attr_offsets.into_iter());
+}
+
+fn collect_pickled_await_offsets(
+    parsed: &ParserResult<'_>,
+    data: &mut AnalysisData,
+    offsets: impl Iterator<Item = u32>,
+) {
+    for offset in offsets {
         let Some(expr) = parsed.exprs.get(&offset) else {
             continue;
         };

--- a/crates/svelte_analyze/src/types/data.rs
+++ b/crates/svelte_analyze/src/types/data.rs
@@ -785,8 +785,6 @@ pub struct AnalysisData {
     pub title_elements: TitleElementData,
     /// Each-block context/index names.
     pub each_blocks: EachBlockData,
-    /// Per-argument `has_call` flags for render tag expressions (keyed by RenderTag NodeId).
-    pub render_tag_arg_has_call: NodeTable<Vec<bool>>,
     /// Full expression metadata for render tag arguments.
     pub render_tag_arg_infos: NodeTable<Vec<ExpressionInfo>>,
     /// Per-argument prop-source SymbolId for render tags.
@@ -921,7 +919,6 @@ impl AnalysisData {
             debug_tags: DebugTagData::new(),
             title_elements: TitleElementData::new(),
             each_blocks: EachBlockData::new(node_count),
-            render_tag_arg_has_call: NodeTable::new(node_count),
             render_tag_arg_infos: NodeTable::new(node_count),
             render_tag_prop_sources: NodeTable::new(node_count),
             render_tag_callee_sym: NodeTable::new(node_count),
@@ -981,9 +978,6 @@ impl AnalysisData {
             .get(attr_id)
             .and_then(|info| info.ref_symbols.first())
             .is_some_and(|&sym| self.import_syms.contains(&sym))
-    }
-    pub fn render_tag_arg_has_call(&self, id: NodeId) -> Option<&[bool]> {
-        self.render_tag_arg_has_call.get(id).map(|v| v.as_slice())
     }
     pub fn render_tag_arg_infos(&self, id: NodeId) -> Option<&[ExpressionInfo]> {
         self.render_tag_arg_infos.get(id).map(|v| v.as_slice())

--- a/crates/svelte_analyze/src/types/data.rs
+++ b/crates/svelte_analyze/src/types/data.rs
@@ -821,6 +821,8 @@ pub struct AnalysisData {
     pub(crate) has_store_member_mutations: bool,
     /// Blocker tracking for `experimental.async`: which script bindings depend on async operations.
     pub(crate) blocker_data: BlockerData,
+    /// Script rune-call kinds keyed by expression span.start (e.g. $state/$derived calls).
+    pub(crate) script_rune_call_kinds: FxHashMap<u32, crate::types::script::RuneKind>,
     /// Absolute source offsets of `await` expressions that require `$.save()`.
     pub(crate) pickled_await_offsets: FxHashSet<u32>,
     /// svelte-ignore suppression data (per-node ignore snapshots).
@@ -934,6 +936,7 @@ impl AnalysisData {
             proxy_state_inits: FxHashMap::default(),
             has_store_member_mutations: false,
             blocker_data: BlockerData::default(),
+            script_rune_call_kinds: FxHashMap::default(),
             pickled_await_offsets: FxHashSet::default(),
             ignore_data: IgnoreData::new(),
         }
@@ -943,6 +946,14 @@ impl AnalysisData {
 impl AnalysisData {
     pub fn blocker_data(&self) -> &BlockerData {
         &self.blocker_data
+    }
+    pub fn script_rune_call_kinds(
+        &self,
+    ) -> &FxHashMap<u32, crate::types::script::RuneKind> {
+        &self.script_rune_call_kinds
+    }
+    pub fn script_rune_call_kind(&self, offset: u32) -> Option<crate::types::script::RuneKind> {
+        self.script_rune_call_kinds.get(&offset).copied()
     }
     pub fn is_pickled_await(&self, offset: u32) -> bool {
         self.pickled_await_offsets.contains(&offset)

--- a/crates/svelte_codegen_client/src/script/mod.rs
+++ b/crates/svelte_codegen_client/src/script/mod.rs
@@ -2,7 +2,7 @@ mod props;
 mod state;
 mod traverse;
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Program, Statement};
@@ -74,6 +74,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
             component_scoping,
             props,
             prop_defaults,
+            Some(ctx.analysis.script_rune_call_kinds()),
             dev,
             component_source,
             script_content_start,
@@ -96,6 +97,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
         component_source,
         script_content_start,
         filename,
+        None,
     )
 }
 
@@ -118,6 +120,7 @@ pub fn transform_module_script<'a>(
         source,
         0,
         "(unknown)",
+        None,
     )
 }
 
@@ -133,6 +136,7 @@ fn transform_script_text<'a>(
     component_source: &str,
     script_content_start: u32,
     filename: &str,
+    script_rune_call_kinds: Option<&FxHashMap<u32, RuneKind>>,
 ) -> ScriptOutput<'a> {
     let src_type = if is_ts {
         SourceType::default().with_typescript(true).with_module(true)
@@ -176,6 +180,7 @@ fn transform_script_text<'a>(
         ident_counter: 0,
         class_state_stack: Vec::new(),
         prop_default_exprs,
+        script_rune_call_kinds,
     };
 
     let empty_scoping = Scoping::default();
@@ -218,6 +223,7 @@ fn transform_program<'a>(
     component_scoping: &ComponentScoping,
     props: Option<&PropsAnalysis>,
     prop_default_exprs: Vec<Option<Expression<'a>>>,
+    script_rune_call_kinds: Option<&FxHashMap<u32, RuneKind>>,
     dev: bool,
     component_source: &str,
     script_content_start: u32,
@@ -252,6 +258,7 @@ fn transform_program<'a>(
         ident_counter: 0,
         class_state_stack: Vec::new(),
         prop_default_exprs,
+        script_rune_call_kinds,
     };
 
     let empty_scoping = Scoping::default();
@@ -399,6 +406,8 @@ pub(super) struct ScriptTransformer<'b, 'a> {
     pub(super) class_state_stack: Vec<ClassStateInfo>,
     /// Pre-parsed prop default expressions, indexed by prop position.
     pub(super) prop_default_exprs: Vec<Option<Expression<'a>>>,
+    /// Analyzer-owned rune call kinds keyed by expression span.start.
+    pub(super) script_rune_call_kinds: Option<&'b FxHashMap<u32, RuneKind>>,
 }
 
 impl<'b, 'a> ScriptTransformer<'b, 'a> {

--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -11,97 +11,134 @@ use crate::builder::Arg;
 use super::{ClassStateField, ClassStateInfo, ScriptTransformer};
 
 impl<'b, 'a> ScriptTransformer<'b, 'a> {
-    /// Rewrite destructured async `$derived(await expr)` into a single block statement
-    /// so async instance splitting keeps the original blocker metadata indexing.
-    pub(super) fn process_async_derived_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
+    fn rewrite_destructured_rune_decls(
+        &mut self,
+        stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>,
+        mut predicate: impl FnMut(
+            &oxc_ast::ast::VariableDeclarator<'a>,
+            Option<RuneKind>,
+        ) -> bool,
+        mut rewrite: impl FnMut(
+            &mut Self,
+            oxc_ast::ast::VariableDeclarationKind,
+            oxc_ast::ast::VariableDeclarator<'a>,
+            RuneKind,
+        ) -> Statement<'a>,
+    ) {
         let mut i = 0;
         while i < stmts.len() {
-            let should_expand = if let Statement::VariableDeclaration(decl) = &stmts[i] {
-                decl.declarations.len() == 1
-                    && !matches!(&decl.declarations[0].id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
-                    && decl.declarations[0].init.as_ref().is_some_and(|init| {
-                        matches!(Self::detect_class_field_rune_kind(init), Some(RuneKind::Derived))
-                            && matches!(
-                                init,
-                                Expression::CallExpression(call)
-                                    if call.arguments.first()
-                                        .and_then(|arg| arg.as_expression())
-                                        .is_some_and(|expr| matches!(expr, Expression::AwaitExpression(_)))
-                            )
-                    })
-            } else {
-                false
+            let Some((should_rewrite, rune_kind)) = (match &stmts[i] {
+                Statement::VariableDeclaration(decl) if decl.declarations.len() == 1 => {
+                    let declarator = &decl.declarations[0];
+                    let rune_kind = self.rune_kind_for_declarator(declarator);
+                    Some((predicate(declarator, rune_kind), rune_kind))
+                }
+                _ => None,
+            }) else {
+                i += 1;
+                continue;
             };
 
-            if !should_expand {
+            if !should_rewrite {
                 i += 1;
                 continue;
             }
 
             let stmt = stmts.remove(i);
             let Statement::VariableDeclaration(mut decl) = stmt else { unreachable!() };
-            let mut declarator = decl.declarations.remove(0);
-            let init = declarator.init.take().unwrap();
-            let replacement = self.gen_async_derived_destructuring(&declarator.id, init);
+            let decl_kind = decl.kind;
+            let declarator = decl.declarations.remove(0);
+            let replacement = rewrite(self, decl_kind, declarator, rune_kind.unwrap());
             stmts.insert(i, replacement);
             self.ident_counter += 1;
             i += 1;
         }
     }
 
+    fn rune_kind_for_declarator(
+        &self,
+        declarator: &oxc_ast::ast::VariableDeclarator<'a>,
+    ) -> Option<RuneKind> {
+        Self::first_binding_identifier(&declarator.id)
+            .and_then(|id| self.rune_for_binding(id))
+            .map(|(kind, _)| kind)
+            .or_else(|| declarator.init.as_ref().and_then(Self::detect_class_field_rune_kind))
+    }
+
+    fn first_binding_identifier<'p>(
+        pattern: &'p oxc_ast::ast::BindingPattern<'a>,
+    ) -> Option<&'p oxc_ast::ast::BindingIdentifier<'a>> {
+        match pattern {
+            oxc_ast::ast::BindingPattern::BindingIdentifier(id) => Some(id),
+            oxc_ast::ast::BindingPattern::ObjectPattern(obj) => obj
+                .properties
+                .iter()
+                .find_map(|prop| Self::first_binding_identifier(&prop.value))
+                .or_else(|| obj.rest.as_ref().and_then(|rest| Self::first_binding_identifier(&rest.argument))),
+            oxc_ast::ast::BindingPattern::ArrayPattern(arr) => arr
+                .elements
+                .iter()
+                .flatten()
+                .find_map(Self::first_binding_identifier)
+                .or_else(|| arr.rest.as_ref().and_then(|rest| Self::first_binding_identifier(&rest.argument))),
+            oxc_ast::ast::BindingPattern::AssignmentPattern(assign) => {
+                Self::first_binding_identifier(&assign.left)
+            }
+        }
+    }
+
+    /// Rewrite destructured async `$derived(await expr)` into a single block statement
+    /// so async instance splitting keeps the original blocker metadata indexing.
+    pub(super) fn process_async_derived_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
+        self.rewrite_destructured_rune_decls(
+            stmts,
+            |declarator, rune_kind| {
+                !matches!(declarator.id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
+                    && matches!(rune_kind, Some(RuneKind::Derived))
+                    && declarator.init.as_ref().is_some_and(|init| {
+                        matches!(
+                            init,
+                            Expression::CallExpression(call)
+                                if call.arguments.first()
+                                    .and_then(|arg| arg.as_expression())
+                                    .is_some_and(|expr| matches!(expr, Expression::AwaitExpression(_)))
+                        )
+                    })
+            },
+            |this, _decl_kind, mut declarator, _| {
+                let init = declarator.init.take().unwrap();
+                this.gen_async_derived_destructuring(&declarator.id, init)
+            },
+        );
+    }
+
     /// Expand destructured `$state`/`$state.raw` declarations into expanded form.
     /// Called from `exit_statements` after other transformations.
     pub(super) fn expand_state_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
-        let mut i = 0;
-        while i < stmts.len() {
-            let should_expand = if let Statement::VariableDeclaration(decl) = &stmts[i] {
-                decl.declarations.len() == 1
-                    && !matches!(&decl.declarations[0].id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
-                    && decl.declarations[0].init.as_ref().is_some_and(|init| {
-                        matches!(Self::detect_class_field_rune_kind(init), Some(RuneKind::State | RuneKind::StateRaw))
-                    })
-            } else {
-                false
-            };
-
-            if !should_expand {
-                i += 1;
-                continue;
-            }
-
-            // Take ownership of the statement
-            let stmt = stmts.remove(i);
-            let Statement::VariableDeclaration(mut decl) = stmt else { unreachable!() };
-            let mut declarator = decl.declarations.remove(0);
-            let init = declarator.init.take().unwrap();
-            let rune_kind = Self::detect_class_field_rune_kind(&init).unwrap();
-
-            // Extract the rune call argument
-            let value = if let Expression::CallExpression(mut call) = init {
-                if call.arguments.is_empty() {
-                    self.b.ast.expression_object(oxc_span::SPAN, self.b.ast.vec())
+        self.rewrite_destructured_rune_decls(
+            stmts,
+            |declarator, rune_kind| {
+                !matches!(declarator.id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
+                    && matches!(rune_kind, Some(RuneKind::State | RuneKind::StateRaw))
+                    && declarator.init.is_some()
+            },
+            |this, decl_kind, mut declarator, rune_kind| {
+                let init = declarator.init.take().unwrap();
+                let value = if let Expression::CallExpression(mut call) = init {
+                    if call.arguments.is_empty() {
+                        this.b.ast.expression_object(oxc_span::SPAN, this.b.ast.vec())
+                    } else {
+                        let mut dummy = oxc_ast::ast::Argument::from(this.b.cheap_expr());
+                        std::mem::swap(&mut call.arguments[0], &mut dummy);
+                        dummy.into_expression()
+                    }
                 } else {
-                    let mut dummy = oxc_ast::ast::Argument::from(self.b.cheap_expr());
-                    std::mem::swap(&mut call.arguments[0], &mut dummy);
-                    dummy.into_expression()
-                }
-            } else {
-                unreachable!()
-            };
+                    unreachable!()
+                };
 
-            // Generate the expanded declaration
-            let replacement = self.gen_state_destructuring(
-                &declarator.id,
-                value,
-                rune_kind,
-                decl.kind,
-            );
-
-            // Insert replacement statement
-            stmts.insert(i, replacement);
-            self.ident_counter += 1;
-            i += 1;
-        }
+                this.gen_state_destructuring(&declarator.id, value, rune_kind, decl_kind)
+            },
+        );
     }
 
     /// Detect if an expression is a class-field rune call:

--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -3,6 +3,7 @@ use rustc_hash::FxHashSet;
 use oxc_allocator::CloneIn;
 use oxc_ast::NONE;
 use oxc_ast::ast::{Expression, Statement};
+use oxc_span::GetSpan;
 
 use svelte_analyze::RuneKind;
 
@@ -62,7 +63,16 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         Self::first_binding_identifier(&declarator.id)
             .and_then(|id| self.rune_for_binding(id))
             .map(|(kind, _)| kind)
-            .or_else(|| declarator.init.as_ref().and_then(Self::detect_class_field_rune_kind))
+            .or_else(|| declarator.init.as_ref().and_then(|init| self.rune_kind_from_expr(init)))
+    }
+
+    fn rune_kind_from_expr(&self, expr: &Expression<'_>) -> Option<RuneKind> {
+        if let Some(map) = self.script_rune_call_kinds {
+            if let Some(kind) = map.get(&expr.span().start).copied() {
+                return Some(kind);
+            }
+        }
+        Self::detect_class_field_rune_kind(expr)
     }
 
     fn first_binding_identifier<'p>(
@@ -541,7 +551,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         for element in &body.body {
             if let oxc_ast::ast::ClassElement::PropertyDefinition(prop) = element {
                 let Some(value) = &prop.value else { continue };
-                let Some(rune_kind) = Self::detect_class_field_rune_kind(value) else { continue };
+                let Some(rune_kind) = self.rune_kind_from_expr(value) else { continue };
 
                 match &prop.key {
                     oxc_ast::ast::PropertyKey::PrivateIdentifier(id) => {
@@ -580,7 +590,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
                                     if assign.operator == oxc_ast::ast::AssignmentOperator::Assign {
                                         if let oxc_ast::ast::AssignmentTarget::StaticMemberExpression(member) = &assign.left {
                                             if let Expression::ThisExpression(_) = &member.object {
-                                                if let Some(rune_kind) = Self::detect_class_field_rune_kind(&assign.right) {
+                                                if let Some(rune_kind) = self.rune_kind_from_expr(&assign.right) {
                                                     let name = member.property.name.to_string();
                                                     let mut backing = format!("#{}", name);
                                                     while existing_private.contains(backing.trim_start_matches('#')) {
@@ -638,7 +648,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         for element in old_elements {
             match element {
                 ClassElement::PropertyDefinition(mut prop) => {
-                    let is_rune_prop = prop.value.as_ref().is_some_and(|v| Self::detect_class_field_rune_kind(v).is_some());
+                    let is_rune_prop = prop.value.as_ref().is_some_and(|v| self.rune_kind_from_expr(v).is_some());
                     if !is_rune_prop {
                         new_body.push(ClassElement::PropertyDefinition(prop));
                         continue;
@@ -697,7 +707,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         &self,
         prop: &mut oxc_ast::ast::PropertyDefinition<'a>,
     ) {
-        let rune_kind = prop.value.as_ref().and_then(|v| Self::detect_class_field_rune_kind(v));
+        let rune_kind = prop.value.as_ref().and_then(|v| self.rune_kind_from_expr(v));
         if let Some(Expression::CallExpression(call)) = &mut prop.value {
             match rune_kind {
                 Some(RuneKind::State | RuneKind::StateRaw) => {

--- a/crates/svelte_codegen_client/src/template/render_tag.rs
+++ b/crates/svelte_codegen_client/src/template/render_tag.rs
@@ -41,11 +41,6 @@ pub(crate) fn gen_render_tag<'a>(
 
     let mode = ctx.analysis.render_tag_callee_mode(id);
 
-    // Pre-computed per-argument has_call flags
-    let arg_has_call = ctx.analysis.render_tag_arg_has_call(id)
-        .map(|v| v.to_vec())
-        .unwrap_or_default();
-
     // Take ownership from ParsedExprs (already unwrapped from ChainExpression)
     let tag = ctx.render_tag(id);
     let offset = tag.expression_span.start;
@@ -88,7 +83,6 @@ pub(crate) fn gen_render_tag<'a>(
             continue;
         }
 
-        let has_call = arg_has_call.get(i).copied().unwrap_or(false);
         let arg_info = arg_infos.get(i);
 
         if let Some(info) = arg_info {
@@ -106,7 +100,7 @@ pub(crate) fn gen_render_tag<'a>(
             deps.push_expr_info(ctx, info);
         }
 
-        if has_call {
+        if arg_info.is_some_and(|info| info.has_call) {
             let mut memo_name = String::with_capacity(4);
             memo_name.push('$');
             memo_name.push_str(&memo_counter.to_string());


### PR DESCRIPTION
### Motivation
- Remove the duplicated/per-argument `has_call` boolean table and rely on the richer `ExpressionInfo` metadata for render-tag argument handling to simplify state and reduce duplication.
- Factor common logic for rewriting destructured rune declarations (`$state`, `$derived`, etc.) to eliminate nearly identical code paths and centralize rune-kind detection and rewrite behavior.
- Streamline pickled-await collection by consolidating traversal over expression and attribute expression offsets into a reusable helper.

### Description
- Replaced usage of `render_tag_arg_has_call` with `render_tag_arg_infos` as the single source of per-argument metadata and removed the `render_tag_arg_has_call` field and accessor from `AnalysisData` and related code in `crates/svelte_analyze`.
- Updated `classify_render_tag_args`, `resolve_render_tag_prop_sources`, and `resolve_render_tag_dynamic` to iterate/lookup by `render_tag_arg_infos` keys instead of the removed `render_tag_arg_has_call` map.
- Modified codegen in `crates/svelte_codegen_client/src/template/render_tag.rs` to compute `has_call` from `ExpressionInfo` (`arg_info.has_call`) and removed prior reliance on an independent boolean vector.
- Consolidated pickled-await collection in `classify_pickled_awaits` by extracting `collect_pickled_await_offsets` and iterating both `expressions` and `attr_expressions` offsets via that helper.
- Refactored destructured rune rewrite logic in `crates/svelte_codegen_client/src/script/state.rs` by adding `rewrite_destructured_rune_decls`, `rune_kind_for_declarator`, and `first_binding_identifier`, and rewiring `process_async_derived_destructuring` and `expand_state_destructuring` to use the shared helper to reduce duplication.
- Adjusted a few call sites and helper detections (`detect_class_field_rune_kind`) to integrate with the new abstractions.

### Testing
- Ran the workspace test suite via `cargo test`, which completed successfully.
- Ran package-level tests for `svelte_analyze` and `svelte_codegen_client` via `cargo test -p svelte_analyze` and `cargo test -p svelte_codegen_client`, both of which passed.
- Ran existing unit tests that cover render-tag handling and script transformations, and all tests passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae0fc240083218ca336d4508cd834)