### PR TITLE
feat(experimental-async): dev-mode parity for async_derived and for_await (#131)

### DIFF
--- a/crates/svelte_codegen_client/src/script/model.rs
+++ b/crates/svelte_codegen_client/src/script/model.rs
@@ -88,6 +88,8 @@ pub(super) struct ScriptTransformer<'b, 'a> {
     pub(super) prop_default_exprs: Vec<Option<Expression<'a>>>,
     pub(super) script_rune_call_kinds: Option<&'b FxHashMap<u32, RuneKind>>,
     pub(super) experimental_async: bool,
+    /// Statement start positions covered by `// svelte-ignore await_waterfall`.
+    pub(super) waterfall_ignored_starts: FxHashSet<u32>,
 }
 
 impl<'b, 'a> ScriptTransformer<'b, 'a> {

--- a/crates/svelte_codegen_client/src/script/pipeline.rs
+++ b/crates/svelte_codegen_client/src/script/pipeline.rs
@@ -148,6 +148,12 @@ fn transform_script_text<'a>(
         None => Vec::new(),
     };
 
+    let waterfall_ignored_starts = if dev {
+        collect_waterfall_ignored_starts(&program)
+    } else {
+        FxHashSet::default()
+    };
+
     let mut transformer = ScriptTransformer {
         b: &b,
         component_scoping,
@@ -169,6 +175,7 @@ fn transform_script_text<'a>(
         prop_default_exprs,
         script_rune_call_kinds,
         experimental_async,
+        waterfall_ignored_starts: waterfall_ignored_starts.clone(),
     };
 
     let empty_scoping = Scoping::default();
@@ -181,6 +188,7 @@ fn transform_script_text<'a>(
             script_content_start,
             filename,
             async_derived_pending: transformer.async_derived_pending,
+            waterfall_ignored_starts,
         };
         super::traverse::wrap_derived_thunks(&b, &mut program, &transformer.derived_pending, Some(&dev_ctx));
     }
@@ -234,6 +242,12 @@ fn transform_program<'a>(
     let scoping = sem.semantic.into_scoping();
     let props_gen = props.map(PropsGenInfo::from_analysis);
 
+    let waterfall_ignored_starts = if dev {
+        collect_waterfall_ignored_starts(&program)
+    } else {
+        FxHashSet::default()
+    };
+
     let mut transformer = ScriptTransformer {
         b: &b,
         component_scoping,
@@ -255,6 +269,7 @@ fn transform_program<'a>(
         prop_default_exprs,
         script_rune_call_kinds,
         experimental_async,
+        waterfall_ignored_starts: waterfall_ignored_starts.clone(),
     };
 
     let empty_scoping = Scoping::default();
@@ -267,6 +282,7 @@ fn transform_program<'a>(
             script_content_start,
             filename,
             async_derived_pending: transformer.async_derived_pending,
+            waterfall_ignored_starts,
         };
         super::traverse::wrap_derived_thunks(&b, &mut program, &transformer.derived_pending, Some(&dev_ctx));
     }
@@ -298,6 +314,25 @@ fn transform_program<'a>(
         source_text,
         program_span_end,
     }
+}
+
+/// Scan JS comments for `// svelte-ignore await_waterfall` and return the
+/// `attached_to` positions of matching comments. These positions correspond
+/// to the start of the statement the comment precedes.
+fn collect_waterfall_ignored_starts(program: &Program<'_>) -> FxHashSet<u32> {
+    let mut starts = FxHashSet::default();
+    let src = program.source_text;
+    for comment in program.comments.iter() {
+        let s = comment.span.start as usize;
+        let e = comment.span.end as usize;
+        if e <= src.len() {
+            let text = &src[s..e];
+            if text.contains("svelte-ignore") && text.contains("await_waterfall") {
+                starts.insert(comment.attached_to);
+            }
+        }
+    }
+    starts
 }
 
 fn reattach_orphaned_comments(program: &mut Program<'_>) {

--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -22,6 +22,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         mut rewrite: impl FnMut(
             &mut Self,
             oxc_ast::ast::VariableDeclarationKind,
+            u32, // decl_span_start
             oxc_ast::ast::VariableDeclarator<'a>,
             RuneKind,
         ) -> Statement<'a>,
@@ -48,8 +49,9 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
             let stmt = stmts.remove(i);
             let Statement::VariableDeclaration(mut decl) = stmt else { unreachable!() };
             let decl_kind = decl.kind;
+            let decl_span_start = decl.span.start;
             let declarator = decl.declarations.remove(0);
-            let replacement = rewrite(self, decl_kind, declarator, rune_kind.unwrap());
+            let replacement = rewrite(self, decl_kind, decl_span_start, declarator, rune_kind.unwrap());
             stmts.insert(i, replacement);
             self.ident_counter += 1;
             i += 1;
@@ -100,24 +102,31 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
     /// Rewrite destructured async `$derived(await expr)` into a single block statement
     /// so async instance splitting keeps the original blocker metadata indexing.
     pub(super) fn process_async_derived_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
+        let dev = self.dev;
         self.rewrite_destructured_rune_decls(
             stmts,
             |declarator, rune_kind| {
                 !matches!(declarator.id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
                     && matches!(rune_kind, Some(RuneKind::Derived))
                     && declarator.init.as_ref().is_some_and(|init| {
-                        matches!(
-                            init,
-                            Expression::CallExpression(call)
-                                if call.arguments.first()
-                                    .and_then(|arg| arg.as_expression())
-                                    .is_some_and(|expr| matches!(expr, Expression::AwaitExpression(_)))
-                        )
+                        if let Expression::CallExpression(call) = init {
+                            call.arguments.first()
+                                .and_then(|arg| arg.as_expression())
+                                .is_some_and(|expr| {
+                                    // Direct await: `$derived(await expr)`
+                                    matches!(expr, Expression::AwaitExpression(_))
+                                    // Dev-transformed: `$derived((await $.track_reactivity_loss(expr))())`
+                                    || (dev && matches!(expr, Expression::CallExpression(c)
+                                        if c.arguments.is_empty() && matches!(&c.callee, Expression::AwaitExpression(_))))
+                                })
+                        } else {
+                            false
+                        }
                     })
             },
-            |this, _decl_kind, mut declarator, _| {
+            |this, _decl_kind, decl_span_start, mut declarator, _| {
                 let init = declarator.init.take().unwrap();
-                this.gen_async_derived_destructuring(&declarator.id, init)
+                this.gen_async_derived_destructuring(&declarator.id, init, decl_span_start)
             },
         );
     }
@@ -132,7 +141,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
                     && matches!(rune_kind, Some(RuneKind::State | RuneKind::StateRaw))
                     && declarator.init.is_some()
             },
-            |this, decl_kind, mut declarator, rune_kind| {
+            |this, decl_kind, _decl_span_start, mut declarator, rune_kind| {
                 let init = declarator.init.take().unwrap();
                 let value = if let Expression::CallExpression(mut call) = init {
                     if call.arguments.is_empty() {
@@ -363,6 +372,7 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         &mut self,
         pattern: &oxc_ast::ast::BindingPattern<'a>,
         init: Expression<'a>,
+        decl_span_start: u32,
     ) -> Statement<'a> {
         let Expression::CallExpression(mut call) = init else {
             unreachable!("async derived destructuring should be a call");
@@ -372,16 +382,23 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         let mut dummy = oxc_ast::ast::Argument::from(self.b.cheap_expr());
         std::mem::swap(&mut call.arguments[0], &mut dummy);
         let awaited = dummy.into_expression();
-        let Expression::AwaitExpression(await_expr) = awaited else {
-            unreachable!("async derived destructuring should contain await");
+
+        // In dev mode, the await has been transformed by rewrite_dev_await_tracking
+        // from `await expr` to `(await $.track_reactivity_loss(expr))()`.
+        // We use the already-transformed expression as an async thunk body.
+        let thunk = if let Expression::AwaitExpression(await_expr) = awaited {
+            // Non-dev: strip the outer await, wrap inner in async thunk.
+            let source_expr = await_expr.unbox().argument;
+            let await_inner = self.b.await_expr(source_expr);
+            self.b.async_thunk(await_inner)
+        } else {
+            // Dev: the expression is already `(await $.track_reactivity_loss(expr))()`.
+            // Wrap in `async () => expr` to produce the thunk.
+            self.b.async_arrow_expr_body(awaited)
         };
 
-        let source_expr = await_expr.unbox().argument;
         let tmp_name = self.gen_unique_name("$$d");
         let tmp_name_str = self.b.alloc_str(&tmp_name);
-
-        let await_inner = self.b.await_expr(source_expr);
-        let thunk = self.b.async_thunk(await_inner);
 
         let mut args: Vec<Arg<'a, '_>> = vec![Arg::Expr(thunk)];
         if self.dev {
@@ -391,10 +408,13 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
             };
             let label = format!("[$derived {kind}]");
             args.push(Arg::Expr(self.b.str_expr(&label)));
-            let full_offset = self.script_content_start + init_span_start;
-            let (line, col) = compute_line_col(self.component_source, full_offset);
-            let loc = format!("{}:{}:{}", sanitize_location(self.filename), line, col);
-            args.push(Arg::Expr(self.b.str_expr(&loc)));
+            // Only pass location if not suppressed by svelte-ignore await_waterfall
+            if !self.waterfall_ignored_starts.contains(&decl_span_start) {
+                let full_offset = self.script_content_start + init_span_start;
+                let (line, col) = compute_line_col(self.component_source, full_offset);
+                let loc = format!("{}:{}:{}", sanitize_location(self.filename), line, col);
+                args.push(Arg::Expr(self.b.str_expr(&loc)));
+            }
         }
 
         let async_derived = self.b.call_expr("$.async_derived", args);

--- a/crates/svelte_codegen_client/src/script/traverse/derived.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/derived.rs
@@ -14,6 +14,9 @@ pub(crate) struct DevContext<'a> {
     /// Symbols whose `$derived` init was `$derived(await expr)` — tracked before
     /// `rewrite_dev_await_tracking` can transform the `await` into a different form.
     pub(crate) async_derived_pending: FxHashSet<oxc_semantic::SymbolId>,
+    /// Statement start positions covered by `// svelte-ignore await_waterfall`.
+    /// When matched, the location arg is omitted from `$.async_derived()`.
+    pub(crate) waterfall_ignored_starts: FxHashSet<u32>,
 }
 
 impl DevContext<'_> {
@@ -44,6 +47,7 @@ fn wrap_derived_thunks_in_stmts<'a>(
     for stmt in stmts.iter_mut() {
         match stmt {
             Statement::VariableDeclaration(decl) => {
+                let decl_start = decl.span.start;
                 for declarator in decl.declarations.iter_mut() {
                     let sym_id = match &declarator.id {
                         oxc_ast::ast::BindingPattern::BindingIdentifier(id) => match id.symbol_id.get()
@@ -102,8 +106,11 @@ fn wrap_derived_thunks_in_stmts<'a>(
                                         _ => String::new(),
                                     };
                                     extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&name)));
-                                    let loc = ctx.locate(init_span_start);
-                                    extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&loc)));
+                                    // Only pass location if not suppressed by svelte-ignore await_waterfall
+                                    if !ctx.waterfall_ignored_starts.contains(&decl_start) {
+                                        let loc = ctx.locate(init_span_start);
+                                        extra_args.push(oxc_ast::ast::Argument::from(b.str_expr(&loc)));
+                                    }
                                 }
 
                                 call.arguments[0] = oxc_ast::ast::Argument::from(thunk);

--- a/crates/svelte_diagnostics/src/codes.rs
+++ b/crates/svelte_diagnostics/src/codes.rs
@@ -17,9 +17,14 @@ pub fn legacy_replacement(code: &str) -> Option<&'static str> {
     }
 }
 
-/// Returns true if the code is a valid compile-time warning code.
+/// Runtime-only warnings that can be suppressed via `svelte-ignore` but are not
+/// emitted by the compiler. Matches Svelte's `IGNORABLE_RUNTIME_WARNINGS`.
+const IGNORABLE_RUNTIME_WARNINGS: &[&str] = &["await_waterfall", "await_reactivity_loss"];
+
+/// Returns true if the code is a valid warning code (compile-time or runtime-ignorable).
 pub fn is_valid_warning_code(code: &str) -> bool {
     DiagnosticKind::all_warning_codes().contains(&code)
+        || IGNORABLE_RUNTIME_WARNINGS.contains(&code)
 }
 
 /// Finds the closest match for `input` among `candidates` using Levenshtein distance.

--- a/specs/experimental-async.md
+++ b/specs/experimental-async.md
@@ -2,12 +2,11 @@
 
 ## Current state
 
-- **Working**: Infrastructure, block wrapping for if/each/html/key/await/svelte:element, directive blockers, `$.template_effect()` blockers, shared async memoization plumbing for render/title/template-effect deps, generic async text/attribute memoization, `{@const}` async with `$.run()` + blocker propagation, `$derived` async basic + destructured, `{@render}` async with blockers + complex async args, `<title>` async with `async_values`, `<svelte:boundary>` async const/snippet scoping, `{await expr}` template syntax, pickled awaits (`$.save()`) in template/attr reactive expressions, dev-mode `$.track_reactivity_loss()` for script/template `await`, `$.async_derived()` label+location args in dev mode, `for await...of` dev wrapping with `$.for_await_track_reactivity_loss`, `$.trace` async function body handling
-- **Partially working**: `await_waterfall` warning for async `$derived` still missing
+- **Working**: Infrastructure, block wrapping for if/each/html/key/await/svelte:element, directive blockers, `$.template_effect()` blockers, shared async memoization plumbing for render/title/template-effect deps, generic async text/attribute memoization, `{@const}` async with `$.run()` + blocker propagation, `$derived` async basic + destructured, `{@render}` async with blockers + complex async args, `<title>` async with `async_values`, `<svelte:boundary>` async const/snippet scoping, `{await expr}` template syntax, pickled awaits (`$.save()`) in template/attr reactive expressions, dev-mode `$.track_reactivity_loss()` for script/template `await`, `$.async_derived()` label+location args in dev mode, `for await...of` dev wrapping with `$.for_await_track_reactivity_loss`, `$.trace` async function body handling, `svelte-ignore await_waterfall` suppression (omits location arg from `$.async_derived()`)
 - **Not working**: —
 - **Out of scope**: SSR (`$.await()` server-side — will be separate phase)
-- **Deferred / out of current batch**: `<slot>` async, `await_waterfall` warning
-- **Next**: `await_waterfall` warning for async `$derived`
+- **Deferred / out of current batch**: `<slot>` async
+- **Next**: All client-side async features complete. Remaining: destructured dev test blocked on Tier 6c `$.tag()`.
 - Last updated: 2026-03-31
 
 ## Source
@@ -115,7 +114,7 @@ Audit of existing implementation (2026-03-28)
 
 ### Dev mode
 34. N/A `{#await}` — reference `AwaitBlock.js` does not use `$.apply()`; no action needed
-35. [ ] `$derived` async — `await_waterfall` warning with location (missing)
+35. [x] `$derived` async — `svelte-ignore await_waterfall` suppression (test: async_derived_dev_ignored; destructured test blocked on Tier 6c `$.tag()`)
 36. [x] `$.track_reactivity_loss()` — script + template `await` wrapping, `$.async_derived()` label+location args, `for await...of` wrapping with `$.for_await_track_reactivity_loss` (tests: async_derived_dev, async_for_await_dev)
 
 ### Tracing
@@ -154,8 +153,10 @@ Audit of existing implementation (2026-03-28)
 ### Done: Tracing (#37)
 1. [x] codegen: `$.trace` with async body — `async_thunk_block` + `await` in `inspect.rs`
 
-### Deferred: Dev-mode waterfall warning (#35)
-1. [ ] codegen: `await_waterfall` warning for async `$derived` (deferred to ROADMAP)
+### Done: Dev-mode waterfall warning suppression (#35)
+1. [x] diagnostics: `await_waterfall` + `await_reactivity_loss` added to `IGNORABLE_RUNTIME_WARNINGS`
+2. [x] codegen: scan JS comments for `// svelte-ignore await_waterfall`, omit location arg from `$.async_derived()` when present
+3. [x] codegen: fix destructured async `$derived` predicate to handle dev-transformed `await` form
 
 
 ## Test cases
@@ -183,3 +184,5 @@ Audit of existing implementation (2026-03-28)
 - `async_pickled_await_template` — template pickled await via `$.save()` ✅
 - `async_derived_dev` — `$.async_derived()` with dev label+location args ✅
 - `async_for_await_dev` — `for await...of` dev wrapping with `$.for_await_track_reactivity_loss` ✅
+- `async_derived_dev_ignored` — `svelte-ignore await_waterfall` suppresses location arg ✅
+- `async_derived_dev_ignored_destructured` — destructured variant (ignored: blocked on Tier 6c `$.tag()`) ⏸

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored/case-rust.js
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored/case-rust.js
@@ -1,0 +1,17 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[6, 0]]);
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	var data;
+	var $$promises = $.run([async () => data = await $.async_derived(async () => (await $.track_reactivity_loss(fetch("/api")))(), "data")]);
+	var $$exports = { ...$.legacy_api() };
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(data)), void 0, void 0, [$$promises[0]]);
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored/case-svelte.js
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored/case-svelte.js
@@ -1,0 +1,17 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[6, 0]]);
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	var data;
+	var $$promises = $.run([async () => data = await $.async_derived(async () => (await $.track_reactivity_loss(fetch("/api")))(), "data")]);
+	var $$exports = { ...$.legacy_api() };
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(data)), void 0, void 0, [$$promises[0]]);
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored/case.svelte
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	// svelte-ignore await_waterfall
+	let data = $derived(await fetch('/api'));
+</script>
+
+<p>{data}</p>

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored/config.json
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored/config.json
@@ -1,0 +1,1 @@
+{"experimental": {"async": true}, "dev": true}

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/case-rust.js
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/case-rust.js
@@ -1,0 +1,21 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[6, 0]]);
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	var name, age;
+	var $$promises = $.run([async () => {
+		var $$d = await $.async_derived(async () => (await $.track_reactivity_loss(fetch("/api")))(), "[$derived object]");
+		name = $.derived(() => $.get($$d).name);
+		age = $.derived(() => $.get($$d).age);
+	}]);
+	var $$exports = { ...$.legacy_api() };
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(name) ?? ""} ${$.get(age) ?? ""}`), void 0, void 0, [$$promises[0]]);
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/case-svelte.js
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/case-svelte.js
@@ -1,0 +1,21 @@
+import "svelte/internal/flags/async";
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[6, 0]]);
+export default function App($$anchor, $$props) {
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	var name, age;
+	var $$promises = $.run([async () => {
+		var $$d = await $.async_derived(async () => (await $.track_reactivity_loss(fetch("/api")))(), "[$derived object]");
+		name = $.tag($.derived(() => $.get($$d).name), "name");
+		age = $.tag($.derived(() => $.get($$d).age), "age");
+	}]);
+	var $$exports = { ...$.legacy_api() };
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(name) ?? ""} ${$.get(age) ?? ""}`), void 0, void 0, [$$promises[0]]);
+	$.append($$anchor, p);
+	return $.pop($$exports);
+}

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/case.svelte
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	// svelte-ignore await_waterfall
+	let { name, age } = $derived(await fetch('/api'));
+</script>
+
+<p>{name} {age}</p>

--- a/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/config.json
+++ b/tasks/compiler_tests/cases2/async_derived_dev_ignored_destructured/config.json
@@ -1,0 +1,1 @@
+{"experimental": {"async": true}, "dev": true}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1824,6 +1824,17 @@ fn async_derived_dev() {
 }
 
 #[rstest]
+fn async_derived_dev_ignored() {
+    assert_compiler("async_derived_dev_ignored");
+}
+
+#[rstest]
+#[ignore = "Tier 6c: $.tag() wrapping for destructured derived not implemented"]
+fn async_derived_dev_ignored_destructured() {
+    assert_compiler("async_derived_dev_ignored_destructured");
+}
+
+#[rstest]
 fn async_for_await_dev() {
     assert_compiler("async_for_await_dev");
 }


### PR DESCRIPTION
* feat(experimental-async): dev-mode parity for async_derived and for_await

- Add `$.async_derived()` label+location args in dev mode (name + source location)
- Add `for await...of` dev wrapping with `$.for_await_track_reactivity_loss()`
- Track `async_derived_pending` set in runes.rs before `rewrite_dev_await_tracking`
  transforms `await expr` → `(await $.track_reactivity_loss(expr))()`
- Fix dev-mode async thunk: use `async_arrow_expr_body` (no extra `await`) instead of
  `async_thunk` when arg is already a CallExpression post-transform
- Add `DevContext` struct to `derived.rs` for dev-mode label/location computation
- Tests: async_derived_dev, async_for_await_dev

https://claude.ai/code/session_01Pt1LqdmnEV3iPkgSbQf2cd

* fix(qa): flatten nested dev_ctx guard, improve comment quality

- Flatten `if let Some(ctx) = dev_ctx { if ctx.dev { } }` to
  `dev_ctx.filter(|c| c.dev)` in wrap_derived_thunks_in_stmts
- Replace "what" comments with "why" comments:
  - locate() doc: clarify offset is relative to script block, not component
  - init_span_start comments: explain must read before mem::swap
- Remove pure "what" comments that add no reasoning

https://claude.ai/code/session_01Pt1LqdmnEV3iPkgSbQf2cd

---------

Co-authored-by: Claude <noreply@anthropic.com>