### PR TITLE
Add CodegenView facade and start migrating codegen to use it

### DIFF
--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -5,18 +5,19 @@ pub(crate) mod utils;
 mod validate;
 pub(crate) mod walker;
 
-pub use types::data::{
-    AnalysisData, AsyncStmtMeta, AwaitBindingData, AwaitBindingInfo, BlockerData, IgnoreData,
-    ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, ConstTagData,
-    ContentStrategy, DebugTagData, DestructureKind, ElementFlags, EventHandlerMode, ExpressionInfo,
-    ExpressionKind, FragmentData, FragmentItem, FragmentKey, LoweredFragment, LoweredTextPart,
-    ParserResult, PropAnalysis, PropsAnalysis, RenderTagCalleeMode, SnippetData,
-};
-pub use utils::IdentGen;
 pub use scope::ComponentScoping;
+pub use types::data::{
+    AnalysisData, AsyncStmtMeta, AwaitBindingData, AwaitBindingInfo, BlockerData,
+    ClassDirectiveInfo, CodegenView, ComponentBindMode, ComponentPropInfo, ComponentPropKind,
+    ConstTagData, ContentStrategy, DebugTagData, DestructureKind, ElementFlags, EventHandlerMode,
+    ExpressionInfo, ExpressionKind, FragmentData, FragmentItem, FragmentKey, IgnoreData,
+    LoweredFragment, LoweredTextPart, ParserResult, PropAnalysis, PropsAnalysis,
+    RenderTagCalleeMode, SnippetData,
+};
 pub use types::script::{
     DeclarationInfo, DeclarationKind, ExportInfo, PropInfo, PropsDeclaration, RuneKind, ScriptInfo,
 };
+pub use utils::IdentGen;
 pub use utils::{
     is_capture_event, is_delegatable_event, is_passive_event, is_simple_identifier,
     strip_capture_event,
@@ -93,7 +94,14 @@ pub fn analyze_with_options<'a>(
     {
         let root = data.scoping.root_scope_id();
         let mut v1 = passes::js_analyze::BindingPreparer;
-        let mut ctx = walker::VisitContext::with_parsed(root, &mut data, &component.store, &parsed, source, runes);
+        let mut ctx = walker::VisitContext::with_parsed(
+            root,
+            &mut data,
+            &component.store,
+            &parsed,
+            source,
+            runes,
+        );
         walker::walk_template(&component.fragment, &mut ctx, &mut [&mut v1]);
         diags.extend(ctx.take_warnings());
     }
@@ -120,12 +128,15 @@ pub fn analyze_with_options<'a>(
         let root = data.scoping.root_scope_id();
         let mut v1 = passes::template_semantic::TemplateSemanticVisitor;
         let mut v2 = passes::template_side_tables::TemplateSideTablesVisitor { component };
-        let mut ctx = walker::VisitContext::with_parsed(root, &mut data, &component.store, &parsed, source, runes);
-        walker::walk_template(
-            &component.fragment,
-            &mut ctx,
-            &mut [&mut v1, &mut v2],
+        let mut ctx = walker::VisitContext::with_parsed(
+            root,
+            &mut data,
+            &component.store,
+            &parsed,
+            source,
+            runes,
         );
+        walker::walk_template(&component.fragment, &mut ctx, &mut [&mut v1, &mut v2]);
         diags.extend(ctx.take_warnings());
     }
     data.scoping.build_template_scope_set();
@@ -135,12 +146,15 @@ pub fn analyze_with_options<'a>(
     {
         let root = data.scoping.root_scope_id();
         let mut v2 = passes::collect_symbols::make_visitor(scoping_built);
-        let mut ctx = walker::VisitContext::with_parsed(root, &mut data, &component.store, &parsed, source, runes);
-        walker::walk_template(
-            &component.fragment,
-            &mut ctx,
-            &mut [&mut v2],
+        let mut ctx = walker::VisitContext::with_parsed(
+            root,
+            &mut data,
+            &component.store,
+            &parsed,
+            source,
+            runes,
         );
+        walker::walk_template(&component.fragment, &mut ctx, &mut [&mut v2]);
         diags.extend(ctx.take_warnings());
     }
     passes::collect_symbols::resolve_script_stores(&mut data);
@@ -174,7 +188,10 @@ pub fn analyze_with_options<'a>(
                     info.kind,
                     crate::types::data::ExpressionKind::MemberExpression
                         | crate::types::data::ExpressionKind::CallExpression { .. }
-                ) && info.ref_symbols.iter().any(|&sym| data.scoping.is_rest_prop(sym))
+                ) && info
+                    .ref_symbols
+                    .iter()
+                    .any(|&sym| data.scoping.is_rest_prop(sym))
             });
     }
 
@@ -191,7 +208,8 @@ pub fn analyze_with_options<'a>(
     // Blocked symbols are reactive (their values change when the promise resolves).
     // Mark them as dynamic so derived symbols that depend on them propagate dynamicity.
     if data.blocker_data.has_async {
-        data.scoping.mark_blocked_symbols_dynamic(&data.blocker_data.symbol_blockers);
+        data.scoping
+            .mark_blocked_symbols_dynamic(&data.blocker_data.symbol_blockers);
     }
 
     passes::js_analyze::classify_expression_dynamicity(&mut data);
@@ -199,7 +217,12 @@ pub fn analyze_with_options<'a>(
     // Mark expressions referencing blocked symbols as dynamic (after classify_expression_dynamicity)
     if data.blocker_data.has_async {
         for info in data.expressions.values_mut() {
-            if !info.is_dynamic && info.ref_symbols.iter().any(|sym| data.blocker_data.symbol_blockers.contains_key(sym)) {
+            if !info.is_dynamic
+                && info
+                    .ref_symbols
+                    .iter()
+                    .any(|sym| data.blocker_data.symbol_blockers.contains_key(sym))
+            {
                 info.is_dynamic = true;
             }
         }
@@ -214,11 +237,7 @@ pub fn analyze_with_options<'a>(
         let root = data.scoping.root_scope_id();
         let mut v1 = passes::reactivity::ReactivityVisitor::new();
         let mut ctx = walker::VisitContext::new(root, &mut data, &component.store, source, runes);
-        walker::walk_template(
-            &component.fragment,
-            &mut ctx,
-            &mut [&mut v1],
-        );
+        walker::walk_template(&component.fragment, &mut ctx, &mut [&mut v1]);
         diags.extend(ctx.take_warnings());
     }
 
@@ -250,7 +269,8 @@ pub fn analyze_with_options<'a>(
             })
             .collect();
         let mut v2 = passes::element_flags::ElementFlagsVisitor::new(&component.source);
-        let mut v3 = passes::hoistable::HoistableSnippetsVisitor::new(script_syms, top_level_snippet_ids);
+        let mut v3 =
+            passes::hoistable::HoistableSnippetsVisitor::new(script_syms, top_level_snippet_ids);
         let mut v4 = passes::bind_semantics::BindSemanticsVisitor::new(&component.source);
         let mut v5 = passes::content_types::ContentAndVarVisitor {
             source: &component.source,
@@ -311,7 +331,10 @@ pub fn analyze_module(
 /// Scope is derived from const_tags.by_fragment + fragment_scopes.
 fn mark_const_tag_bindings(data: &mut AnalysisData) {
     use types::script::RuneKind;
-    let pairs: Vec<_> = data.const_tags.by_fragment.iter()
+    let pairs: Vec<_> = data
+        .const_tags
+        .by_fragment
+        .iter()
         .filter_map(|(frag_key, tag_ids)| {
             let scope = data.scoping.fragment_scope(frag_key)?;
             Some((scope, tag_ids.clone()))
@@ -319,10 +342,14 @@ fn mark_const_tag_bindings(data: &mut AnalysisData) {
         .collect();
     for (scope, tag_ids) in pairs {
         for tag_id in tag_ids {
-            let Some(names) = data.const_tags.names(tag_id).cloned() else { continue };
+            let Some(names) = data.const_tags.names(tag_id).cloned() else {
+                continue;
+            };
             let is_destructured = names.len() > 1;
             // Get deps from the @const expression's ref_symbols
-            let deps: Vec<_> = data.expressions.get(tag_id)
+            let deps: Vec<_> = data
+                .expressions
+                .get(tag_id)
                 .map(|info| info.ref_symbols.to_vec())
                 .unwrap_or_default();
             for name in &names {

--- a/crates/svelte_analyze/src/types/data.rs
+++ b/crates/svelte_analyze/src/types/data.rs
@@ -5,8 +5,8 @@ use svelte_ast::{ConcatPart, NodeId, StyleDirective};
 use svelte_span::Span;
 
 use super::node_table::{NodeBitSet, NodeTable};
-use crate::scope::{ComponentScoping, SymbolId};
 use super::script::{ExportInfo, ScriptInfo};
+use crate::scope::{ComponentScoping, SymbolId};
 
 pub use svelte_parser::ParserResult;
 
@@ -17,7 +17,10 @@ pub use svelte_parser::ParserResult;
 #[derive(Debug, Clone)]
 pub enum AwaitBindingInfo {
     Simple(String),
-    Destructured { kind: DestructureKind, names: Vec<String> },
+    Destructured {
+        kind: DestructureKind,
+        names: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -135,13 +138,20 @@ impl FragmentKey {
     pub fn node_id(&self) -> Option<NodeId> {
         match self {
             Self::Root => None,
-            Self::Element(id) | Self::ComponentNode(id)
-            | Self::IfConsequent(id) | Self::IfAlternate(id)
-            | Self::EachBody(id) | Self::EachFallback(id)
-            | Self::SnippetBody(id) | Self::KeyBlockBody(id)
-            | Self::SvelteHeadBody(id) | Self::SvelteElementBody(id)
+            Self::Element(id)
+            | Self::ComponentNode(id)
+            | Self::IfConsequent(id)
+            | Self::IfAlternate(id)
+            | Self::EachBody(id)
+            | Self::EachFallback(id)
+            | Self::SnippetBody(id)
+            | Self::KeyBlockBody(id)
+            | Self::SvelteHeadBody(id)
+            | Self::SvelteElementBody(id)
             | Self::SvelteBoundaryBody(id)
-            | Self::AwaitPending(id) | Self::AwaitThen(id) | Self::AwaitCatch(id) => Some(*id),
+            | Self::AwaitPending(id)
+            | Self::AwaitThen(id)
+            | Self::AwaitCatch(id) => Some(*id),
         }
     }
 }
@@ -422,7 +432,9 @@ impl FragmentData {
 
     /// Pre-computed blocker indices for a fragment's text expressions.
     pub fn fragment_blockers(&self, key: &FragmentKey) -> &[u32] {
-        self.fragment_blockers.get(key).map_or(&[], |v| v.as_slice())
+        self.fragment_blockers
+            .get(key)
+            .map_or(&[], |v| v.as_slice())
     }
 }
 
@@ -552,7 +564,9 @@ impl EachBlockData {
 
     /// Build reverse lookup from index_syms. Call after Walk 2 populates index_syms.
     pub(crate) fn build_index_lookup(&mut self) {
-        self.index_sym_to_block = self.index_syms.iter()
+        self.index_sym_to_block = self
+            .index_syms
+            .iter()
             .map(|(block_id, &sym)| (sym, block_id))
             .collect();
     }
@@ -829,6 +843,128 @@ pub struct AnalysisData {
     pub ignore_data: IgnoreData,
 }
 
+/// Read-only facade for codegen access to analysis queries.
+///
+/// This narrows the surface area that codegen can depend on and provides
+/// an explicit migration path away from raw `AnalysisData` field access.
+#[derive(Clone, Copy)]
+pub struct CodegenView<'a> {
+    data: &'a AnalysisData,
+}
+
+impl<'a> CodegenView<'a> {
+    pub fn new(data: &'a AnalysisData) -> Self {
+        Self { data }
+    }
+
+    /// Temporary migration path while template modules are moved to facade methods.
+    pub fn raw(&self) -> &'a AnalysisData {
+        self.data
+    }
+
+    pub fn custom_element(&self) -> bool {
+        self.data.custom_element
+    }
+    pub fn exports(&self) -> &[ExportInfo] {
+        &self.data.exports
+    }
+    pub fn props(&self) -> Option<&PropsAnalysis> {
+        self.data.props.as_ref()
+    }
+    pub fn needs_context(&self) -> bool {
+        self.data.needs_context
+    }
+    pub fn props_id(&self) -> Option<&str> {
+        self.data.props_id.as_deref()
+    }
+    pub fn scoping(&self) -> &ComponentScoping {
+        &self.data.scoping
+    }
+    pub fn blocker_data(&self) -> &BlockerData {
+        self.data.blocker_data()
+    }
+    pub fn expr_has_blockers(&self, id: NodeId) -> bool {
+        self.data.expr_has_blockers(id)
+    }
+    pub fn expression_blockers(&self, id: NodeId) -> SmallVec<[u32; 2]> {
+        self.data.expression_blockers(id)
+    }
+
+    pub fn lowered_fragment(&self, key: &FragmentKey) -> Option<&LoweredFragment> {
+        self.data.fragments.lowered(key)
+    }
+    pub fn content_type(&self, key: &FragmentKey) -> ContentStrategy {
+        self.data.fragments.content_type(key)
+    }
+    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool {
+        self.data.fragments.has_dynamic_children(key)
+    }
+
+    pub fn has_spread(&self, id: NodeId) -> bool {
+        self.data.element_flags.has_spread(id)
+    }
+    pub fn has_class_directives(&self, id: NodeId) -> bool {
+        self.data.element_flags.has_class_directives(id)
+    }
+    pub fn has_class_attribute(&self, id: NodeId) -> bool {
+        self.data.element_flags.has_class_attribute(id)
+    }
+    pub fn needs_clsx(&self, id: NodeId) -> bool {
+        self.data.element_flags.needs_clsx(id)
+    }
+    pub fn has_style_directives(&self, id: NodeId) -> bool {
+        self.data.element_flags.has_style_directives(id)
+    }
+    pub fn style_directives(&self, id: NodeId) -> &[StyleDirective] {
+        self.data.element_flags.style_directives(id)
+    }
+    pub fn needs_input_defaults(&self, id: NodeId) -> bool {
+        self.data.element_flags.needs_input_defaults(id)
+    }
+    pub fn needs_var(&self, id: NodeId) -> bool {
+        self.data.element_flags.needs_var(id)
+    }
+    pub fn is_dynamic_attr(&self, id: NodeId) -> bool {
+        self.data.element_flags.is_dynamic_attr(id)
+    }
+    pub fn static_class(&self, id: NodeId) -> Option<&str> {
+        self.data.element_flags.static_class(id)
+    }
+    pub fn static_style(&self, id: NodeId) -> Option<&str> {
+        self.data.element_flags.static_style(id)
+    }
+    pub fn is_bound_contenteditable(&self, id: NodeId) -> bool {
+        self.data.element_flags.is_bound_contenteditable(id)
+    }
+    pub fn has_use_directive(&self, id: NodeId) -> bool {
+        self.data.element_flags.has_use_directive(id)
+    }
+    pub fn has_dynamic_class_directives(&self, id: NodeId) -> bool {
+        self.data.element_flags.has_dynamic_class_directives(id)
+    }
+    pub fn class_needs_state(&self, id: NodeId) -> bool {
+        self.data.element_flags.class_needs_state(id)
+    }
+    pub fn class_attr_id(&self, id: NodeId) -> Option<NodeId> {
+        self.data.element_flags.class_attr_id(id)
+    }
+    pub fn class_directive_info(&self, id: NodeId) -> Option<&[ClassDirectiveInfo]> {
+        self.data.element_flags.class_directive_info(id)
+    }
+    pub fn is_expression_shorthand(&self, id: NodeId) -> bool {
+        self.data.element_flags.is_expression_shorthand(id)
+    }
+    pub fn component_props(&self, id: NodeId) -> &[ComponentPropInfo] {
+        self.data.element_flags.component_props(id)
+    }
+    pub fn component_snippets(&self, id: NodeId) -> &[NodeId] {
+        self.data.snippets.component_snippets(id)
+    }
+    pub fn event_handler_mode(&self, id: NodeId) -> Option<EventHandlerMode> {
+        self.data.element_flags.event_handler_mode(id)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Blocker tracking (experimental.async)
 // ---------------------------------------------------------------------------
@@ -947,9 +1083,7 @@ impl AnalysisData {
     pub fn blocker_data(&self) -> &BlockerData {
         &self.blocker_data
     }
-    pub fn script_rune_call_kinds(
-        &self,
-    ) -> &FxHashMap<u32, crate::types::script::RuneKind> {
+    pub fn script_rune_call_kinds(&self) -> &FxHashMap<u32, crate::types::script::RuneKind> {
         &self.script_rune_call_kinds
     }
     pub fn script_rune_call_kind(&self, offset: u32) -> Option<crate::types::script::RuneKind> {
@@ -1024,7 +1158,9 @@ impl AnalysisData {
             return false;
         }
         self.expressions.get(id).is_some_and(|info| {
-            info.ref_symbols.iter().any(|sym| self.blocker_data.symbol_blockers.contains_key(sym))
+            info.ref_symbols
+                .iter()
+                .any(|sym| self.blocker_data.symbol_blockers.contains_key(sym))
         })
     }
 
@@ -1078,15 +1214,25 @@ impl AnalysisData {
     /// Check if any expression in a fragment (recursively for elements) references
     /// any of the given symbols. Used to decide whether snippet bodies need
     /// duplicated @const tags in boundary codegen.
-    pub fn fragment_references_any_symbol(&self, key: &FragmentKey, syms: &FxHashSet<SymbolId>) -> bool {
-        if syms.is_empty() { return false; }
-        let Some(fragment) = self.fragments.lowered(key) else { return false };
+    pub fn fragment_references_any_symbol(
+        &self,
+        key: &FragmentKey,
+        syms: &FxHashSet<SymbolId>,
+    ) -> bool {
+        if syms.is_empty() {
+            return false;
+        }
+        let Some(fragment) = self.fragments.lowered(key) else {
+            return false;
+        };
         for item in &fragment.items {
             match item {
                 FragmentItem::TextConcat { parts, .. } => {
                     for part in parts {
                         if let LoweredTextPart::Expr(id) = part {
-                            if self.expressions.get(*id).is_some_and(|info| info.ref_symbols.iter().any(|s| syms.contains(s))) {
+                            if self.expressions.get(*id).is_some_and(|info| {
+                                info.ref_symbols.iter().any(|s| syms.contains(s))
+                            }) {
                                 return true;
                             }
                         }
@@ -1099,15 +1245,19 @@ impl AnalysisData {
                 }
                 FragmentItem::IfBlock(id) => {
                     if self.node_expr_references_syms(*id, syms)
-                        || self.fragment_references_any_symbol(&FragmentKey::IfConsequent(*id), syms)
-                        || self.fragment_references_any_symbol(&FragmentKey::IfAlternate(*id), syms) {
+                        || self
+                            .fragment_references_any_symbol(&FragmentKey::IfConsequent(*id), syms)
+                        || self.fragment_references_any_symbol(&FragmentKey::IfAlternate(*id), syms)
+                    {
                         return true;
                     }
                 }
                 FragmentItem::EachBlock(id) => {
                     if self.node_expr_references_syms(*id, syms)
                         || self.fragment_references_any_symbol(&FragmentKey::EachBody(*id), syms)
-                        || self.fragment_references_any_symbol(&FragmentKey::EachFallback(*id), syms) {
+                        || self
+                            .fragment_references_any_symbol(&FragmentKey::EachFallback(*id), syms)
+                    {
                         return true;
                     }
                 }
@@ -1118,18 +1268,26 @@ impl AnalysisData {
                 }
                 FragmentItem::KeyBlock(id) => {
                     if self.node_expr_references_syms(*id, syms)
-                        || self.fragment_references_any_symbol(&FragmentKey::KeyBlockBody(*id), syms) {
+                        || self
+                            .fragment_references_any_symbol(&FragmentKey::KeyBlockBody(*id), syms)
+                    {
                         return true;
                     }
                 }
                 FragmentItem::SvelteElement(id) => {
                     if self.node_expr_references_syms(*id, syms)
-                        || self.fragment_references_any_symbol(&FragmentKey::SvelteElementBody(*id), syms) {
+                        || self.fragment_references_any_symbol(
+                            &FragmentKey::SvelteElementBody(*id),
+                            syms,
+                        )
+                    {
                         return true;
                     }
                 }
                 FragmentItem::SvelteBoundary(id) => {
-                    if self.fragment_references_any_symbol(&FragmentKey::SvelteBoundaryBody(*id), syms) {
+                    if self
+                        .fragment_references_any_symbol(&FragmentKey::SvelteBoundaryBody(*id), syms)
+                    {
                         return true;
                     }
                 }
@@ -1150,7 +1308,9 @@ impl AnalysisData {
 
     /// Check if a node's expression references any of the given symbols.
     fn node_expr_references_syms(&self, id: NodeId, syms: &FxHashSet<SymbolId>) -> bool {
-        self.expressions.get(id).is_some_and(|info| info.ref_symbols.iter().any(|s| syms.contains(s)))
+        self.expressions
+            .get(id)
+            .is_some_and(|info| info.ref_symbols.iter().any(|s| syms.contains(s)))
     }
 }
 

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::{Expression, Statement};
 use oxc_semantic::SymbolId;
-use svelte_analyze::{AnalysisData, ClassDirectiveInfo, ComponentPropInfo, ContentStrategy, EventHandlerMode, FragmentKey, IdentGen, LoweredFragment, ParserResult};
+use svelte_analyze::{AnalysisData, ClassDirectiveInfo, CodegenView, ComponentPropInfo, ContentStrategy, EventHandlerMode, FragmentKey, IdentGen, LoweredFragment, ParserResult};
 use svelte_ast::{AwaitBlock, Component, ComponentNode, DebugTag, EachBlock, Element, IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow};
 use svelte_analyze::ExpressionInfo;
 use svelte_transform::TransformData;
@@ -14,7 +14,7 @@ use crate::builder::Builder;
 pub struct Ctx<'a> {
     pub b: Builder<'a>,
     pub component: &'a Component,
-    pub analysis: &'a AnalysisData,
+    pub query: CodegenView<'a>,
     pub name: &'a str,
     /// Data produced by the transform phase (e.g. tmp names for destructured const tags).
     pub transform_data: TransformData,
@@ -82,7 +82,7 @@ impl<'a> Ctx<'a> {
         Self {
             b: Builder::new(allocator),
             component,
-            analysis,
+            query: CodegenView::new(analysis),
             name,
             transform_data,
             parsed,
@@ -121,8 +121,13 @@ impl<'a> Ctx<'a> {
     pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody { self.component.store.svelte_body(id) }
 
     pub fn lowered_fragment(&self, key: &FragmentKey) -> &LoweredFragment {
-        self.analysis.fragments.lowered(key)
+        self.query.lowered_fragment(key)
             .unwrap_or_else(|| panic!("lowered fragment {:?} not found", key))
+    }
+
+    /// Temporary migration path for still-unported call-sites.
+    pub fn analysis(&self) -> &'a AnalysisData {
+        self.query.raw()
     }
 
     // -- Identifiers --
@@ -134,31 +139,31 @@ impl<'a> Ctx<'a> {
 
     // -- Analysis shortcuts --
 
-    pub fn is_dynamic(&self, id: NodeId) -> bool { self.analysis.is_dynamic(id) }
-    pub fn is_elseif_alt(&self, id: NodeId) -> bool { self.analysis.is_elseif_alt(id) }
+    pub fn is_dynamic(&self, id: NodeId) -> bool { self.analysis().is_dynamic(id) }
+    pub fn is_elseif_alt(&self, id: NodeId) -> bool { self.analysis().is_elseif_alt(id) }
     pub fn is_mutable_rune_target(&self, id: NodeId) -> bool {
-        self.analysis.bind_semantics.is_mutable_rune_target(id)
+        self.analysis().bind_semantics.is_mutable_rune_target(id)
     }
     pub fn is_prop_source_node(&self, id: NodeId) -> bool {
-        self.analysis.bind_semantics.is_prop_source(id)
+        self.analysis().bind_semantics.is_prop_source(id)
     }
     pub fn bind_each_context(&self, id: NodeId) -> Option<&Vec<String>> {
-        self.analysis.bind_semantics.each_context(id)
+        self.analysis().bind_semantics.each_context(id)
     }
     pub fn each_index_name(&self, id: NodeId) -> Option<String> {
-        self.analysis.each_blocks.index_sym(id)
-            .map(|sym| self.analysis.scoping.symbol_name(sym).to_string())
+        self.analysis().each_blocks.index_sym(id)
+            .map(|sym| self.analysis().scoping.symbol_name(sym).to_string())
     }
     pub fn await_value_binding(&self, id: NodeId) -> Option<&svelte_analyze::AwaitBindingInfo> {
-        self.analysis.await_bindings.value(id)
+        self.analysis().await_bindings.value(id)
     }
     pub fn await_error_binding(&self, id: NodeId) -> Option<&svelte_analyze::AwaitBindingInfo> {
-        self.analysis.await_bindings.error(id)
+        self.analysis().await_bindings.error(id)
     }
     pub fn attr_is_import(&self, attr_id: NodeId) -> bool {
-        self.analysis.attr_is_import(attr_id)
+        self.analysis().attr_is_import(attr_id)
     }
-    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> { self.analysis.expression(id) }
+    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> { self.analysis().expression(id) }
     pub fn const_tag_symbol_blocker_expr(&self, sym: SymbolId) -> Option<Expression<'a>> {
         let (name, idx) = self.const_tag_blockers.get(&sym)?;
         Some(self.b.computed_member_expr(
@@ -166,7 +171,7 @@ impl<'a> Ctx<'a> {
             self.b.num_expr(*idx as f64),
         ))
     }
-    pub fn known_value(&self, name: &str) -> Option<&str> { self.analysis.known_value(name) }
+    pub fn known_value(&self, name: &str) -> Option<&str> { self.analysis().known_value(name) }
 
     /// Check if expression for node has `has_await`.
     pub fn expr_has_await(&self, id: NodeId) -> bool {
@@ -175,7 +180,7 @@ impl<'a> Ctx<'a> {
 
     /// Check if expression has blockers (references bindings with blocker metadata).
     pub fn expr_has_blockers(&self, id: NodeId) -> bool {
-        self.analysis.expr_has_blockers(id)
+        self.query.expr_has_blockers(id)
     }
 
 
@@ -198,7 +203,7 @@ impl<'a> Ctx<'a> {
 
     /// Build `[$$promises[i], ...]` blockers array from expression's blocker indices.
     pub fn build_blockers_array(&mut self, id: NodeId) -> oxc_ast::ast::Expression<'a> {
-        let indices = self.analysis.expression_blockers(id);
+        let indices = self.query.expression_blockers(id);
         if indices.is_empty() {
             return self.b.empty_array_expr();
         }
@@ -238,67 +243,67 @@ impl<'a> Ctx<'a> {
 
     // -- Fragment shortcuts --
 
-    pub fn content_type(&self, key: &FragmentKey) -> ContentStrategy { self.analysis.fragments.content_type(key) }
-    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool { self.analysis.fragments.has_dynamic_children(key) }
+    pub fn content_type(&self, key: &FragmentKey) -> ContentStrategy { self.query.content_type(key) }
+    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool { self.query.has_dynamic_children(key) }
 
     // -- Element flag shortcuts --
 
-    pub fn has_spread(&self, id: NodeId) -> bool { self.analysis.element_flags.has_spread(id) }
-    pub fn has_class_directives(&self, id: NodeId) -> bool { self.analysis.element_flags.has_class_directives(id) }
-    pub fn has_class_attribute(&self, id: NodeId) -> bool { self.analysis.element_flags.has_class_attribute(id) }
-    pub fn needs_clsx(&self, id: NodeId) -> bool { self.analysis.element_flags.needs_clsx(id) }
-    pub fn has_style_directives(&self, id: NodeId) -> bool { self.analysis.element_flags.has_style_directives(id) }
-    pub fn style_directives(&self, id: NodeId) -> &[svelte_ast::StyleDirective] { self.analysis.element_flags.style_directives(id) }
-    pub fn needs_input_defaults(&self, id: NodeId) -> bool { self.analysis.element_flags.needs_input_defaults(id) }
-    pub fn needs_var(&self, id: NodeId) -> bool { self.analysis.element_flags.needs_var(id) }
-    pub fn is_dynamic_attr(&self, id: NodeId) -> bool { self.analysis.element_flags.is_dynamic_attr(id) }
-    pub fn static_class(&self, id: NodeId) -> Option<&str> { self.analysis.element_flags.static_class(id) }
-    pub fn static_style(&self, id: NodeId) -> Option<&str> { self.analysis.element_flags.static_style(id) }
-    pub fn is_bound_contenteditable(&self, id: NodeId) -> bool { self.analysis.element_flags.is_bound_contenteditable(id) }
-    pub fn has_use_directive(&self, id: NodeId) -> bool { self.analysis.element_flags.has_use_directive(id) }
+    pub fn has_spread(&self, id: NodeId) -> bool { self.query.has_spread(id) }
+    pub fn has_class_directives(&self, id: NodeId) -> bool { self.query.has_class_directives(id) }
+    pub fn has_class_attribute(&self, id: NodeId) -> bool { self.query.has_class_attribute(id) }
+    pub fn needs_clsx(&self, id: NodeId) -> bool { self.query.needs_clsx(id) }
+    pub fn has_style_directives(&self, id: NodeId) -> bool { self.query.has_style_directives(id) }
+    pub fn style_directives(&self, id: NodeId) -> &[svelte_ast::StyleDirective] { self.query.style_directives(id) }
+    pub fn needs_input_defaults(&self, id: NodeId) -> bool { self.query.needs_input_defaults(id) }
+    pub fn needs_var(&self, id: NodeId) -> bool { self.query.needs_var(id) }
+    pub fn is_dynamic_attr(&self, id: NodeId) -> bool { self.query.is_dynamic_attr(id) }
+    pub fn static_class(&self, id: NodeId) -> Option<&str> { self.query.static_class(id) }
+    pub fn static_style(&self, id: NodeId) -> Option<&str> { self.query.static_style(id) }
+    pub fn is_bound_contenteditable(&self, id: NodeId) -> bool { self.query.is_bound_contenteditable(id) }
+    pub fn has_use_directive(&self, id: NodeId) -> bool { self.query.has_use_directive(id) }
     #[allow(dead_code)]
-    pub fn has_dynamic_class_directives(&self, id: NodeId) -> bool { self.analysis.element_flags.has_dynamic_class_directives(id) }
-    pub fn class_needs_state(&self, id: NodeId) -> bool { self.analysis.element_flags.class_needs_state(id) }
-    pub fn class_attr_id(&self, id: NodeId) -> Option<NodeId> { self.analysis.element_flags.class_attr_id(id) }
-    pub fn class_directive_info(&self, id: NodeId) -> Option<&[ClassDirectiveInfo]> { self.analysis.element_flags.class_directive_info(id) }
-    pub fn is_expression_shorthand(&self, id: NodeId) -> bool { self.analysis.element_flags.is_expression_shorthand(id) }
-    pub fn component_props(&self, id: NodeId) -> &[ComponentPropInfo] { self.analysis.element_flags.component_props(id) }
-    pub fn component_snippets(&self, id: NodeId) -> &[NodeId] { self.analysis.snippets.component_snippets(id) }
-    pub fn event_handler_mode(&self, attr_id: NodeId) -> Option<EventHandlerMode> { self.analysis.element_flags.event_handler_mode(attr_id) }
-    pub fn has_bind_group(&self, id: NodeId) -> bool { self.analysis.bind_semantics.has_bind_group(id) }
-    pub fn bind_group_value_attr(&self, id: NodeId) -> Option<NodeId> { self.analysis.bind_semantics.bind_group_value_attr(id) }
-    pub fn parent_each_blocks(&self, id: NodeId) -> Option<&Vec<NodeId>> { self.analysis.bind_semantics.parent_each_blocks(id) }
-    pub fn contains_group_binding(&self, id: NodeId) -> bool { self.analysis.bind_semantics.contains_group_binding(id) }
+    pub fn has_dynamic_class_directives(&self, id: NodeId) -> bool { self.query.has_dynamic_class_directives(id) }
+    pub fn class_needs_state(&self, id: NodeId) -> bool { self.query.class_needs_state(id) }
+    pub fn class_attr_id(&self, id: NodeId) -> Option<NodeId> { self.query.class_attr_id(id) }
+    pub fn class_directive_info(&self, id: NodeId) -> Option<&[ClassDirectiveInfo]> { self.query.class_directive_info(id) }
+    pub fn is_expression_shorthand(&self, id: NodeId) -> bool { self.query.is_expression_shorthand(id) }
+    pub fn component_props(&self, id: NodeId) -> &[ComponentPropInfo] { self.query.component_props(id) }
+    pub fn component_snippets(&self, id: NodeId) -> &[NodeId] { self.query.component_snippets(id) }
+    pub fn event_handler_mode(&self, attr_id: NodeId) -> Option<EventHandlerMode> { self.query.event_handler_mode(attr_id) }
+    pub fn has_bind_group(&self, id: NodeId) -> bool { self.analysis().bind_semantics.has_bind_group(id) }
+    pub fn bind_group_value_attr(&self, id: NodeId) -> Option<NodeId> { self.analysis().bind_semantics.bind_group_value_attr(id) }
+    pub fn parent_each_blocks(&self, id: NodeId) -> Option<&Vec<NodeId>> { self.analysis().bind_semantics.parent_each_blocks(id) }
+    pub fn contains_group_binding(&self, id: NodeId) -> bool { self.analysis().bind_semantics.contains_group_binding(id) }
 
     // -- Snippet shortcuts --
 
-    pub fn is_snippet_hoistable(&self, id: NodeId) -> bool { self.analysis.snippets.is_hoistable(id) }
+    pub fn is_snippet_hoistable(&self, id: NodeId) -> bool { self.analysis().snippets.is_hoistable(id) }
 
     // -- ConstTag shortcuts --
 
-    pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis.const_tags.names(id) }
-    pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis.const_tags.by_fragment(key) }
+    pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis().const_tags.names(id) }
+    pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis().const_tags.by_fragment(key) }
 
     // -- DebugTag shortcuts --
 
     pub fn debug_tag(&self, id: NodeId) -> &'a DebugTag { self.component.store.debug_tag(id) }
-    pub fn debug_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis.debug_tags.by_fragment(key) }
+    pub fn debug_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis().debug_tags.by_fragment(key) }
 
     // -- EachBlock shortcuts --
 
-    pub fn each_key_uses_index(&self, id: NodeId) -> bool { self.analysis.each_blocks.key_uses_index(id) }
-    pub fn each_body_uses_index(&self, id: NodeId) -> bool { self.analysis.each_blocks.body_uses_index(id) }
-    pub fn each_key_is_item(&self, id: NodeId) -> bool { self.analysis.each_blocks.key_is_item(id) }
-    pub fn each_has_animate(&self, id: NodeId) -> bool { self.analysis.each_blocks.has_animate(id) }
+    pub fn each_key_uses_index(&self, id: NodeId) -> bool { self.analysis().each_blocks.key_uses_index(id) }
+    pub fn each_body_uses_index(&self, id: NodeId) -> bool { self.analysis().each_blocks.body_uses_index(id) }
+    pub fn each_key_is_item(&self, id: NodeId) -> bool { self.analysis().each_blocks.key_is_item(id) }
+    pub fn each_has_animate(&self, id: NodeId) -> bool { self.analysis().each_blocks.has_animate(id) }
 
     // -- Expression offset lookups (for offset-keyed ParserResult) --
 
     pub fn node_expr_offset(&self, node_id: NodeId) -> u32 {
-        self.analysis.node_expr_offset(node_id)
+        self.analysis().node_expr_offset(node_id)
     }
 
     pub fn attr_expr_offset(&self, attr_id: NodeId) -> u32 {
-        self.analysis.attr_expr_offset(attr_id)
+        self.analysis().attr_expr_offset(attr_id)
     }
 
     // -- Delegated events --

--- a/crates/svelte_codegen_client/src/custom_element.rs
+++ b/crates/svelte_codegen_client/src/custom_element.rs
@@ -19,7 +19,7 @@ pub fn gen_custom_element<'a>(
     // Determine tag and parsed options based on config variant
     let (simple_tag, parsed) = match ce_config {
         CustomElementConfig::Tag(tag) => (Some(tag.as_str()), None),
-        CustomElementConfig::Expression(_) => (None, ctx.analysis.ce_config.as_ref()),
+        CustomElementConfig::Expression(_) => (None, ctx.analysis().ce_config.as_ref()),
     };
 
     // Resolve tag: simple form uses tag directly, object form uses parsed tag
@@ -37,7 +37,7 @@ pub fn gen_custom_element<'a>(
 
     // -- Arg 4: Accessors array (from exports) --
     let accessors = b.array_from_args(
-        ctx.analysis.exports.iter().map(|e| {
+        ctx.analysis().exports.iter().map(|e| {
             let name = e.alias.as_deref().unwrap_or(e.name.as_str());
             Arg::StrRef(name)
         })
@@ -47,7 +47,7 @@ pub fn gen_custom_element<'a>(
     let is_shadow_none = parsed.is_some_and(|o| o.shadow == CeShadowMode::None);
 
     // -- Arg 6: Extend (pre-parsed in analyze) --
-    let extend_arg: Option<Expression<'a>> = ctx.analysis.ce_config.as_ref()
+    let extend_arg: Option<Expression<'a>> = ctx.analysis().ce_config.as_ref()
         .and_then(|c| c.extend_span)
         .and_then(|span| ctx.parsed.exprs.remove(&span.start));
 
@@ -116,7 +116,7 @@ fn build_props_metadata<'a>(
     }
 
     // Second: emit remaining component props not already in CE config
-    if let Some(ref props_analysis) = ctx.analysis.props {
+    if let Some(ref props_analysis) = ctx.analysis().props {
         for prop in &props_analysis.props {
             if prop.is_rest || prop.is_reserved {
                 continue;
@@ -138,7 +138,7 @@ fn build_props_metadata<'a>(
 
 /// Resolve the prop key: use prop_alias if the binding has one, otherwise use the name.
 fn resolve_prop_key(ctx: &Ctx<'_>, name: &str) -> String {
-    if let Some(ref props) = ctx.analysis.props {
+    if let Some(ref props) = ctx.analysis().props {
         for prop in &props.props {
             if prop.local_name == name || prop.prop_name == name {
                 return prop.prop_name.clone();

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -46,18 +46,18 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
     // -----------------------------------------------------------------------
     // 3. Build function body (needs &mut ctx for snippets)
     // -----------------------------------------------------------------------
-    let is_custom_element = ctx.analysis.custom_element;
-    let has_exports = !ctx.analysis.exports.is_empty();
-    let has_bindable = ctx.analysis.props.as_ref().is_some_and(|p| p.has_bindable);
-    let has_stores = !ctx.analysis.scoping.store_symbol_ids().is_empty();
-    let has_ce_props = is_custom_element && ctx.analysis.props.as_ref().is_some_and(|p| !p.props.is_empty());
-    let needs_push = has_bindable || has_exports || has_ce_props || ctx.analysis.needs_context || ctx.dev;
+    let is_custom_element = ctx.query.custom_element();
+    let has_exports = !ctx.query.exports().is_empty();
+    let has_bindable = ctx.query.props().is_some_and(|p| p.has_bindable);
+    let has_stores = !ctx.query.scoping().store_symbol_ids().is_empty();
+    let has_ce_props = is_custom_element && ctx.query.props().is_some_and(|p| !p.props.is_empty());
+    let needs_push = has_bindable || has_exports || has_ce_props || ctx.query.needs_context() || ctx.dev;
     let has_component_exports = has_exports || has_ce_props || ctx.dev;
 
     let mut fn_body: Vec<Statement<'_>> = Vec::new();
 
     // $props.id() → must be first statement for hydration correctness
-    if let Some(ref props_id_name) = ctx.analysis.props_id {
+    if let Some(props_id_name) = ctx.query.props_id() {
         let name: &str = ctx.b.alloc_str(props_id_name);
         let call = ctx.b.call_expr("$.props_id", std::iter::empty::<Arg<'_, '_>>());
         fn_body.push(ctx.b.const_stmt(name, call));
@@ -84,8 +84,8 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
     //   const [$$stores, $$cleanup] = $.setup_stores();
     if has_stores {
         // Sort store base names for deterministic output
-        let mut store_names: Vec<&str> = ctx.analysis.scoping.store_symbol_ids().iter()
-            .map(|&sym| ctx.analysis.scoping.symbol_name(sym))
+        let mut store_names: Vec<&str> = ctx.query.scoping().store_symbol_ids().iter()
+            .map(|&sym| ctx.query.scoping().symbol_name(sym))
             .collect();
         store_names.sort();
 
@@ -115,8 +115,8 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
 
     // Instance body splitting for experimental.async:
     // Statements after first `await` become async thunks in $.run([...])
-    if ctx.experimental_async && ctx.analysis.blocker_data().has_async() {
-        let split_body = split_async_instance_body(&ctx.b, script_body, ctx.analysis.blocker_data());
+    if ctx.experimental_async && ctx.query.blocker_data().has_async() {
+        let split_body = split_async_instance_body(&ctx.b, script_body, ctx.query.blocker_data());
         fn_body.extend(split_body);
     } else {
         fn_body.extend(script_body);
@@ -127,7 +127,7 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
         let mut export_props: Vec<ObjProp<'_>> = Vec::new();
 
         // Regular exports (e.g., `export function reset()`)
-        for e in &ctx.analysis.exports {
+        for e in ctx.query.exports() {
             let name: &str = ctx.b.alloc_str(&e.name);
             if let Some(alias) = &e.alias {
                 let alias: &str = ctx.b.alloc_str(alias);
@@ -139,7 +139,7 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
 
         // Custom element prop getter/setters
         if has_ce_props {
-            if let Some(ref props_analysis) = ctx.analysis.props {
+            if let Some(props_analysis) = ctx.query.props() {
                 for prop in &props_analysis.props {
                     if prop.is_rest || prop.is_reserved {
                         continue;
@@ -218,7 +218,7 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
         }))
     });
 
-    let fn_params = if ctx.analysis.props.is_some() || needs_push || has_bubble_events {
+    let fn_params = if ctx.query.props().is_some() || needs_push || has_bubble_events {
         b.params(["$$anchor", "$$props"])
     } else {
         b.params(["$$anchor"])

--- a/crates/svelte_codegen_client/src/script/mod.rs
+++ b/crates/svelte_codegen_client/src/script/mod.rs
@@ -53,8 +53,8 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
     };
 
     let allocator = ctx.b.ast.allocator;
-    let component_scoping = &ctx.analysis.scoping;
-    let props = ctx.analysis.props.as_ref();
+    let component_scoping = &ctx.analysis().scoping;
+    let props = ctx.analysis().props.as_ref();
     let component_source = &ctx.component.source;
     let script_content_start = ctx.component.script.as_ref().unwrap().content_span.start;
 
@@ -74,7 +74,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
             component_scoping,
             props,
             prop_defaults,
-            Some(ctx.analysis.script_rune_call_kinds()),
+            Some(ctx.analysis().script_rune_call_kinds()),
             dev,
             component_source,
             script_content_start,

--- a/crates/svelte_codegen_client/src/template/attributes.rs
+++ b/crates/svelte_codegen_client/src/template/attributes.rs
@@ -94,7 +94,7 @@ pub(crate) fn process_attr<'a>(
                     .unwrap_or(raw_event_name).to_string();
 
                 let expr_offset = a.expression_span.start;
-                let has_call = ctx.analysis.attr_expression(attr_id).map_or(false, |e| e.has_call);
+                let has_call = ctx.analysis().attr_expression(attr_id).map_or(false, |e| e.has_call);
                 let val = get_attr_expr(ctx, attr_id);
                 let handler = build_event_handler_s5(ctx, attr_id, val, has_call, init);
                 let handler = dev_event_handler(ctx, handler, &event_name, expr_offset);
@@ -138,7 +138,7 @@ pub(crate) fn process_attr<'a>(
             }
             // Memoize dynamic attrs with has_call/await — extract into dependency array
             let needs_memo = is_dyn
-                && ctx.analysis.attr_expression(attr_id).is_some_and(|e| e.has_call || e.has_await);
+                && ctx.analysis().attr_expression(attr_id).is_some_and(|e| e.has_call || e.has_await);
             if needs_memo {
                 let (setter_fn, attr_name) = if a.name == "value" && tag_name == "input" {
                     ("$.set_value", None)

--- a/crates/svelte_codegen_client/src/template/bind.rs
+++ b/crates/svelte_codegen_client/src/template/bind.rs
@@ -199,7 +199,7 @@ pub(crate) fn gen_bind_directive<'a>(
     };
 
     // Pre-computed blocker indices from analyze
-    let bind_blockers = ctx.analysis.bind_semantics.bind_blockers(bind.id).to_vec();
+    let bind_blockers = ctx.analysis().bind_semantics.bind_blockers(bind.id).to_vec();
 
     let stmt = match bind.name.as_str() {
         // --- Input/Form ---

--- a/crates/svelte_codegen_client/src/template/const_tag.rs
+++ b/crates/svelte_codegen_client/src/template/const_tag.rs
@@ -21,7 +21,7 @@ pub(crate) fn gen_const_tags<'a>(
 
     // Check if any const tag triggers async mode
     let needs_async = ctx.experimental_async && ids.iter().any(|&id| {
-        ctx.expr_has_await(id) || !ctx.analysis.expression_blockers(id).is_empty()
+        ctx.expr_has_await(id) || !ctx.analysis().expression_blockers(id).is_empty()
     });
 
     if needs_async {
@@ -77,12 +77,12 @@ fn gen_const_tags_async<'a>(
     let promises_name = ctx.gen_ident("promises");
     let mut thunks: Vec<Expression<'a>> = Vec::new();
 
-    let scope = ctx.analysis.scoping.fragment_scope(&key);
+    let scope = ctx.analysis().scoping.fragment_scope(&key);
 
     for &id in ids {
         let names = ctx.const_tag_names(id).cloned().unwrap_or_default();
         let has_await = ctx.expr_has_await(id);
-        let blockers = ctx.analysis.expression_blockers(id);
+        let blockers = ctx.analysis().expression_blockers(id);
         let init_expr = extract_const_init(ctx, id);
 
         if names.len() == 1 {
@@ -119,7 +119,7 @@ fn gen_const_tags_async<'a>(
 
             let thunk_idx = thunks.len() - 1;
             if let Some(scope_id) = scope {
-                if let Some(sym_id) = ctx.analysis.scoping.find_binding(scope_id, &names[0]) {
+                if let Some(sym_id) = ctx.analysis().scoping.find_binding(scope_id, &names[0]) {
                     ctx.const_tag_blockers.insert(sym_id, (promises_name.clone(), thunk_idx));
                 }
             }
@@ -157,7 +157,7 @@ fn gen_const_tags_async<'a>(
             let thunk_idx = thunks.len() - 1;
             if let Some(scope_id) = scope {
                 for name in &names {
-                    if let Some(sym_id) = ctx.analysis.scoping.find_binding(scope_id, name) {
+                    if let Some(sym_id) = ctx.analysis().scoping.find_binding(scope_id, name) {
                         ctx.const_tag_blockers.insert(sym_id, (promises_name.clone(), thunk_idx));
                     }
                 }

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -46,7 +46,7 @@ pub(crate) fn gen_each_block<'a>(
         var_decl.declarations.remove(0).id
     });
 
-    let context_name = ctx.analysis.each_blocks.context_name(block_id).to_string();
+    let context_name = ctx.analysis().each_blocks.context_name(block_id).to_string();
 
     let key_is_item = ctx.each_key_is_item(block_id);
 

--- a/crates/svelte_codegen_client/src/template/events.rs
+++ b/crates/svelte_codegen_client/src/template/events.rs
@@ -68,7 +68,7 @@ pub(crate) fn gen_use_directive<'a>(
 
     let mut stmt = ctx.b.call_stmt("$.action", args);
 
-    let blockers = ctx.analysis.attr_expression_blockers(attr_id);
+    let blockers = ctx.analysis().attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
         stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
@@ -92,7 +92,7 @@ pub(crate) fn gen_attach_tag<'a>(
     let thunk = ctx.b.thunk(expr);
     let mut stmt = ctx.b.call_stmt("$.attach", [Arg::Ident(el_name), Arg::Expr(thunk)]);
 
-    let blockers = ctx.analysis.attr_expression_blockers(attr_id);
+    let blockers = ctx.analysis().attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
         stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
@@ -138,7 +138,7 @@ pub(crate) fn gen_transition_directive<'a>(
 
     let mut stmt = ctx.b.call_stmt("$.transition", args);
 
-    let blockers = ctx.analysis.attr_expression_blockers(attr_id);
+    let blockers = ctx.analysis().attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
         stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
@@ -173,7 +173,7 @@ pub(crate) fn gen_animate_directive<'a>(
 
     let mut stmt = ctx.b.call_stmt("$.animation", args);
 
-    let blockers = ctx.analysis.attr_expression_blockers(attr_id);
+    let blockers = ctx.analysis().attr_expression_blockers(attr_id);
     if !blockers.is_empty() {
         stmt = gen_run_after_blockers(ctx, stmt, &blockers);
     }
@@ -470,7 +470,7 @@ pub(crate) fn gen_event_attr_on<'a>(
         (raw_event_name.to_string(), false)
     };
 
-    let has_call = ctx.analysis.attr_expression(attr_id).map_or(false, |e| e.has_call);
+    let has_call = ctx.analysis().attr_expression(attr_id).map_or(false, |e| e.has_call);
     let handler_expr = super::expression::get_attr_expr(ctx, attr_id);
     let handler = build_event_handler_s5(ctx, attr_id, handler_expr, has_call, stmts);
     let handler = dev_event_handler(ctx, handler, &event_name, expr_offset);

--- a/crates/svelte_codegen_client/src/template/expression.rs
+++ b/crates/svelte_codegen_client/src/template/expression.rs
@@ -66,10 +66,10 @@ impl<'a> VisitMut<'a> for AwaitExprFinalizer<'_, 'a> {
 
         let ignored = self
             .ignore_node
-            .is_some_and(|id| self.ctx.analysis.ignore_data.is_ignored(id, "await_reactivity_loss"));
+            .is_some_and(|id| self.ctx.analysis().ignore_data.is_ignored(id, "await_reactivity_loss"));
 
         let arg = self.ctx.b.move_expr(&mut await_expr.argument);
-        if self.ctx.analysis.is_pickled_await(await_expr.span.start) {
+        if self.ctx.analysis().is_pickled_await(await_expr.span.start) {
             let save_call = self.ctx.b.call_expr("$.save", [Arg::Expr(arg)]);
             let awaited = self.ctx.b.await_expr(save_call);
             *expr = self
@@ -223,7 +223,7 @@ impl<'a> TemplateMemoState<'a> {
 
     pub(crate) fn push_expr_info(&mut self, ctx: &Ctx<'a>, info: &ExpressionInfo) {
         for sym in &info.ref_symbols {
-            if let Some(idx) = ctx.analysis.blocker_data().symbol_blocker(*sym) {
+            if let Some(idx) = ctx.analysis().blocker_data().symbol_blocker(*sym) {
                 self.push_script_blocker(idx);
             }
             if let Some(expr) = ctx.const_tag_symbol_blocker_expr(*sym) {
@@ -233,7 +233,7 @@ impl<'a> TemplateMemoState<'a> {
     }
 
     pub(crate) fn push_node_deps(&mut self, ctx: &mut Ctx<'a>, id: NodeId) {
-        for idx in ctx.analysis.expression_blockers(id) {
+        for idx in ctx.analysis().expression_blockers(id) {
             self.push_script_blocker(idx);
         }
         self.extra_blockers.extend(ctx.const_tag_blocker_exprs(id));
@@ -391,7 +391,7 @@ pub(crate) fn emit_text_update<'a>(
         if let FragmentItem::TextConcat { parts, .. } = item {
             for part in parts {
                 if let LoweredTextPart::Expr(id) = part {
-                    for idx in ctx.analysis.expression_blockers(*id) {
+                    for idx in ctx.analysis().expression_blockers(*id) {
                         if !blockers.contains(&idx) { blockers.push(idx); }
                     }
                     extra_blockers.extend(ctx.const_tag_blocker_exprs(*id));
@@ -506,7 +506,7 @@ pub(crate) fn text_content_needs_memo(item: &FragmentItem, ctx: &Ctx<'_>) -> boo
     if let FragmentItem::TextConcat { parts, .. } = item {
         return parts.iter().any(|p| {
             if let LoweredTextPart::Expr(id) = p {
-                ctx.analysis.needs_expr_memoization(*id)
+                ctx.analysis().needs_expr_memoization(*id)
             } else {
                 false
             }
@@ -597,7 +597,7 @@ pub(crate) fn emit_template_effect_with_memo<'a>(
         args.push(Arg::Expr(ctx.b.rid_expr(&param_names[i])));
         callback_body.push(ctx.b.call_stmt(setter_fn, args));
 
-        let info = ctx.analysis.attr_expression(attr_id)
+        let info = ctx.analysis().attr_expression(attr_id)
             .expect("memoized attribute should have expression metadata");
         deps.push_expr_info(ctx, info);
         if info.has_await {
@@ -635,7 +635,7 @@ fn build_concat_with_memo<'a>(
             }
 
             let expr = get_node_expr(ctx, nid);
-            if ctx.analysis.needs_expr_memoization(nid) {
+            if ctx.analysis().needs_expr_memoization(nid) {
                 if ctx.expr_has_await(nid) {
                     let index = deps.async_values.len();
                     deps.async_values.push(ctx.b.clone_expr(&expr));
@@ -673,7 +673,7 @@ fn build_concat_with_memo<'a>(
                 }
 
                 let expr = get_node_expr(ctx, *nid);
-                let expr = if ctx.analysis.needs_expr_memoization(*nid) {
+                let expr = if ctx.analysis().needs_expr_memoization(*nid) {
                     if ctx.expr_has_await(*nid) {
                         let index = deps.async_values.len();
                         deps.async_values.push(ctx.b.clone_expr(&expr));

--- a/crates/svelte_codegen_client/src/template/html.rs
+++ b/crates/svelte_codegen_client/src/template/html.rs
@@ -12,7 +12,7 @@ use super::expression::item_has_local_blockers;
 /// Returns `(html, needs_import_node)` — the flag is true when the fragment
 /// contains a `<video>` element (which requires `importNode` instead of `cloneNode`).
 pub(crate) fn fragment_html(ctx: &Ctx<'_>, key: FragmentKey) -> (String, bool) {
-    let Some(lf) = ctx.analysis.fragments.lowered(&key) else {
+    let Some(lf) = ctx.analysis().fragments.lowered(&key) else {
         return (String::new(), false);
     };
     let mut html = String::new();

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -91,7 +91,7 @@ pub(crate) fn gen_if_block<'a>(
             // Root async condition: resolved via $.get($$condition) inside $.async callback
             derived_names.push(None);
         } else {
-            let needs_memo = ctx.analysis.needs_expr_memoization(branch.block_id);
+            let needs_memo = ctx.analysis().needs_expr_memoization(branch.block_id);
             if needs_memo {
                 let expr = get_node_expr(ctx, branch.block_id);
                 let thunk = ctx.b.thunk(expr);

--- a/crates/svelte_codegen_client/src/template/mod.rs
+++ b/crates/svelte_codegen_client/src/template/mod.rs
@@ -368,7 +368,7 @@ fn emit_single_element<'a>(
 
     // Pre-computed blocker indices for this element's fragment
     let el_key = svelte_analyze::FragmentKey::Element(el_id);
-    let el_blockers = ctx.analysis.fragments.fragment_blockers(&el_key).to_vec();
+    let el_blockers = ctx.analysis().fragments.fragment_blockers(&el_key).to_vec();
 
     if is_root {
         // Root: template BEFORE children (top-down)
@@ -413,7 +413,7 @@ fn emit_single_block<'a>(
     // RenderTag / ComponentNode: call directly with $$anchor, no wrapping.
     // Non-root consumes a "fragment" ident for consistent numbering.
     match item {
-        FragmentItem::RenderTag(id) if !ctx.analysis.render_tag_callee_mode(*id).is_dynamic() => {
+        FragmentItem::RenderTag(id) if !ctx.analysis().render_tag_callee_mode(*id).is_dynamic() => {
             if !is_root { ctx.gen_ident("fragment"); }
             gen_render_tag(ctx, *id, ctx.b.rid_expr("$$anchor"), true, body);
             return;

--- a/crates/svelte_codegen_client/src/template/render_tag.rs
+++ b/crates/svelte_codegen_client/src/template/render_tag.rs
@@ -39,7 +39,7 @@ pub(crate) fn gen_render_tag<'a>(
     let tag = ctx.render_tag(id);
     let full_source = ctx.component.source_text(tag.expression_span);
 
-    let mode = ctx.analysis.render_tag_callee_mode(id);
+    let mode = ctx.analysis().render_tag_callee_mode(id);
 
     // Take ownership from ParsedExprs (already unwrapped from ChainExpression)
     let tag = ctx.render_tag(id);
@@ -57,13 +57,13 @@ pub(crate) fn gen_render_tag<'a>(
     let callee_span = call.callee.span();
     let callee_text = &full_source[callee_span.start as usize..callee_span.end as usize];
 
-    let prop_sources = ctx.analysis.render_tag_prop_sources(id);
+    let prop_sources = ctx.analysis().render_tag_prop_sources(id);
 
     // Unbox to separate callee expression and arguments
     let unboxed = call.unbox();
     let callee_expr = unboxed.callee;
 
-    let arg_infos = ctx.analysis.render_tag_arg_infos(id)
+    let arg_infos = ctx.analysis().render_tag_arg_infos(id)
         .map(|infos| infos.to_vec())
         .unwrap_or_default();
 
@@ -78,7 +78,7 @@ pub(crate) fn gen_render_tag<'a>(
 
         // Prop-source args: pass the getter identifier directly without a thunk
         if let Some(Some(sym_id)) = prop_sources.and_then(|ps| ps.get(i)) {
-            let name = ctx.analysis.scoping.symbol_name(*sym_id);
+            let name = ctx.analysis().scoping.symbol_name(*sym_id);
             arg_thunks.push(Arg::Expr(ctx.b.rid_expr(name)));
             continue;
         }
@@ -147,7 +147,7 @@ pub(crate) fn gen_render_tag<'a>(
     if needs_async {
         let mut inner = memo_stmts;
         inner.push(final_stmt);
-        for idx in ctx.analysis.expression_blockers(id) {
+        for idx in ctx.analysis().expression_blockers(id) {
             deps.push_script_blocker(idx);
         }
         let callback_params = if deps.has_async_values() {

--- a/crates/svelte_codegen_client/src/template/snippet.rs
+++ b/crates/svelte_codegen_client/src/template/snippet.rs
@@ -21,7 +21,7 @@ pub(crate) fn gen_snippet_block<'a>(
     let block = ctx.snippet_block(id);
     let name = block.name(ctx.source).to_string();
 
-    let param_names: Vec<String> = ctx.analysis.snippets.params(id).to_vec();
+    let param_names: Vec<String> = ctx.analysis().snippets.params(id).to_vec();
 
     // Set snippet params so expression codegen wraps them as thunk calls.
     // Save and restore to handle nested snippets correctly.

--- a/crates/svelte_codegen_client/src/template/svelte_boundary.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_boundary.rs
@@ -122,11 +122,11 @@ pub(crate) fn gen_svelte_boundary<'a>(
 
     // Resolve const-tag binding SymbolIds for snippet reference checking
     let const_binding_syms: FxHashSet<SymbolId> = if has_const_tags {
-        let scope = ctx.analysis.scoping.fragment_scope(&FragmentKey::SvelteBoundaryBody(id));
+        let scope = ctx.analysis().scoping.fragment_scope(&FragmentKey::SvelteBoundaryBody(id));
         if let Some(scope_id) = scope {
             const_tag_ids.iter()
                 .flat_map(|cid| ctx.const_tag_names(*cid).cloned().unwrap_or_default())
-                .filter_map(|name| ctx.analysis.scoping.find_binding(scope_id, &name))
+                .filter_map(|name| ctx.analysis().scoping.find_binding(scope_id, &name))
                 .collect()
         } else {
             FxHashSet::default()
@@ -171,7 +171,7 @@ pub(crate) fn gen_svelte_boundary<'a>(
         // Only inject const tags into snippets that actually reference the const-tag bindings
         let snippet_uses_const = if has_const_tags {
             let key = FragmentKey::SnippetBody(*snippet_id);
-            ctx.analysis.fragment_references_any_symbol(&key, &const_binding_syms)
+            ctx.analysis().fragment_references_any_symbol(&key, &const_binding_syms)
         } else {
             false
         };

--- a/crates/svelte_codegen_client/src/template/title_element.rs
+++ b/crates/svelte_codegen_client/src/template/title_element.rs
@@ -66,7 +66,7 @@ pub(crate) fn emit_title_elements<'a>(
     key: FragmentKey,
     stmts: &mut Vec<Statement<'a>>,
 ) {
-    let Some(ids) = ctx.analysis.title_elements.by_fragment(&key).cloned() else {
+    let Some(ids) = ctx.analysis().title_elements.by_fragment(&key).cloned() else {
         return;
     };
     for id in ids {


### PR DESCRIPTION
### Motivation
- Reduce the surface area that codegen depends on in `AnalysisData` by providing a read-only query facade for safe, incremental migration. 
- Start migrating `svelte_codegen_client` to use explicit query methods instead of direct field access to enforce phase-boundary hygiene and make subsequent porting of template modules safer.

### Description
- Added `CodegenView<'a>` in `crates/svelte_analyze/src/types/data.rs` that wraps `&AnalysisData` and exposes a minimal, read-only query surface used by codegen (component flags, `exports`, `props`, `needs_context`, `props_id`, blocker queries, fragment/element queries, element flags, etc.) and a temporary `raw()` accessor for migration. 
- Re-exported `CodegenView` from `svelte_analyze` public API so downstream crates can use it. 
- Replaced `Ctx.analysis: &AnalysisData` with `Ctx.query: CodegenView<'a>` in `crates/svelte_codegen_client/src/context.rs` and added a thin shim `Ctx::analysis()` that returns the raw `&AnalysisData` for unported call-sites during the migration period. 
- Converted safe direct reads in `crates/svelte_codegen_client/src/lib.rs` to use the facade (`custom_element`, `exports`, `props`, `needs_context`, `props_id`, `scoping`, `blocker_data`) and migrated many `ctx.analysis.*` call-sites to the transitional `ctx.analysis().*` or `ctx.query.*` usage across template modules to localize raw access.
- No codegen emission logic was changed; the change is only about routing reads through the new facade to preserve behavior while providing an explicit migration path.

### Testing
- Ran `cargo test -p svelte_codegen_client` and it completed successfully (unit tests passed). 
- Ran `cargo test -p svelte_analyze` and it completed successfully (existing analyzer tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb607c3e748321b252954f15510277)