### PR TITLE
Split codegen context into CodegenQuery and CodegenState

### DIFF
--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -1,21 +1,146 @@
-use rustc_hash::FxHashMap;
+use std::ops::{Deref, DerefMut};
+
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::{Expression, Statement};
 use oxc_semantic::SymbolId;
-use svelte_analyze::{AnalysisData, ClassDirectiveInfo, CodegenView, ComponentPropInfo, ContentStrategy, EventHandlerMode, FragmentKey, IdentGen, LoweredFragment, ParserResult};
-use svelte_ast::{AwaitBlock, Component, ComponentNode, DebugTag, EachBlock, Element, IfBlock, KeyBlock, NodeId, RenderTag, SnippetBlock, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement, SvelteWindow};
-use svelte_analyze::ExpressionInfo;
+use svelte_analyze::{
+    AnalysisData, ClassDirectiveInfo, CodegenView, ComponentPropInfo, ContentStrategy,
+    EventHandlerMode, ExpressionInfo, FragmentKey, IdentGen, LoweredFragment, ParserResult,
+};
+use svelte_ast::{
+    AwaitBlock, Component, ComponentNode, DebugTag, EachBlock, Element, IfBlock, KeyBlock, NodeId,
+    RenderTag, SnippetBlock, SvelteBody, SvelteBoundary, SvelteDocument, SvelteElement,
+    SvelteWindow,
+};
 use svelte_transform::TransformData;
 
 use crate::builder::Builder;
 
-/// Central codegen context. Holds refs to allocator, builder, component, analysis,
-/// and mutable state (ident counter, node index).
-pub struct Ctx<'a> {
-    pub b: Builder<'a>,
+/// Read-only codegen query context.
+///
+/// Owns immutable access to component AST, analysis-derived view and compile metadata.
+pub struct CodegenQuery<'a> {
     pub component: &'a Component,
-    pub query: CodegenView<'a>,
+    pub view: CodegenView<'a>,
     pub name: &'a str,
+    pub source: &'a str,
+    pub filename: &'a str,
+    pub experimental_async: bool,
+    pub dev: bool,
+}
+
+impl<'a> CodegenQuery<'a> {
+    pub fn new(
+        component: &'a Component,
+        analysis: &'a AnalysisData,
+        name: &'a str,
+        source: &'a str,
+        filename: &'a str,
+        experimental_async: bool,
+        dev: bool,
+    ) -> Self {
+        Self {
+            component,
+            view: CodegenView::new(analysis),
+            name,
+            source,
+            filename,
+            experimental_async,
+            dev,
+        }
+    }
+
+    pub fn raw(&self) -> &'a AnalysisData {
+        self.view.raw()
+    }
+
+    // -- Node lookups (O(1)) --
+
+    pub fn element(&self, id: NodeId) -> &'a Element {
+        self.component.store.element(id)
+    }
+    pub fn component_node(&self, id: NodeId) -> &'a ComponentNode {
+        self.component.store.component_node(id)
+    }
+    pub fn if_block(&self, id: NodeId) -> &'a IfBlock {
+        self.component.store.if_block(id)
+    }
+    pub fn each_block(&self, id: NodeId) -> &'a EachBlock {
+        self.component.store.each_block(id)
+    }
+    pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock {
+        self.component.store.snippet_block(id)
+    }
+    pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
+        self.component.store.render_tag(id)
+    }
+    pub fn key_block(&self, id: NodeId) -> &'a KeyBlock {
+        self.component.store.key_block(id)
+    }
+    pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement {
+        self.component.store.svelte_element(id)
+    }
+    pub fn svelte_boundary(&self, id: NodeId) -> &'a SvelteBoundary {
+        self.component.store.svelte_boundary(id)
+    }
+    pub fn await_block(&self, id: NodeId) -> &'a AwaitBlock {
+        self.component.store.await_block(id)
+    }
+    pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow {
+        self.component.store.svelte_window(id)
+    }
+    pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument {
+        self.component.store.svelte_document(id)
+    }
+    pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody {
+        self.component.store.svelte_body(id)
+    }
+    pub fn debug_tag(&self, id: NodeId) -> &'a DebugTag {
+        self.component.store.debug_tag(id)
+    }
+
+    pub fn lowered_fragment(&self, key: &FragmentKey) -> &LoweredFragment {
+        self.view
+            .lowered_fragment(key)
+            .unwrap_or_else(|| panic!("lowered fragment {:?} not found", key))
+    }
+
+    pub fn known_value(&self, name: &str) -> Option<&str> {
+        self.raw().known_value(name)
+    }
+
+    pub fn expr_has_blockers(&self, id: NodeId) -> bool {
+        self.view.expr_has_blockers(id)
+    }
+
+    pub fn expression_blockers(&self, id: NodeId) -> Vec<u32> {
+        self.view.expression_blockers(id).into_iter().collect()
+    }
+
+    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> {
+        self.raw().expression(id)
+    }
+}
+
+impl<'a> Deref for CodegenQuery<'a> {
+    type Target = CodegenView<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.view
+    }
+}
+
+/// Mutable runtime/codegen state used during emission.
+pub struct CodegenState<'a> {
+    pub b: Builder<'a>,
+    // Compatibility fields while call-sites migrate from `ctx.*` to `ctx.query.*`.
+    pub component: &'a Component,
+    pub name: &'a str,
+    pub source: &'a str,
+    pub filename: &'a str,
+    pub experimental_async: bool,
+    pub dev: bool,
     /// Data produced by the transform phase (e.g. tmp names for destructured const tags).
     pub transform_data: TransformData,
     /// Pre-parsed and pre-transformed expression ASTs (mutable for ownership transfer via remove).
@@ -36,22 +161,13 @@ pub struct Ctx<'a> {
     /// Snippet param names for the currently generating snippet body.
     pub snippet_param_names: Vec<String>,
 
-    /// Whether dev-mode features ($inspect, ownership checks, etc.) are enabled.
-    pub dev: bool,
-
     /// Event names that use delegation (e.g., "click" from `onclick={handler}`).
     /// Ordered Vec for deterministic output + HashSet for O(1) dedup.
     pub delegated_events: Vec<String>,
-    delegated_events_set: rustc_hash::FxHashSet<String>,
+    delegated_events_set: FxHashSet<String>,
 
-    /// Original component source text (for re-parsing expression spans in codegen).
-    pub source: &'a str,
-    /// Filename from CompileOptions (used in trace labels and $.FILENAME).
-    pub filename: &'a str,
     /// Whether any $inspect.trace() was found in template expressions (triggers tracing import).
     pub has_tracing: bool,
-    /// Whether `experimental.async` is enabled.
-    pub experimental_async: bool,
     /// Const-tag blocker propagation (experimental.async).
     /// Maps SymbolId of a const-tag binding → (promises_var_name, thunk_index).
     /// Populated by `emit_const_tags` when `$.run()` mode is used.
@@ -62,7 +178,85 @@ pub struct Ctx<'a> {
     pub(crate) pending_const_blockers: Vec<Expression<'a>>,
 }
 
+impl<'a> CodegenState<'a> {
+    fn new(
+        allocator: &'a oxc_allocator::Allocator,
+        component: &'a Component,
+        name: &'a str,
+        source: &'a str,
+        filename: &'a str,
+        experimental_async: bool,
+        dev: bool,
+        parsed: &'a mut ParserResult<'a>,
+        ident_gen: &'a mut IdentGen,
+        transform_data: TransformData,
+    ) -> Self {
+        Self {
+            b: Builder::new(allocator),
+            component,
+            name,
+            source,
+            filename,
+            experimental_async,
+            dev,
+            transform_data,
+            parsed,
+            ident_gen,
+            module_hoisted: Vec::new(),
+            needs_binding_group: false,
+            group_index_names: FxHashMap::default(),
+            bound_contenteditable: false,
+            snippet_param_names: Vec::new(),
+            delegated_events: Vec::new(),
+            delegated_events_set: FxHashSet::default(),
+            has_tracing: false,
+            const_tag_blockers: FxHashMap::default(),
+            pending_const_blockers: Vec::new(),
+        }
+    }
+
+    pub fn gen_ident(&mut self, prefix: &str) -> String {
+        self.ident_gen.gen(prefix)
+    }
+
+    pub fn add_delegated_event(&mut self, event_name: String) {
+        if self.delegated_events_set.insert(event_name.clone()) {
+            self.delegated_events.push(event_name);
+        }
+    }
+}
+
+/// Compatibility wrapper during query/state split migration.
+///
+/// Migration note:
+/// - Temporary Ctx proxy methods are all methods that forward to `self.query.*` or `self.state.*`.
+/// - Migrate template modules in this order:
+///   1) replace read sites with `ctx.query.*` (node lookup + analysis queries),
+///   2) replace write sites with `ctx.state.*`,
+///   3) once module has no `Ctx` proxy calls, delete those specific proxy methods.
+/// - Final cleanup step is removing `Ctx` deref-based compatibility and using `CodegenQuery/CodegenState`
+///   explicitly across all call-sites.
+pub struct Ctx<'a> {
+    pub query: CodegenQuery<'a>,
+    pub state: CodegenState<'a>,
+}
+
+impl<'a> Deref for Ctx<'a> {
+    type Target = CodegenState<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl<'a> DerefMut for Ctx<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
+}
+
 impl<'a> Ctx<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         allocator: &'a oxc_allocator::Allocator,
         component: &'a Component,
@@ -80,49 +274,74 @@ impl<'a> Ctx<'a> {
         let filename = allocator.alloc_str(filename);
 
         Self {
-            b: Builder::new(allocator),
-            component,
-            query: CodegenView::new(analysis),
-            name,
-            transform_data,
-            parsed,
-            ident_gen,
-            module_hoisted: Vec::new(),
-            dev,
-            needs_binding_group: false,
-            group_index_names: FxHashMap::default(),
-            bound_contenteditable: false,
-            snippet_param_names: Vec::new(),
-            delegated_events: Vec::new(),
-            delegated_events_set: rustc_hash::FxHashSet::default(),
-            source,
-            filename,
-            has_tracing: false,
-            experimental_async,
-            const_tag_blockers: FxHashMap::default(),
-            pending_const_blockers: Vec::new(),
+            query: CodegenQuery::new(
+                component,
+                analysis,
+                name,
+                source,
+                filename,
+                experimental_async,
+                dev,
+            ),
+            state: CodegenState::new(
+                allocator,
+                component,
+                name,
+                source,
+                filename,
+                experimental_async,
+                dev,
+                parsed,
+                ident_gen,
+                transform_data,
+            ),
         }
     }
 
     // -- Node lookups (O(1)) --
 
-    pub fn element(&self, id: NodeId) -> &'a Element { self.component.store.element(id) }
-    pub fn component_node(&self, id: NodeId) -> &'a ComponentNode { self.component.store.component_node(id) }
-    pub fn if_block(&self, id: NodeId) -> &'a IfBlock { self.component.store.if_block(id) }
-    pub fn each_block(&self, id: NodeId) -> &'a EachBlock { self.component.store.each_block(id) }
-    pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock { self.component.store.snippet_block(id) }
-    pub fn render_tag(&self, id: NodeId) -> &'a RenderTag { self.component.store.render_tag(id) }
-    pub fn key_block(&self, id: NodeId) -> &'a KeyBlock { self.component.store.key_block(id) }
-    pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement { self.component.store.svelte_element(id) }
-    pub fn svelte_boundary(&self, id: NodeId) -> &'a SvelteBoundary { self.component.store.svelte_boundary(id) }
-    pub fn await_block(&self, id: NodeId) -> &'a AwaitBlock { self.component.store.await_block(id) }
-    pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow { self.component.store.svelte_window(id) }
-    pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument { self.component.store.svelte_document(id) }
-    pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody { self.component.store.svelte_body(id) }
+    pub fn element(&self, id: NodeId) -> &'a Element {
+        self.query.element(id)
+    }
+    pub fn component_node(&self, id: NodeId) -> &'a ComponentNode {
+        self.query.component_node(id)
+    }
+    pub fn if_block(&self, id: NodeId) -> &'a IfBlock {
+        self.query.if_block(id)
+    }
+    pub fn each_block(&self, id: NodeId) -> &'a EachBlock {
+        self.query.each_block(id)
+    }
+    pub fn snippet_block(&self, id: NodeId) -> &'a SnippetBlock {
+        self.query.snippet_block(id)
+    }
+    pub fn render_tag(&self, id: NodeId) -> &'a RenderTag {
+        self.query.render_tag(id)
+    }
+    pub fn key_block(&self, id: NodeId) -> &'a KeyBlock {
+        self.query.key_block(id)
+    }
+    pub fn svelte_element(&self, id: NodeId) -> &'a SvelteElement {
+        self.query.svelte_element(id)
+    }
+    pub fn svelte_boundary(&self, id: NodeId) -> &'a SvelteBoundary {
+        self.query.svelte_boundary(id)
+    }
+    pub fn await_block(&self, id: NodeId) -> &'a AwaitBlock {
+        self.query.await_block(id)
+    }
+    pub fn svelte_window(&self, id: NodeId) -> &'a SvelteWindow {
+        self.query.svelte_window(id)
+    }
+    pub fn svelte_document(&self, id: NodeId) -> &'a SvelteDocument {
+        self.query.svelte_document(id)
+    }
+    pub fn svelte_body(&self, id: NodeId) -> &'a SvelteBody {
+        self.query.svelte_body(id)
+    }
 
     pub fn lowered_fragment(&self, key: &FragmentKey) -> &LoweredFragment {
         self.query.lowered_fragment(key)
-            .unwrap_or_else(|| panic!("lowered fragment {:?} not found", key))
     }
 
     /// Temporary migration path for still-unported call-sites.
@@ -134,13 +353,17 @@ impl<'a> Ctx<'a> {
 
     /// Generate a unique identifier like `root`, `root_1`, `root_2`, …
     pub fn gen_ident(&mut self, prefix: &str) -> String {
-        self.ident_gen.gen(prefix)
+        self.state.gen_ident(prefix)
     }
 
     // -- Analysis shortcuts --
 
-    pub fn is_dynamic(&self, id: NodeId) -> bool { self.analysis().is_dynamic(id) }
-    pub fn is_elseif_alt(&self, id: NodeId) -> bool { self.analysis().is_elseif_alt(id) }
+    pub fn is_dynamic(&self, id: NodeId) -> bool {
+        self.analysis().is_dynamic(id)
+    }
+    pub fn is_elseif_alt(&self, id: NodeId) -> bool {
+        self.analysis().is_elseif_alt(id)
+    }
     pub fn is_mutable_rune_target(&self, id: NodeId) -> bool {
         self.analysis().bind_semantics.is_mutable_rune_target(id)
     }
@@ -151,7 +374,9 @@ impl<'a> Ctx<'a> {
         self.analysis().bind_semantics.each_context(id)
     }
     pub fn each_index_name(&self, id: NodeId) -> Option<String> {
-        self.analysis().each_blocks.index_sym(id)
+        self.analysis()
+            .each_blocks
+            .index_sym(id)
             .map(|sym| self.analysis().scoping.symbol_name(sym).to_string())
     }
     pub fn await_value_binding(&self, id: NodeId) -> Option<&svelte_analyze::AwaitBindingInfo> {
@@ -163,15 +388,19 @@ impl<'a> Ctx<'a> {
     pub fn attr_is_import(&self, attr_id: NodeId) -> bool {
         self.analysis().attr_is_import(attr_id)
     }
-    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> { self.analysis().expression(id) }
+    pub fn expression(&self, id: NodeId) -> Option<&ExpressionInfo> {
+        self.query.expression(id)
+    }
     pub fn const_tag_symbol_blocker_expr(&self, sym: SymbolId) -> Option<Expression<'a>> {
         let (name, idx) = self.const_tag_blockers.get(&sym)?;
-        Some(self.b.computed_member_expr(
-            self.b.rid_expr(name),
-            self.b.num_expr(*idx as f64),
-        ))
+        Some(
+            self.b
+                .computed_member_expr(self.b.rid_expr(name), self.b.num_expr(*idx as f64)),
+        )
     }
-    pub fn known_value(&self, name: &str) -> Option<&str> { self.analysis().known_value(name) }
+    pub fn known_value(&self, name: &str) -> Option<&str> {
+        self.query.known_value(name)
+    }
 
     /// Check if expression for node has `has_await`.
     pub fn expr_has_await(&self, id: NodeId) -> bool {
@@ -183,14 +412,15 @@ impl<'a> Ctx<'a> {
         self.query.expr_has_blockers(id)
     }
 
-
     /// Build `promises_var[index]` expressions for const-tag symbols referenced by a node's expression.
     /// Returns one expression per referenced const-tag binding that has a blocker.
     pub fn const_tag_blocker_exprs(&mut self, id: NodeId) -> Vec<Expression<'a>> {
         if self.const_tag_blockers.is_empty() {
             return Vec::new();
         }
-        let Some(info) = self.expression(id) else { return Vec::new() };
+        let Some(info) = self.expression(id) else {
+            return Vec::new();
+        };
         let ref_symbols = info.ref_symbols.clone();
         let mut result = Vec::new();
         for sym in &ref_symbols {
@@ -233,68 +463,143 @@ impl<'a> Ctx<'a> {
             self.b.params(["node"])
         };
         let callback = self.b.arrow_block_expr(callback_params, inner_stmts);
-        self.b.call_stmt("$.async", [
-            crate::builder::Arg::Expr(anchor),
-            crate::builder::Arg::Expr(blockers),
-            async_values,
-            crate::builder::Arg::Expr(callback),
-        ])
+        self.b.call_stmt(
+            "$.async",
+            [
+                crate::builder::Arg::Expr(anchor),
+                crate::builder::Arg::Expr(blockers),
+                async_values,
+                crate::builder::Arg::Expr(callback),
+            ],
+        )
     }
 
     // -- Fragment shortcuts --
 
-    pub fn content_type(&self, key: &FragmentKey) -> ContentStrategy { self.query.content_type(key) }
-    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool { self.query.has_dynamic_children(key) }
+    pub fn content_type(&self, key: &FragmentKey) -> ContentStrategy {
+        self.query.view.content_type(key)
+    }
+    pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool {
+        self.query.view.has_dynamic_children(key)
+    }
 
     // -- Element flag shortcuts --
 
-    pub fn has_spread(&self, id: NodeId) -> bool { self.query.has_spread(id) }
-    pub fn has_class_directives(&self, id: NodeId) -> bool { self.query.has_class_directives(id) }
-    pub fn has_class_attribute(&self, id: NodeId) -> bool { self.query.has_class_attribute(id) }
-    pub fn needs_clsx(&self, id: NodeId) -> bool { self.query.needs_clsx(id) }
-    pub fn has_style_directives(&self, id: NodeId) -> bool { self.query.has_style_directives(id) }
-    pub fn style_directives(&self, id: NodeId) -> &[svelte_ast::StyleDirective] { self.query.style_directives(id) }
-    pub fn needs_input_defaults(&self, id: NodeId) -> bool { self.query.needs_input_defaults(id) }
-    pub fn needs_var(&self, id: NodeId) -> bool { self.query.needs_var(id) }
-    pub fn is_dynamic_attr(&self, id: NodeId) -> bool { self.query.is_dynamic_attr(id) }
-    pub fn static_class(&self, id: NodeId) -> Option<&str> { self.query.static_class(id) }
-    pub fn static_style(&self, id: NodeId) -> Option<&str> { self.query.static_style(id) }
-    pub fn is_bound_contenteditable(&self, id: NodeId) -> bool { self.query.is_bound_contenteditable(id) }
-    pub fn has_use_directive(&self, id: NodeId) -> bool { self.query.has_use_directive(id) }
+    pub fn has_spread(&self, id: NodeId) -> bool {
+        self.query.view.has_spread(id)
+    }
+    pub fn has_class_directives(&self, id: NodeId) -> bool {
+        self.query.view.has_class_directives(id)
+    }
+    pub fn has_class_attribute(&self, id: NodeId) -> bool {
+        self.query.view.has_class_attribute(id)
+    }
+    pub fn needs_clsx(&self, id: NodeId) -> bool {
+        self.query.view.needs_clsx(id)
+    }
+    pub fn has_style_directives(&self, id: NodeId) -> bool {
+        self.query.view.has_style_directives(id)
+    }
+    pub fn style_directives(&self, id: NodeId) -> &[svelte_ast::StyleDirective] {
+        self.query.view.style_directives(id)
+    }
+    pub fn needs_input_defaults(&self, id: NodeId) -> bool {
+        self.query.view.needs_input_defaults(id)
+    }
+    pub fn needs_var(&self, id: NodeId) -> bool {
+        self.query.view.needs_var(id)
+    }
+    pub fn is_dynamic_attr(&self, id: NodeId) -> bool {
+        self.query.view.is_dynamic_attr(id)
+    }
+    pub fn static_class(&self, id: NodeId) -> Option<&str> {
+        self.query.view.static_class(id)
+    }
+    pub fn static_style(&self, id: NodeId) -> Option<&str> {
+        self.query.view.static_style(id)
+    }
+    pub fn is_bound_contenteditable(&self, id: NodeId) -> bool {
+        self.query.view.is_bound_contenteditable(id)
+    }
+    pub fn has_use_directive(&self, id: NodeId) -> bool {
+        self.query.view.has_use_directive(id)
+    }
     #[allow(dead_code)]
-    pub fn has_dynamic_class_directives(&self, id: NodeId) -> bool { self.query.has_dynamic_class_directives(id) }
-    pub fn class_needs_state(&self, id: NodeId) -> bool { self.query.class_needs_state(id) }
-    pub fn class_attr_id(&self, id: NodeId) -> Option<NodeId> { self.query.class_attr_id(id) }
-    pub fn class_directive_info(&self, id: NodeId) -> Option<&[ClassDirectiveInfo]> { self.query.class_directive_info(id) }
-    pub fn is_expression_shorthand(&self, id: NodeId) -> bool { self.query.is_expression_shorthand(id) }
-    pub fn component_props(&self, id: NodeId) -> &[ComponentPropInfo] { self.query.component_props(id) }
-    pub fn component_snippets(&self, id: NodeId) -> &[NodeId] { self.query.component_snippets(id) }
-    pub fn event_handler_mode(&self, attr_id: NodeId) -> Option<EventHandlerMode> { self.query.event_handler_mode(attr_id) }
-    pub fn has_bind_group(&self, id: NodeId) -> bool { self.analysis().bind_semantics.has_bind_group(id) }
-    pub fn bind_group_value_attr(&self, id: NodeId) -> Option<NodeId> { self.analysis().bind_semantics.bind_group_value_attr(id) }
-    pub fn parent_each_blocks(&self, id: NodeId) -> Option<&Vec<NodeId>> { self.analysis().bind_semantics.parent_each_blocks(id) }
-    pub fn contains_group_binding(&self, id: NodeId) -> bool { self.analysis().bind_semantics.contains_group_binding(id) }
+    pub fn has_dynamic_class_directives(&self, id: NodeId) -> bool {
+        self.query.view.has_dynamic_class_directives(id)
+    }
+    pub fn class_needs_state(&self, id: NodeId) -> bool {
+        self.query.view.class_needs_state(id)
+    }
+    pub fn class_attr_id(&self, id: NodeId) -> Option<NodeId> {
+        self.query.view.class_attr_id(id)
+    }
+    pub fn class_directive_info(&self, id: NodeId) -> Option<&[ClassDirectiveInfo]> {
+        self.query.view.class_directive_info(id)
+    }
+    pub fn is_expression_shorthand(&self, id: NodeId) -> bool {
+        self.query.view.is_expression_shorthand(id)
+    }
+    pub fn component_props(&self, id: NodeId) -> &[ComponentPropInfo] {
+        self.query.view.component_props(id)
+    }
+    pub fn component_snippets(&self, id: NodeId) -> &[NodeId] {
+        self.query.view.component_snippets(id)
+    }
+    pub fn event_handler_mode(&self, attr_id: NodeId) -> Option<EventHandlerMode> {
+        self.query.view.event_handler_mode(attr_id)
+    }
+    pub fn has_bind_group(&self, id: NodeId) -> bool {
+        self.analysis().bind_semantics.has_bind_group(id)
+    }
+    pub fn bind_group_value_attr(&self, id: NodeId) -> Option<NodeId> {
+        self.analysis().bind_semantics.bind_group_value_attr(id)
+    }
+    pub fn parent_each_blocks(&self, id: NodeId) -> Option<&Vec<NodeId>> {
+        self.analysis().bind_semantics.parent_each_blocks(id)
+    }
+    pub fn contains_group_binding(&self, id: NodeId) -> bool {
+        self.analysis().bind_semantics.contains_group_binding(id)
+    }
 
     // -- Snippet shortcuts --
 
-    pub fn is_snippet_hoistable(&self, id: NodeId) -> bool { self.analysis().snippets.is_hoistable(id) }
+    pub fn is_snippet_hoistable(&self, id: NodeId) -> bool {
+        self.analysis().snippets.is_hoistable(id)
+    }
 
     // -- ConstTag shortcuts --
 
-    pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> { self.analysis().const_tags.names(id) }
-    pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis().const_tags.by_fragment(key) }
+    pub fn const_tag_names(&self, id: NodeId) -> Option<&Vec<String>> {
+        self.analysis().const_tags.names(id)
+    }
+    pub fn const_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> {
+        self.analysis().const_tags.by_fragment(key)
+    }
 
     // -- DebugTag shortcuts --
 
-    pub fn debug_tag(&self, id: NodeId) -> &'a DebugTag { self.component.store.debug_tag(id) }
-    pub fn debug_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> { self.analysis().debug_tags.by_fragment(key) }
+    pub fn debug_tag(&self, id: NodeId) -> &'a DebugTag {
+        self.query.debug_tag(id)
+    }
+    pub fn debug_tags_for_fragment(&self, key: &FragmentKey) -> Option<&Vec<NodeId>> {
+        self.analysis().debug_tags.by_fragment(key)
+    }
 
     // -- EachBlock shortcuts --
 
-    pub fn each_key_uses_index(&self, id: NodeId) -> bool { self.analysis().each_blocks.key_uses_index(id) }
-    pub fn each_body_uses_index(&self, id: NodeId) -> bool { self.analysis().each_blocks.body_uses_index(id) }
-    pub fn each_key_is_item(&self, id: NodeId) -> bool { self.analysis().each_blocks.key_is_item(id) }
-    pub fn each_has_animate(&self, id: NodeId) -> bool { self.analysis().each_blocks.has_animate(id) }
+    pub fn each_key_uses_index(&self, id: NodeId) -> bool {
+        self.analysis().each_blocks.key_uses_index(id)
+    }
+    pub fn each_body_uses_index(&self, id: NodeId) -> bool {
+        self.analysis().each_blocks.body_uses_index(id)
+    }
+    pub fn each_key_is_item(&self, id: NodeId) -> bool {
+        self.analysis().each_blocks.key_is_item(id)
+    }
+    pub fn each_has_animate(&self, id: NodeId) -> bool {
+        self.analysis().each_blocks.has_animate(id)
+    }
 
     // -- Expression offset lookups (for offset-keyed ParserResult) --
 
@@ -310,8 +615,6 @@ impl<'a> Ctx<'a> {
 
     /// Register a delegated event name (deduplicates via O(1) HashSet lookup).
     pub fn add_delegated_event(&mut self, event_name: String) {
-        if self.delegated_events_set.insert(event_name.clone()) {
-            self.delegated_events.push(event_name);
-        }
+        self.state.add_delegated_event(event_name);
     }
 }

--- a/crates/svelte_codegen_client/src/custom_element.rs
+++ b/crates/svelte_codegen_client/src/custom_element.rs
@@ -14,8 +14,6 @@ pub fn gen_custom_element<'a>(
     ctx: &mut Ctx<'a>,
     ce_config: &CustomElementConfig,
 ) -> Vec<Statement<'a>> {
-    let b = &ctx.b;
-
     // Determine tag and parsed options based on config variant
     let (simple_tag, parsed) = match ce_config {
         CustomElementConfig::Tag(tag) => (Some(tag.as_str()), None),
@@ -33,23 +31,27 @@ pub fn gen_custom_element<'a>(
     let props_obj = build_props_metadata(ctx, parsed);
 
     // -- Arg 3: Slots array (always empty in Svelte 5 runes mode) --
-    let slots = b.array_from_args(std::iter::empty::<Arg<'_, '_>>());
+    let slots = ctx.b.array_from_args(std::iter::empty::<Arg<'_, '_>>());
 
     // -- Arg 4: Accessors array (from exports) --
-    let accessors = b.array_from_args(
-        ctx.analysis().exports.iter().map(|e| {
+    let accessors = ctx
+        .b
+        .array_from_args(ctx.analysis().exports.iter().map(|e| {
             let name = e.alias.as_deref().unwrap_or(e.name.as_str());
             Arg::StrRef(name)
-        })
-    );
+        }));
 
     // -- Arg 5: Shadow root config --
     let is_shadow_none = parsed.is_some_and(|o| o.shadow == CeShadowMode::None);
 
     // -- Arg 6: Extend (pre-parsed in analyze) --
-    let extend_arg: Option<Expression<'a>> = ctx.analysis().ce_config.as_ref()
+    let extend_arg: Option<Expression<'a>> = ctx
+        .analysis()
+        .ce_config
+        .as_ref()
         .and_then(|c| c.extend_span)
         .and_then(|span| ctx.parsed.exprs.remove(&span.start));
+    let b = &ctx.b;
 
     // Build $.create_custom_element() call
     let mut args: Vec<Arg<'a, '_>> = vec![
@@ -74,14 +76,9 @@ pub fn gen_custom_element<'a>(
     // Wrap in customElements.define() if tag is present
     let mut stmts = Vec::new();
     if let Some(tag_str) = resolved_tag {
-        let define_callee = b.static_member_expr(
-            b.rid_expr("customElements"),
-            "define",
-        );
-        let define_call = b.call_expr_callee(define_callee, [
-            Arg::StrRef(tag_str),
-            Arg::Expr(create_ce),
-        ]);
+        let define_callee = b.static_member_expr(b.rid_expr("customElements"), "define");
+        let define_call =
+            b.call_expr_callee(define_callee, [Arg::StrRef(tag_str), Arg::Expr(create_ce)]);
         stmts.push(b.expr_stmt(define_call));
     } else {
         stmts.push(b.expr_stmt(create_ce));
@@ -94,10 +91,7 @@ pub fn gen_custom_element<'a>(
 ///
 /// For each prop from CE config: build `{ attribute?, reflect?, type? }`.
 /// For remaining component props not in config: add `propName: {}`.
-fn build_props_metadata<'a>(
-    ctx: &Ctx<'a>,
-    parsed_opts: Option<&ParsedCeConfig>,
-) -> Expression<'a> {
+fn build_props_metadata<'a>(ctx: &Ctx<'a>, parsed_opts: Option<&ParsedCeConfig>) -> Expression<'a> {
     let b = &ctx.b;
     let mut obj_props: Vec<ObjProp<'a>> = Vec::new();
 
@@ -149,10 +143,7 @@ fn resolve_prop_key(ctx: &Ctx<'_>, name: &str) -> String {
 }
 
 /// Build the value expression for a single prop definition: `{ attribute?, reflect?, type? }`.
-fn build_prop_def_expr<'a>(
-    b: &crate::builder::Builder<'a>,
-    def: &CePropConfig,
-) -> Expression<'a> {
+fn build_prop_def_expr<'a>(b: &crate::builder::Builder<'a>, def: &CePropConfig) -> Expression<'a> {
     let mut props: Vec<ObjProp<'a>> = Vec::new();
 
     if let Some(ref attr) = def.attribute {

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -27,7 +27,7 @@ pub(crate) fn gen_each_block<'a>(
     is_controlled: bool,
     body: &mut Vec<Statement<'a>>,
 ) {
-    let block = ctx.each_block(block_id);
+    let block = ctx.query.each_block(block_id);
     let body_key = FragmentKey::EachBody(block_id);
     let expr_span = block.expression_span;
     let span_start = block.span.start;
@@ -38,7 +38,11 @@ pub(crate) fn gen_each_block<'a>(
     // Extract the context binding pattern once when `as ...` is present.
     // Consumed by key function (clone for arrow param) and destructuring (ownership transfer).
     let context_pattern = block.context_span.map(|cs| {
-        let stmt = ctx.parsed.stmts.remove(&cs.start)
+        let stmt = ctx
+            .state
+            .parsed
+            .stmts
+            .remove(&cs.start)
             .expect("each block with context must have pre-parsed context stmt");
         let Statement::VariableDeclaration(mut var_decl) = stmt else {
             unreachable!("each context stmt must be VariableDeclaration");
@@ -46,7 +50,12 @@ pub(crate) fn gen_each_block<'a>(
         var_decl.declarations.remove(0).id
     });
 
-    let context_name = ctx.analysis().each_blocks.context_name(block_id).to_string();
+    let context_name = ctx
+        .query
+        .raw()
+        .each_blocks
+        .context_name(block_id)
+        .to_string();
 
     let key_is_item = ctx.each_key_is_item(block_id);
 
@@ -63,7 +72,9 @@ pub(crate) fn gen_each_block<'a>(
 
     // EACH_ITEM_REACTIVE: collection references external state
     // In runes mode: skip when key_is_item (item identity is the key)
-    let expr_has_refs = ctx.expression(block_id)
+    let expr_has_refs = ctx
+        .query
+        .expression(block_id)
         .is_some_and(|info| !info.ref_symbols.is_empty());
     if expr_has_refs && !key_is_item {
         flags |= EACH_ITEM_REACTIVE;
@@ -84,12 +95,13 @@ pub(crate) fn gen_each_block<'a>(
     let needs_group_index = ctx.contains_group_binding(block_id);
     let body_uses_index = ctx.each_body_uses_index(block_id);
     let render_index_name = if body_uses_index || needs_group_index {
-        user_index_name.clone()
-            .or_else(|| needs_group_index.then(|| {
+        user_index_name.clone().or_else(|| {
+            needs_group_index.then(|| {
                 let name = ctx.gen_ident("$$index");
-                ctx.group_index_names.insert(block_id, name.clone());
+                ctx.state.group_index_names.insert(block_id, name.clone());
                 name
-            }))
+            })
+        })
     } else {
         None
     };
@@ -109,10 +121,11 @@ pub(crate) fn gen_each_block<'a>(
     let is_prop_source = ctx.is_prop_source_node(block_id);
     let collection_fn = if needs_async {
         // Inside $.async callback: () => $.get($$collection)
-        ctx.b.thunk(ctx.b.call_expr("$.get", [Arg::Ident("$$collection")]))
+        ctx.b
+            .thunk(ctx.b.call_expr("$.get", [Arg::Ident("$$collection")]))
     } else if is_prop_source {
         // Prop getter is already a function — pass directly without thunk
-        let expr_source = ctx.component.source_text(expr_span).trim();
+        let expr_source = ctx.query.component.source_text(expr_span).trim();
         ctx.b.rid_expr(expr_source)
     } else {
         let collection = get_node_expr(ctx, block_id);
@@ -122,8 +135,8 @@ pub(crate) fn gen_each_block<'a>(
 
     // Key function: keyed each uses (pattern[, index]) => key_expr, unkeyed uses $.index
     let key_fn = {
-        let key_span = ctx.each_block(block_id).key_span;
-        let key_expr = key_span.and_then(|ks| ctx.parsed.exprs.remove(&ks.start));
+        let key_span = ctx.query.each_block(block_id).key_span;
+        let key_expr = key_span.and_then(|ks| ctx.state.parsed.exprs.remove(&ks.start));
         if let Some(key_expr) = key_expr {
             let key_body = ctx.b.expr_stmt(key_expr);
             let context_param = match &context_pattern {
@@ -134,12 +147,17 @@ pub(crate) fn gen_each_block<'a>(
                 None => ctx.b.formal_parameter_from_str(&context_name),
             };
             if ctx.each_key_uses_index(block_id) {
-                let idx_name = user_index_name.as_ref()
+                let idx_name = user_index_name
+                    .as_ref()
                     .expect("key_uses_index implies index exists");
                 let idx_param = ctx.b.formal_parameter_from_str(idx_name);
-                ctx.b.arrow_expr(ctx.b.formal_parameters([context_param, idx_param]), [key_body])
+                ctx.b.arrow_expr(
+                    ctx.b.formal_parameters([context_param, idx_param]),
+                    [key_body],
+                )
             } else {
-                ctx.b.arrow_expr(ctx.b.formal_parameters([context_param]), [key_body])
+                ctx.b
+                    .arrow_expr(ctx.b.formal_parameters([context_param]), [key_body])
             }
         } else {
             ctx.b.rid_expr("$.index")
@@ -165,9 +183,11 @@ pub(crate) fn gen_each_block<'a>(
     }
 
     let frag_fn = if let Some(ref idx) = render_index_name {
-        ctx.b.arrow_block_expr(ctx.b.params(["$$anchor", &context_name, idx]), frag_body)
+        ctx.b
+            .arrow_block_expr(ctx.b.params(["$$anchor", &context_name, idx]), frag_body)
     } else {
-        ctx.b.arrow_block_expr(ctx.b.params(["$$anchor", &context_name]), frag_body)
+        ctx.b
+            .arrow_block_expr(ctx.b.params(["$$anchor", &context_name]), frag_body)
     };
 
     if needs_async {
@@ -183,15 +203,28 @@ pub(crate) fn gen_each_block<'a>(
         if has_fallback {
             let fallback_key = FragmentKey::EachFallback(block_id);
             let fallback_body = gen_fragment(ctx, fallback_key);
-            let fallback_fn = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), fallback_body);
+            let fallback_fn = ctx
+                .b
+                .arrow_block_expr(ctx.b.params(["$$anchor"]), fallback_body);
             each_args.push(Arg::Expr(fallback_fn));
         }
 
         let each_call = ctx.b.call_expr("$.each", each_args);
         let each_stmt = super::add_svelte_meta(ctx, each_call, span_start, "each");
 
-        let async_thunk = if has_await { async_collection_thunk } else { None };
-        body.push(ctx.gen_async_block(block_id, anchor, has_await, async_thunk, "$$collection", vec![each_stmt]));
+        let async_thunk = if has_await {
+            async_collection_thunk
+        } else {
+            None
+        };
+        body.push(ctx.gen_async_block(
+            block_id,
+            anchor,
+            has_await,
+            async_thunk,
+            "$$collection",
+            vec![each_stmt],
+        ));
     } else {
         let mut each_args: Vec<Arg<'a, '_>> = vec![
             Arg::Expr(anchor),
@@ -204,7 +237,9 @@ pub(crate) fn gen_each_block<'a>(
         if has_fallback {
             let fallback_key = FragmentKey::EachFallback(block_id);
             let fallback_body = gen_fragment(ctx, fallback_key);
-            let fallback_fn = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), fallback_body);
+            let fallback_fn = ctx
+                .b
+                .arrow_block_expr(ctx.b.params(["$$anchor"]), fallback_body);
             each_args.push(Arg::Expr(fallback_fn));
         }
 
@@ -238,8 +273,13 @@ fn gen_destructuring_declarations<'a>(
             } else {
                 ctx.b.rid_expr("$$item")
             };
-            let to_array = ctx.b.call_expr("$.to_array", [Arg::Expr(item_access), Arg::Num(count as f64)]);
-            let derived = ctx.b.call_expr("$.derived", [Arg::Expr(ctx.b.thunk(to_array))]);
+            let to_array = ctx.b.call_expr(
+                "$.to_array",
+                [Arg::Expr(item_access), Arg::Num(count as f64)],
+            );
+            let derived = ctx
+                .b
+                .call_expr("$.derived", [Arg::Expr(ctx.b.thunk(to_array))]);
             decls.push(ctx.b.var_stmt(&array_name, derived));
 
             for (i, elem) in elements.into_iter().enumerate() {
@@ -255,7 +295,9 @@ fn gen_destructuring_declarations<'a>(
                     _ => continue,
                 };
                 let get_array = ctx.b.call_expr("$.get", [Arg::Ident(&array_name)]);
-                let access = ctx.b.computed_member_expr(get_array, ctx.b.num_expr(i as f64));
+                let access = ctx
+                    .b
+                    .computed_member_expr(get_array, ctx.b.num_expr(i as f64));
                 let thunk = ctx.b.thunk(access);
                 decls.push(ctx.b.let_init_stmt(&name, thunk));
             }
@@ -280,7 +322,9 @@ fn gen_destructuring_declarations<'a>(
                     }
                     BindingPattern::AssignmentPattern(assign) => {
                         let assign = assign.unbox();
-                        let BindingPattern::BindingIdentifier(id) = assign.left else { continue };
+                        let BindingPattern::BindingIdentifier(id) = assign.left else {
+                            continue;
+                        };
                         let name = id.name.as_str().to_string();
                         let prop_key = key_name.as_deref().unwrap_or(&name);
                         let item_access = if item_reactive {
@@ -289,8 +333,12 @@ fn gen_destructuring_declarations<'a>(
                             ctx.b.rid_expr("$$item")
                         };
                         let member = ctx.b.static_member_expr(item_access, prop_key);
-                        let fallback = ctx.b.call_expr("$.fallback", [Arg::Expr(member), Arg::Expr(assign.right)]);
-                        let derived = ctx.b.call_expr("$.derived_safe_equal", [Arg::Expr(ctx.b.thunk(fallback))]);
+                        let fallback = ctx
+                            .b
+                            .call_expr("$.fallback", [Arg::Expr(member), Arg::Expr(assign.right)]);
+                        let derived = ctx
+                            .b
+                            .call_expr("$.derived_safe_equal", [Arg::Expr(ctx.b.thunk(fallback))]);
                         decls.push(ctx.b.let_init_stmt(&name, derived));
                     }
                     _ => continue,

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -33,7 +33,7 @@ pub(crate) fn gen_if_block<'a>(
     let mut current = block_id;
 
     loop {
-        let block = ctx.if_block(current);
+        let block = ctx.query.if_block(current);
         let has_alternate = block.alternate.is_some();
 
         branches.push(Branch {
@@ -46,10 +46,14 @@ pub(crate) fn gen_if_block<'a>(
         }
 
         let alternate_key = FragmentKey::IfAlternate(current);
-        let alt_is_elseif = ctx.is_elseif_alt(current);
+        let alt_is_elseif = ctx.query.raw().is_elseif_alt(current);
 
         if alt_is_elseif {
-            let nested_id = ctx.lowered_fragment(&alternate_key).first_if_block_id().unwrap();
+            let nested_id = ctx
+                .query
+                .lowered_fragment(&alternate_key)
+                .first_if_block_id()
+                .unwrap();
             current = nested_id;
             continue;
         } else {
@@ -59,7 +63,11 @@ pub(crate) fn gen_if_block<'a>(
     }
 
     // Build the expression for the root condition (needed before stmts consume it)
-    let expression = if needs_async { Some(get_node_expr(ctx, block_id)) } else { None };
+    let expression = if needs_async {
+        Some(get_node_expr(ctx, block_id))
+    } else {
+        None
+    };
 
     let mut stmts = Vec::new();
 
@@ -91,7 +99,7 @@ pub(crate) fn gen_if_block<'a>(
             // Root async condition: resolved via $.get($$condition) inside $.async callback
             derived_names.push(None);
         } else {
-            let needs_memo = ctx.analysis().needs_expr_memoization(branch.block_id);
+            let needs_memo = ctx.query.raw().needs_expr_memoization(branch.block_id);
             if needs_memo {
                 let expr = get_node_expr(ctx, branch.block_id);
                 let thunk = ctx.b.thunk(expr);
@@ -108,9 +116,10 @@ pub(crate) fn gen_if_block<'a>(
     // 3. Build the if/else-if/else chain (bottom-up)
     let num_branches = branches.len();
 
-    let mut else_clause: Option<Statement<'a>> = alt_name
-        .as_ref()
-        .map(|an| ctx.b.call_stmt("$$render", [Arg::Ident(an), Arg::Num(-1.0)]));
+    let mut else_clause: Option<Statement<'a>> = alt_name.as_ref().map(|an| {
+        ctx.b
+            .call_stmt("$$render", [Arg::Ident(an), Arg::Num(-1.0)])
+    });
 
     for i in (0..num_branches).rev() {
         let test = if i == 0 && has_await {
@@ -134,7 +143,7 @@ pub(crate) fn gen_if_block<'a>(
     let render_fn = ctx.b.arrow(ctx.b.params(["$$render"]), [render_body_stmt]);
 
     // 4. $.if() call + optional $.async() wrapping
-    let span_start = ctx.if_block(block_id).span.start;
+    let span_start = ctx.query.if_block(block_id).span.start;
 
     if needs_async {
         // Inside $.async callback: use "node" param as anchor
@@ -143,8 +152,19 @@ pub(crate) fn gen_if_block<'a>(
         let if_call = ctx.b.call_expr("$.if", if_args);
         stmts.push(super::add_svelte_meta(ctx, if_call, span_start, "if"));
 
-        let async_thunk = if has_await { Some(ctx.b.async_thunk(expression.unwrap())) } else { None };
-        vec![ctx.gen_async_block(block_id, anchor, has_await, async_thunk, "$$condition", stmts)]
+        let async_thunk = if has_await {
+            Some(ctx.b.async_thunk(expression.unwrap()))
+        } else {
+            None
+        };
+        vec![ctx.gen_async_block(
+            block_id,
+            anchor,
+            has_await,
+            async_thunk,
+            "$$condition",
+            stmts,
+        )]
     } else {
         let if_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor), Arg::Arrow(render_fn)];
         let if_call = ctx.b.call_expr("$.if", if_args);


### PR DESCRIPTION
### Motivation
- Make codegen responsibilities explicit by separating read-only analysis/component access from mutable runtime/codegen state to improve safety and make future migrations low-risk.
- Preserve existing behavior and call-sites during migration by keeping a thin `Ctx<'a>` compatibility wrapper that forwards to the new query/state primitives.

### Description
- Introduced `CodegenQuery<'a>` (read-only access to `Component`, `CodegenView` and analysis helpers) and `CodegenState<'a>` (mutable `Builder`, `parsed`, `ident_gen`, hoists, delegated events, blockers, etc.) in `crates/svelte_codegen_client/src/context.rs`.
- Kept `Ctx<'a>` as a compatibility wrapper that contains `query: CodegenQuery<'a>` and `state: CodegenState<'a>`, implements `Deref/DerefMut` to the state for a smooth transition, and preserves existing public proxy methods (e.g., `element`, `expression`, `gen_ident`, `content_type`).
- Moved fields across the ownership boundary so read-only data (component, view, compile metadata) live on `CodegenQuery` and all mutable emission state (parsed `ParserResult`, `ident_gen`, `module_hoisted`, `group_index_names`, delegated events, const-tag blockers, pending blockers, etc.) live on `CodegenState` while keeping the original external API intact.
- Migrated two template modules as proofs-of-safety: `template/if_block.rs` and `template/each_block.rs` were updated to use `ctx.query.*` for reads and `ctx.state.*` for writes without changing business logic.
- Small borrow-order / local-borrow compatibility fix in `custom_element.rs` to satisfy the borrow checker after the split, without altering emitted output or logic.
- Added migration guidance comments in `context.rs` documenting which `Ctx` proxies are temporary and the recommended order for porting remaining template modules.

### Testing
- Ran `cargo check -p svelte_codegen_client` which completed successfully with no errors and only mild unused-field warnings.
- Ran the full compiler test suite via `just test-compiler` and all compiler tests passed (`357 passed; 0 failed`).
- Verified that output snapshots and behavior are preserved based on the passing compiler test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb68e26df88321af92709e488a7ec4)