### PR TITLE
feat(experimental-async): dev-mode parity for async_derived and for_await

### DIFF
--- a/crates/svelte_codegen_client/src/script/model.rs
+++ b/crates/svelte_codegen_client/src/script/model.rs
@@ -71,6 +71,9 @@ pub(super) struct ScriptTransformer<'b, 'a> {
     pub(super) scoping: Scoping,
     pub(super) props_gen: Option<PropsGenInfo>,
     pub(super) derived_pending: FxHashSet<oxc_semantic::SymbolId>,
+    /// Subset of `derived_pending`: symbols whose `$derived` init was `$derived(await expr)`.
+    /// Used by `wrap_derived_thunks` to determine async thunk form after dev transforms run.
+    pub(super) async_derived_pending: FxHashSet<oxc_semantic::SymbolId>,
     pub(super) strip_exports: bool,
     pub(super) dev: bool,
     pub(super) is_ts: bool,
@@ -84,6 +87,7 @@ pub(super) struct ScriptTransformer<'b, 'a> {
     pub(super) class_state_stack: Vec<ClassStateInfo>,
     pub(super) prop_default_exprs: Vec<Option<Expression<'a>>>,
     pub(super) script_rune_call_kinds: Option<&'b FxHashMap<u32, RuneKind>>,
+    pub(super) experimental_async: bool,
 }
 
 impl<'b, 'a> ScriptTransformer<'b, 'a> {

--- a/crates/svelte_codegen_client/src/script/pipeline.rs
+++ b/crates/svelte_codegen_client/src/script/pipeline.rs
@@ -64,6 +64,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
             component_source,
             script_content_start,
             filename,
+            ctx.state.experimental_async,
         );
     }
 
@@ -84,6 +85,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
         script_content_start,
         filename,
         None,
+        ctx.state.experimental_async,
     )
 }
 
@@ -105,6 +107,7 @@ pub fn transform_module_script<'a>(
         0,
         "(unknown)",
         None,
+        false,
     )
 }
 
@@ -120,6 +123,7 @@ fn transform_script_text<'a>(
     script_content_start: u32,
     filename: &str,
     script_rune_call_kinds: Option<&FxHashMap<u32, RuneKind>>,
+    experimental_async: bool,
 ) -> ScriptOutput<'a> {
     let src_type = if is_ts {
         SourceType::default().with_typescript(true).with_module(true)
@@ -150,6 +154,7 @@ fn transform_script_text<'a>(
         scoping,
         props_gen,
         derived_pending: FxHashSet::default(),
+        async_derived_pending: FxHashSet::default(),
         strip_exports,
         dev,
         is_ts,
@@ -163,13 +168,21 @@ fn transform_script_text<'a>(
         class_state_stack: Vec::new(),
         prop_default_exprs,
         script_rune_call_kinds,
+        experimental_async,
     };
 
     let empty_scoping = Scoping::default();
     traverse_mut(&mut transformer, allocator, &mut program, empty_scoping, ());
 
     if !transformer.derived_pending.is_empty() {
-        super::traverse::wrap_derived_thunks(&b, &mut program, &transformer.derived_pending);
+        let dev_ctx = super::traverse::DevContext {
+            dev,
+            component_source,
+            script_content_start,
+            filename,
+            async_derived_pending: transformer.async_derived_pending,
+        };
+        super::traverse::wrap_derived_thunks(&b, &mut program, &transformer.derived_pending, Some(&dev_ctx));
     }
 
     let has_tracing = transformer.has_tracing;
@@ -213,6 +226,7 @@ fn transform_program<'a>(
     component_source: &str,
     script_content_start: u32,
     filename: &str,
+    experimental_async: bool,
 ) -> ScriptOutput<'a> {
     let b = Builder::new(allocator);
     let is_ts = program.source_type.is_typescript();
@@ -226,6 +240,7 @@ fn transform_program<'a>(
         scoping,
         props_gen,
         derived_pending: FxHashSet::default(),
+        async_derived_pending: FxHashSet::default(),
         strip_exports: true,
         dev,
         is_ts,
@@ -239,13 +254,21 @@ fn transform_program<'a>(
         class_state_stack: Vec::new(),
         prop_default_exprs,
         script_rune_call_kinds,
+        experimental_async,
     };
 
     let empty_scoping = Scoping::default();
     traverse_mut(&mut transformer, allocator, &mut program, empty_scoping, ());
 
     if !transformer.derived_pending.is_empty() {
-        super::traverse::wrap_derived_thunks(&b, &mut program, &transformer.derived_pending);
+        let dev_ctx = super::traverse::DevContext {
+            dev,
+            component_source,
+            script_content_start,
+            filename,
+            async_derived_pending: transformer.async_derived_pending,
+        };
+        super::traverse::wrap_derived_thunks(&b, &mut program, &transformer.derived_pending, Some(&dev_ctx));
     }
 
     let has_tracing = transformer.has_tracing;

--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -367,7 +367,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         let Expression::CallExpression(mut call) = init else {
             unreachable!("async derived destructuring should be a call");
         };
-        // Capture span before extracting arguments for dev-mode location.
+        // Must read span before mem::swap removes the original argument.
         let init_span_start = call.span.start;
         let mut dummy = oxc_ast::ast::Argument::from(self.b.cheap_expr());
         std::mem::swap(&mut call.arguments[0], &mut dummy);
@@ -380,11 +380,9 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         let tmp_name = self.gen_unique_name("$$d");
         let tmp_name_str = self.b.alloc_str(&tmp_name);
 
-        // Async thunk: `async () => await source_expr` — matches reference output.
         let await_inner = self.b.await_expr(source_expr);
         let thunk = self.b.async_thunk(await_inner);
 
-        // Build args: thunk + optional dev-mode label + location.
         let mut args: Vec<Arg<'a, '_>> = vec![Arg::Expr(thunk)];
         if self.dev {
             let kind = match pattern {

--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -9,7 +9,7 @@ use svelte_analyze::RuneKind;
 
 use crate::builder::Arg;
 
-use super::{ClassStateField, ClassStateInfo, ScriptTransformer};
+use super::{ClassStateField, ClassStateInfo, ScriptTransformer, compute_line_col, sanitize_location};
 
 impl<'b, 'a> ScriptTransformer<'b, 'a> {
     fn rewrite_destructured_rune_decls(
@@ -367,6 +367,8 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         let Expression::CallExpression(mut call) = init else {
             unreachable!("async derived destructuring should be a call");
         };
+        // Capture span before extracting arguments for dev-mode location.
+        let init_span_start = call.span.start;
         let mut dummy = oxc_ast::ast::Argument::from(self.b.cheap_expr());
         std::mem::swap(&mut call.arguments[0], &mut dummy);
         let awaited = dummy.into_expression();
@@ -377,8 +379,27 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         let source_expr = await_expr.unbox().argument;
         let tmp_name = self.gen_unique_name("$$d");
         let tmp_name_str = self.b.alloc_str(&tmp_name);
-        let thunk = self.b.thunk(source_expr);
-        let async_derived = self.b.call_expr("$.async_derived", [Arg::Expr(thunk)]);
+
+        // Async thunk: `async () => await source_expr` — matches reference output.
+        let await_inner = self.b.await_expr(source_expr);
+        let thunk = self.b.async_thunk(await_inner);
+
+        // Build args: thunk + optional dev-mode label + location.
+        let mut args: Vec<Arg<'a, '_>> = vec![Arg::Expr(thunk)];
+        if self.dev {
+            let kind = match pattern {
+                oxc_ast::ast::BindingPattern::ArrayPattern(_) => "iterable",
+                _ => "object",
+            };
+            let label = format!("[$derived {kind}]");
+            args.push(Arg::Expr(self.b.str_expr(&label)));
+            let full_offset = self.script_content_start + init_span_start;
+            let (line, col) = compute_line_col(self.component_source, full_offset);
+            let loc = format!("{}:{}:{}", sanitize_location(self.filename), line, col);
+            args.push(Arg::Expr(self.b.str_expr(&loc)));
+        }
+
+        let async_derived = self.b.call_expr("$.async_derived", args);
         let tmp_stmt = self.b.var_stmt(tmp_name_str, self.b.await_expr(async_derived));
 
         let access_root = self.b.call_expr("$.get", [Arg::Ident(tmp_name_str)]);

--- a/crates/svelte_codegen_client/src/script/traverse/derived.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/derived.rs
@@ -3,20 +3,43 @@ use rustc_hash::FxHashSet;
 use oxc_ast::ast::{Expression, Statement};
 
 use crate::builder::Builder;
+use crate::script::{compute_line_col, sanitize_location};
+
+/// Dev-mode context for adding label/location args to `$.async_derived`.
+pub(crate) struct DevContext<'a> {
+    pub(crate) dev: bool,
+    pub(crate) component_source: &'a str,
+    pub(crate) script_content_start: u32,
+    pub(crate) filename: &'a str,
+    /// Symbols whose `$derived` init was `$derived(await expr)` — tracked before
+    /// `rewrite_dev_await_tracking` can transform the `await` into a different form.
+    pub(crate) async_derived_pending: FxHashSet<oxc_semantic::SymbolId>,
+}
+
+impl DevContext<'_> {
+    /// Compute `"filename:line:col"` from a byte offset inside the script.
+    fn locate(&self, script_offset: u32) -> String {
+        let full_offset = self.script_content_start + script_offset;
+        let (line, col) = compute_line_col(self.component_source, full_offset);
+        format!("{}:{}:{}", sanitize_location(self.filename), line, col)
+    }
+}
 
 /// Post-traverse: wrap `$.derived(expr)` → `$.derived(() => expr)` for $derived runes.
 pub(crate) fn wrap_derived_thunks<'a>(
     b: &Builder<'a>,
     program: &mut oxc_ast::ast::Program<'a>,
     pending: &FxHashSet<oxc_semantic::SymbolId>,
+    dev_ctx: Option<&DevContext<'_>>,
 ) {
-    wrap_derived_thunks_in_stmts(b, &mut program.body, pending);
+    wrap_derived_thunks_in_stmts(b, &mut program.body, pending, dev_ctx);
 }
 
 fn wrap_derived_thunks_in_stmts<'a>(
     b: &Builder<'a>,
     stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>,
     pending: &FxHashSet<oxc_semantic::SymbolId>,
+    dev_ctx: Option<&DevContext<'_>>,
 ) {
     for stmt in stmts.iter_mut() {
         match stmt {
@@ -39,10 +62,59 @@ fn wrap_derived_thunks_in_stmts<'a>(
                             std::mem::swap(&mut call.arguments[0], &mut dummy);
                             let arg_expr = dummy.into_expression();
 
-                            if let Expression::AwaitExpression(await_expr) = arg_expr {
-                                let inner = await_expr.unbox().argument;
-                                let thunk = b.thunk(inner);
+                            // Determine whether this is an async derived.
+                            // We rely on `async_derived_pending` because in dev mode the
+                            // `await` inside `$derived(await expr)` has already been
+                            // transformed to `(await $.track_reactivity_loss(expr))()` by
+                            // `rewrite_dev_await_tracking`, so we can't detect it by
+                            // checking for `AwaitExpression` alone.
+                            let is_async = matches!(arg_expr, Expression::AwaitExpression(_))
+                                || dev_ctx.as_ref().is_some_and(|ctx| {
+                                    ctx.async_derived_pending.contains(&sym_id)
+                                });
+
+                            if is_async {
+                                // Capture init span before mutating call for location computation.
+                                let init_span_start = call.span.start;
+
+                                // Thunk form depends on whether arg is still AwaitExpression
+                                // (non-dev mode) or already transformed (dev mode).
+                                let thunk = if let Expression::AwaitExpression(await_expr) = arg_expr {
+                                    // Non-dev: strip the await, create non-async thunk.
+                                    // `async () => await fetch(x)` → optimized to `() => fetch(x)`
+                                    // by the reference's `unthunk`. We match that behavior directly.
+                                    let inner = await_expr.unbox().argument;
+                                    b.thunk(inner)
+                                } else {
+                                    // Dev mode: arg was already transformed to
+                                    // `(await $.track_reactivity_loss(expr))()` by
+                                    // `rewrite_dev_await_tracking`. Use async_arrow_expr_body
+                                    // to avoid adding an extra `await`.
+                                    b.async_arrow_expr_body(arg_expr)
+                                };
+
+                                // Build dev-mode extra args.
+                                let mut extra_args: Vec<oxc_ast::ast::Argument<'a>> = Vec::new();
+                                if let Some(ctx) = dev_ctx {
+                                    if ctx.dev {
+                                        // 2nd arg: identifier name string
+                                        let name = match &declarator.id {
+                                            oxc_ast::ast::BindingPattern::BindingIdentifier(id) => {
+                                                id.name.to_string()
+                                            }
+                                            _ => String::new(),
+                                        };
+                                        extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&name)));
+                                        // 3rd arg: source location string
+                                        let loc = ctx.locate(init_span_start);
+                                        extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&loc)));
+                                    }
+                                }
+
                                 call.arguments[0] = oxc_ast::ast::Argument::from(thunk);
+                                for arg in extra_args {
+                                    call.arguments.push(arg);
+                                }
                                 call.callee = b.rid_expr("$.async_derived");
                                 let call_expr = b.move_expr(declarator.init.as_mut().unwrap());
                                 declarator.init = Some(b.await_expr(call_expr));
@@ -56,7 +128,7 @@ fn wrap_derived_thunks_in_stmts<'a>(
             }
             Statement::FunctionDeclaration(func) => {
                 if let Some(body) = &mut func.body {
-                    wrap_derived_thunks_in_stmts(b, &mut body.statements, pending);
+                    wrap_derived_thunks_in_stmts(b, &mut body.statements, pending, dev_ctx);
                 }
             }
             Statement::ExportNamedDeclaration(export) => {
@@ -64,7 +136,7 @@ fn wrap_derived_thunks_in_stmts<'a>(
                     &mut export.declaration
                 {
                     if let Some(body) = &mut func.body {
-                        wrap_derived_thunks_in_stmts(b, &mut body.statements, pending);
+                        wrap_derived_thunks_in_stmts(b, &mut body.statements, pending, dev_ctx);
                     }
                 }
             }

--- a/crates/svelte_codegen_client/src/script/traverse/derived.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/derived.rs
@@ -17,7 +17,7 @@ pub(crate) struct DevContext<'a> {
 }
 
 impl DevContext<'_> {
-    /// Compute `"filename:line:col"` from a byte offset inside the script.
+    /// `script_offset` is relative to the script block start, not the full component source.
     fn locate(&self, script_offset: u32) -> String {
         let full_offset = self.script_content_start + script_offset;
         let (line, col) = compute_line_col(self.component_source, full_offset);
@@ -74,7 +74,7 @@ fn wrap_derived_thunks_in_stmts<'a>(
                                 });
 
                             if is_async {
-                                // Capture init span before mutating call for location computation.
+                                // Must read span before the mem::swap below invalidates arg positions.
                                 let init_span_start = call.span.start;
 
                                 // Thunk form depends on whether arg is still AwaitExpression
@@ -93,22 +93,17 @@ fn wrap_derived_thunks_in_stmts<'a>(
                                     b.async_arrow_expr_body(arg_expr)
                                 };
 
-                                // Build dev-mode extra args.
                                 let mut extra_args: Vec<oxc_ast::ast::Argument<'a>> = Vec::new();
-                                if let Some(ctx) = dev_ctx {
-                                    if ctx.dev {
-                                        // 2nd arg: identifier name string
-                                        let name = match &declarator.id {
-                                            oxc_ast::ast::BindingPattern::BindingIdentifier(id) => {
-                                                id.name.to_string()
-                                            }
-                                            _ => String::new(),
-                                        };
-                                        extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&name)));
-                                        // 3rd arg: source location string
-                                        let loc = ctx.locate(init_span_start);
-                                        extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&loc)));
-                                    }
+                                if let Some(ctx) = dev_ctx.filter(|c| c.dev) {
+                                    let name = match &declarator.id {
+                                        oxc_ast::ast::BindingPattern::BindingIdentifier(id) => {
+                                            id.name.to_string()
+                                        }
+                                        _ => String::new(),
+                                    };
+                                    extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&name)));
+                                    let loc = ctx.locate(init_span_start);
+                                    extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&loc)));
                                 }
 
                                 call.arguments[0] = oxc_ast::ast::Argument::from(thunk);

--- a/crates/svelte_codegen_client/src/script/traverse/mod.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/mod.rs
@@ -10,7 +10,7 @@ use oxc_traverse::{Traverse, TraverseCtx};
 
 use super::{FunctionInfo, ScriptTransformer};
 
-pub(super) use derived::{wrap_derived_thunks, wrap_lazy};
+pub(super) use derived::{wrap_derived_thunks, wrap_lazy, DevContext};
 
 impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
     fn enter_class_body(
@@ -191,6 +191,18 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
         self.strip_ts_variable_declarator_bits(node);
         self.capture_variable_arrow_name(node);
         self.rewrite_variable_rune_init(node);
+    }
+
+    fn enter_for_of_statement(
+        &mut self,
+        node: &mut oxc_ast::ast::ForOfStatement<'a>,
+        _ctx: &mut TraverseCtx<'a, ()>,
+    ) {
+        if node.r#await && self.dev && self.experimental_async {
+            use crate::builder::Arg;
+            let right = self.b.move_expr(&mut node.right);
+            node.right = self.b.call_expr("$.for_await_track_reactivity_loss", [Arg::Expr(right)]);
+        }
     }
 
     fn enter_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a, ()>) {

--- a/crates/svelte_codegen_client/src/script/traverse/runes.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/runes.rs
@@ -32,6 +32,14 @@ impl<'a> ScriptTransformer<'_, 'a> {
                     if let oxc_ast::ast::BindingPattern::BindingIdentifier(bid) = &node.id {
                         if let Some(sym_id) = bid.symbol_id.get() {
                             self.derived_pending.insert(sym_id);
+                            // Track async derived BEFORE `rewrite_dev_await_tracking` can
+                            // transform the `await` inside to `$.track_reactivity_loss` form.
+                            let is_async_init = call.arguments.first()
+                                .and_then(|a| a.as_expression())
+                                .is_some_and(|e| matches!(e, oxc_ast::ast::Expression::AwaitExpression(_)));
+                            if is_async_init {
+                                self.async_derived_pending.insert(sym_id);
+                            }
                         }
                     }
                     node.init = Some(oxc_ast::ast::Expression::CallExpression(call));

--- a/specs/experimental-async.md
+++ b/specs/experimental-async.md
@@ -2,13 +2,13 @@
 
 ## Current state
 
-- **Working**: Infrastructure, block wrapping for if/each/html/key/await/svelte:element, directive blockers, `$.template_effect()` blockers, shared async memoization plumbing for render/title/template-effect deps, generic async text/attribute memoization, `{@const}` async with `$.run()` + blocker propagation, `$derived` async basic + destructured, `{@render}` async with blockers + complex async args, `<title>` async with `async_values`, `<svelte:boundary>` async const/snippet scoping, `{await expr}` template syntax, pickled awaits (`$.save()`) in template/attr reactive expressions
-- **Partially working**: Dev-mode async support only has template/script `await` reactivity-loss wrapping; `{#await}` `$.apply()` and async-derived waterfall warnings are still missing
-- **Not working**: Remaining dev-mode parity, tracing audit
+- **Working**: Infrastructure, block wrapping for if/each/html/key/await/svelte:element, directive blockers, `$.template_effect()` blockers, shared async memoization plumbing for render/title/template-effect deps, generic async text/attribute memoization, `{@const}` async with `$.run()` + blocker propagation, `$derived` async basic + destructured, `{@render}` async with blockers + complex async args, `<title>` async with `async_values`, `<svelte:boundary>` async const/snippet scoping, `{await expr}` template syntax, pickled awaits (`$.save()`) in template/attr reactive expressions, dev-mode `$.track_reactivity_loss()` for script/template `await`, `$.async_derived()` label+location args in dev mode, `for await...of` dev wrapping with `$.for_await_track_reactivity_loss`, `$.trace` async function body handling
+- **Partially working**: `await_waterfall` warning for async `$derived` still missing
+- **Not working**: —
 - **Out of scope**: SSR (`$.await()` server-side — will be separate phase)
-- **Deferred / out of current batch**: `<slot>` async
-- **Next**: Finish dev-mode parity (`{#await}` `$.apply()`, async-derived waterfall warnings) and then re-audit tracing parity
-- Last updated: 2026-03-30
+- **Deferred / out of current batch**: `<slot>` async, `await_waterfall` warning
+- **Next**: `await_waterfall` warning for async `$derived`
+- Last updated: 2026-03-31
 
 ## Source
 
@@ -114,12 +114,12 @@ Audit of existing implementation (2026-03-28)
 33. [x] `(await $.save(expr))()` — context preservation for awaits in reactive expressions (covered for template/attr expressions)
 
 ### Dev mode
-34. [ ] `{#await}` — dev-mode `$.apply()` wrapping for await expression (missing)
+34. N/A `{#await}` — reference `AwaitBlock.js` does not use `$.apply()`; no action needed
 35. [ ] `$derived` async — `await_waterfall` warning with location (missing)
-36. [~] `$.track_reactivity_loss()` — script + template await wrapping works; full dev parity still pending
+36. [x] `$.track_reactivity_loss()` — script + template `await` wrapping, `$.async_derived()` label+location args, `for await...of` wrapping with `$.for_await_track_reactivity_loss` (tests: async_derived_dev, async_for_await_dev)
 
 ### Tracing
-37. [ ] `$.trace` with async function bodies — `b.thunk(body, is_async)` + `b.await(call)` (missing)
+37. [x] `$.trace` with async function bodies — handled in `inspect.rs:89-103` via `async_thunk_block` + `await` of trace call
 
 ## Tasks
 
@@ -146,12 +146,16 @@ Audit of existing implementation (2026-03-28)
 1. [x] parser: parse `{await expr}` template syntax
 2. [x] analyze + codegen: handle new syntax
 
-### Missing: Dev mode (#33, #34)
-1. [ ] codegen: `$.apply()` wrapping in dev mode for `{#await}`
-2. [ ] codegen: `await_waterfall` warning for async `$derived`
+### Done: Dev mode (#36)
+1. [x] codegen: `$.track_reactivity_loss()` in script + template `await` (dev mode)
+2. [x] codegen: `$.async_derived()` label+location args in dev mode
+3. [x] codegen: `for await...of` dev wrapping with `$.for_await_track_reactivity_loss`
 
-### Missing: Tracing (#35)
-1. [ ] codegen: `$.trace` with async body handling
+### Done: Tracing (#37)
+1. [x] codegen: `$.trace` with async body — `async_thunk_block` + `await` in `inspect.rs`
+
+### Deferred: Dev-mode waterfall warning (#35)
+1. [ ] codegen: `await_waterfall` warning for async `$derived` (deferred to ROADMAP)
 
 
 ## Test cases
@@ -177,3 +181,5 @@ Audit of existing implementation (2026-03-28)
 - `inline_await_text_concat` — `{await expr}` inside text concat ✅
 - `inline_await_attr` — `{await expr}` in attribute position ✅
 - `async_pickled_await_template` — template pickled await via `$.save()` ✅
+- `async_derived_dev` — `$.async_derived()` with dev label+location args ✅
+- `async_for_await_dev` — `for await...of` dev wrapping with `$.for_await_track_reactivity_loss` ✅

--- a/tasks/compiler_tests/cases2/async_derived_dev/case-rust.js
+++ b/tasks/compiler_tests/cases2/async_derived_dev/case-rust.js
@@ -1,0 +1,17 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[5, 0]]);
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	var data;
+	var $$promises = $.run([async () => data = await $.async_derived(async () => (await $.track_reactivity_loss(fetch("/api")))(), "data", "(unknown):2:12")]);
+	var $$exports = { ...$.legacy_api() };
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(data)), void 0, void 0, [$$promises[0]]);
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_derived_dev/case-svelte.js
+++ b/tasks/compiler_tests/cases2/async_derived_dev/case-svelte.js
@@ -1,0 +1,17 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[5, 0]]);
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	var data;
+	var $$promises = $.run([async () => data = await $.async_derived(async () => (await $.track_reactivity_loss(fetch("/api")))(), "data", "(unknown):2:12")]);
+	var $$exports = { ...$.legacy_api() };
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(data)), void 0, void 0, [$$promises[0]]);
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_derived_dev/case.svelte
+++ b/tasks/compiler_tests/cases2/async_derived_dev/case.svelte
@@ -1,0 +1,5 @@
+<script>
+	let data = $derived(await fetch('/api'));
+</script>
+
+<p>{data}</p>

--- a/tasks/compiler_tests/cases2/async_derived_dev/config.json
+++ b/tasks/compiler_tests/cases2/async_derived_dev/config.json
@@ -1,0 +1,1 @@
+{"experimental": {"async": true}, "dev": true}

--- a/tasks/compiler_tests/cases2/async_for_await_dev/case-rust.js
+++ b/tasks/compiler_tests/cases2/async_for_await_dev/case-rust.js
@@ -1,0 +1,16 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	async function process(source) {
+		const results = [];
+		for await (const item of $.for_await_track_reactivity_loss(source)) {
+			results.push(item);
+		}
+		return results;
+	}
+	var $$exports = { ...$.legacy_api() };
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_for_await_dev/case-svelte.js
+++ b/tasks/compiler_tests/cases2/async_for_await_dev/case-svelte.js
@@ -1,0 +1,16 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	async function process(source) {
+		const results = [];
+		for await (const item of $.for_await_track_reactivity_loss(source)) {
+			results.push(item);
+		}
+		return results;
+	}
+	var $$exports = { ...$.legacy_api() };
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_for_await_dev/case.svelte
+++ b/tasks/compiler_tests/cases2/async_for_await_dev/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	async function process(source) {
+		const results = [];
+		for await (const item of source) {
+			results.push(item);
+		}
+		return results;
+	}
+</script>

--- a/tasks/compiler_tests/cases2/async_for_await_dev/config.json
+++ b/tasks/compiler_tests/cases2/async_for_await_dev/config.json
@@ -1,0 +1,1 @@
+{"experimental": {"async": true}, "dev": true}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1819,6 +1819,16 @@ fn async_derived_destructured() {
 }
 
 #[rstest]
+fn async_derived_dev() {
+    assert_compiler("async_derived_dev");
+}
+
+#[rstest]
+fn async_for_await_dev() {
+    assert_compiler("async_for_await_dev");
+}
+
+#[rstest]
 fn inline_await_basic() {
     assert_compiler("inline_await_basic");
 }


### PR DESCRIPTION
- Add `$.async_derived()` label+location args in dev mode (name + source location)
- Add `for await...of` dev wrapping with `$.for_await_track_reactivity_loss()`
- Track `async_derived_pending` set in runes.rs before `rewrite_dev_await_tracking`
  transforms `await expr` → `(await $.track_reactivity_loss(expr))()`
- Fix dev-mode async thunk: use `async_arrow_expr_body` (no extra `await`) instead of
  `async_thunk` when arg is already a CallExpression post-transform
- Add `DevContext` struct to `derived.rs` for dev-mode label/location computation
- Tests: async_derived_dev, async_for_await_dev

https://claude.ai/code/session_01Pt1LqdmnEV3iPkgSbQf2cd