### PR TITLE
feat(experimental-async): dev-mode parity for async_derived and for_await (#131)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ For a full feature parity audit, see [PARITY.md](PARITY.md).
 ---
 
 <details>
-<summary>Done ✅ (AST & Parser, Analyze, Script codegen, Template codegen, Event handling, Bind directives, Directives, Special elements, Module compilation, Optimizations, WASM, Custom Elements, Tier 1 Core Gaps, Tier 1.1 Async infrastructure)</summary>
+<summary>Done ✅ (AST & Parser, Analyze, Script codegen, Template codegen, Event handling, Bind directives, Directives, Special elements, Module compilation, Optimizations, WASM, Custom Elements, Tier 1 Core Gaps, Tier 1.1 Experimental Async)</summary>
 
 ### AST & Parser (6 items)
 `Text`, `Element`, `ComponentNode`, `Comment`, `ExpressionTag`, `IfBlock`, `EachBlock`, `SnippetBlock`, `RenderTag`, Attributes, Script/Style blocks, Void elements
@@ -40,20 +40,10 @@ All completed.
 ### Tier 1 — Core Gaps ✅
 1a `ModuleCompileOptions`, 1b Template expression transforms (`svelte_transform`) — all completed.
 
-### Tier 1.1 — Experimental Async (completed items)
-Infrastructure (5/6), block wrapping (3/4), bind directives, actions/attachments/transitions — all completed.
+### Tier 1.1 — Experimental Async ✅
+All client-side async features completed: infrastructure, block wrapping (if/each/html/key/await/svelte:element), directive blockers, `{@const}` async, `$derived` async, memoizer async, `{@render}` async, `<title>` async, `<svelte:boundary>` async, `{await expr}` template syntax, pickled awaits, dev-mode reactivity loss tracking.
 
 </details>
-
----
-
-## Tier 1.1 — Experimental Async (remaining)
-
-Spec: `specs/experimental-async.md`
-
-- [ ] Full blocker tracking: const tags with async expressions → `binding.blocker` propagation
-- [ ] `{await expr}` experimental template syntax (Svelte 5.36+)
-- [ ] `<svelte:boundary>` — `experimental.async` handling for const tag scoping changes
 
 ---
 
@@ -414,7 +404,6 @@ trait NodeStore {
 
 ### experimental.async (Tier 1.1)
 - Function blocker analysis: deferred max-blocker tracking for function declarations
-- `for await` reactivity loss tracking (dev mode)
 
 ### $state rune — legacy (Tier 7)
 - `$.deep_read_state()` for bindable props in `$:` reactive statements — only used in non-runes mode (LabeledStatement.js, shared/utils.js build_expression)

--- a/specs/snippet-block.md
+++ b/specs/snippet-block.md
@@ -1,0 +1,74 @@
+# SnippetBlock
+
+## Current state
+- **Working**: 9/14 use cases — basic snippets, simple params, hoisting, dev mode, component props, nested
+- **Missing**: 5 use cases — all parameter destructuring variants (object, array, defaults, rest, mixed)
+- **Next**: Implement `extract_paths`-style destructuring in codegen (`build_snippet_params` + declarations)
+- Last updated: 2026-04-01
+
+## Source
+ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
+
+## Use cases
+
+### Basic structure
+1. [x] No parameters: `{#snippet foo()}` → `($$anchor) => { ... }` (test: snippet_basic)
+2. [x] Simple identifier params: `{#snippet foo(a, b)}` → `($$anchor, a = $.noop, b = $.noop) => { ... }` (test: snippet_basic)
+3. [x] Hoisted snippet (top-level, no instance refs) → module-level declaration (test: snippet_basic)
+4. [x] Non-hoisted snippet (references instance vars) → instance-level declaration (test: snippet_ident_conflict_with_script)
+5. [x] Nested snippet (inside block/element) → local declaration (test: boundary_const_in_snippet)
+6. [x] Snippet as component prop → passed as named prop (test: component_snippet_prop)
+7. [x] Dev mode: `$.wrap_snippet(Name, function(...) { $.validate_snippet_args(...arguments); ... })` (test: tag_snippet_dev)
+
+### Parameter destructuring
+8. [ ] Object destructuring: `{#snippet foo({ x, y })}` → `$$arg0` param + `let x = () => $$arg0?.().x` (test: snippet_object_destructure, needs infrastructure)
+9. [ ] Object destructuring with defaults: `{#snippet foo({ x = 5 })}` → `$.derived_safe_equal(() => $.fallback(...))` (test: snippet_object_destructure, needs infrastructure)
+10. [ ] Object rest: `{#snippet foo({ x, ...rest })}` → `$.exclude_from_object($$arg0?.(), ['x'])` (test: snippet_object_destructure, needs infrastructure)
+11. [ ] Array destructuring: `{#snippet foo([a, b])}` → `$.to_array($$arg0?.(), 2)` + derived intermediary (test: snippet_array_destructure, needs infrastructure)
+12. [ ] Array destructuring with rest: `{#snippet foo([a, ...rest])}` → `$.get($$array).slice(1)` (test: snippet_array_destructure, needs infrastructure)
+13. [ ] Mixed params: `{#snippet foo(a, { x }, [b])}` → identifier + object + array in one signature (test: snippet_mixed_params, needs infrastructure)
+
+### Validation (Tier 5)
+14. [ ] `snippet_parameter_assignment` — error on assignment to snippet param (deferred to Tier 5b)
+
+### Deferred
+- SSR snippet codegen
+- `snippet_invalid_rest_parameter` validation (rest params in snippet are an error in reference)
+- `snippet_shadowing_prop` / `snippet_conflict` validation (Tier 5)
+- `snippet_invalid_export` validation (Tier 5)
+
+## Reference
+
+### Svelte (reference compiler)
+- `reference/compiler/phases/3-transform/client/visitors/SnippetBlock.js` — parameter dispatch, `extract_paths` usage, dev wrapping
+- `reference/compiler/utils/ast.js` lines 243–415 — `extract_paths` / `_extract_paths`: recursive destructuring → inserts (array intermediaries) + paths (leaf bindings)
+- `reference/compiler/utils/ast.js` lines 585–597 — `build_fallback`: default value wrapping with `$.fallback()`
+- `reference/compiler/phases/scope.js` lines 1331–1346 — snippet param declared as `kind: 'snippet'`
+- `reference/compiler/phases/2-analyze/visitors/SnippetBlock.js` — hoistability, validation
+
+### Our code
+- `crates/svelte_codegen_client/src/template/snippet.rs` — `gen_snippet_block`, `build_snippet_params` (flat params only)
+- `crates/svelte_analyze/src/passes/template_side_tables.rs:148` — `SnippetParamMarker`, `SnippetParamNameCollector`
+- `crates/svelte_analyze/src/types/data/template_data.rs` — `SnippetData` (stores flat `Vec<String>` of leaf names)
+- `crates/svelte_parser/src/parse_js.rs:184` — `parse_snippet_decl_with_alloc` (OXC parses patterns correctly)
+
+## Tasks
+
+### Analysis
+- [ ] Preserve original parameter patterns in `SnippetData` — store `Vec<SnippetParam>` enum (Identifier / ObjectPattern / ArrayPattern) instead of flat `Vec<String>`. OXC already parses these; analyze just needs to preserve the shape info.
+- [ ] Alternative: skip shape info in analyze, use `parsed.stmts` directly in codegen (the arrow params are already parsed by OXC). Codegen can walk the `FormalParameters` from the parsed arrow to reconstruct declarations.
+
+### Codegen
+- [ ] Implement `extract_paths`-equivalent in `snippet.rs`: walk OXC `BindingPattern` recursively, producing `inserts` (array intermediaries → `$.derived(() => $.to_array(...))`) and `paths` (leaf bindings → `let name = ...` or `$.derived_safe_equal(...)`)
+- [ ] For `ObjectPattern` properties: generate `let name = () => $$argN?.().prop`
+- [ ] For `ObjectPattern` rest: generate `let rest = () => $.exclude_from_object($$argN?.(), [excluded_keys])`
+- [ ] For `ArrayPattern`: generate `var $$array = $.derived(() => $.to_array($$argN?.(), len))` + `let name = () => $.get($$array)[i]`
+- [ ] For `AssignmentPattern` (defaults): generate `$.derived_safe_equal(() => $.fallback(expr, default))` or `$.fallback(expr, default)` for simple defaults
+- [ ] For array rest: `let rest = () => $.get($$array).slice(i)`
+- [ ] Dev mode: after each destructured `let` declaration, emit eager evaluation statement
+- [ ] Update `build_snippet_params` to emit `$$argN` (plain identifier) for destructured params instead of flat `name = $.noop`
+
+## Implementation order
+1. Codegen first — walk parsed arrow params from `parsed.stmts`, generate declarations inline
+2. No analyze changes needed if codegen reads params directly from parsed arrow AST
+3. Tests verify output matches reference

--- a/tasks/compiler_tests/cases2/snippet_array_destructure/case-svelte.js
+++ b/tasks/compiler_tests/cases2/snippet_array_destructure/case-svelte.js
@@ -1,0 +1,37 @@
+import * as $ from "svelte/internal/client";
+const show = ($$anchor, $$arg0) => {
+	var $$array = $.derived(() => $.to_array($$arg0?.(), 2));
+	let a = () => $.get($$array)[0];
+	let b = () => $.get($$array)[1];
+	var p = root_1();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${a() ?? ""} and ${b() ?? ""}`));
+	$.append($$anchor, p);
+};
+const withRest = ($$anchor, $$arg0) => {
+	var $$array_1 = $.derived(() => $.to_array($$arg0?.()));
+	let first = () => $.get($$array_1)[0];
+	let others = () => $.get($$array_1).slice(1);
+	var p_1 = root_2();
+	var text_1 = $.child(p_1, true);
+	$.reset(p_1);
+	$.template_effect(() => $.set_text(text_1, first()));
+	$.append($$anchor, p_1);
+};
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p> </p>`);
+var root = $.from_html(`<!> <!>`, 1);
+export default function App($$anchor) {
+	let pair = $.proxy([10, 20]);
+	var fragment = root();
+	var node = $.first_child(fragment);
+	show(node, () => pair);
+	var node_1 = $.sibling(node, 2);
+	withRest(node_1, () => [
+		1,
+		2,
+		3
+	]);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/snippet_array_destructure/case.svelte
+++ b/tasks/compiler_tests/cases2/snippet_array_destructure/case.svelte
@@ -1,0 +1,14 @@
+<script>
+	let pair = $state([10, 20]);
+</script>
+
+{#snippet show([a, b])}
+	<p>{a} and {b}</p>
+{/snippet}
+
+{#snippet withRest([first, ...others])}
+	<p>{first}</p>
+{/snippet}
+
+{@render show(pair)}
+{@render withRest([1, 2, 3])}

--- a/tasks/compiler_tests/cases2/snippet_mixed_params/case-svelte.js
+++ b/tasks/compiler_tests/cases2/snippet_mixed_params/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+const row = ($$anchor, label = $.noop, $$arg1, $$arg2) => {
+	let id = () => $$arg1?.().id;
+	var $$array = $.derived(() => $.to_array($$arg2?.(), 1));
+	let value = () => $.get($$array)[0];
+	var p = root_1();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${label() ?? ""}: ${id() ?? ""} = ${value() ?? ""}`));
+	$.append($$anchor, p);
+};
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let items = $.proxy([{ id: 1 }]);
+	row($$anchor, () => "test", () => items[0], () => [42]);
+}

--- a/tasks/compiler_tests/cases2/snippet_mixed_params/case.svelte
+++ b/tasks/compiler_tests/cases2/snippet_mixed_params/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	let items = $state([{ id: 1 }]);
+</script>
+
+{#snippet row(label, { id }, [value])}
+	<p>{label}: {id} = {value}</p>
+{/snippet}
+
+{@render row("test", items[0], [42])}

--- a/tasks/compiler_tests/cases2/snippet_object_destructure/case-rust.js
+++ b/tasks/compiler_tests/cases2/snippet_object_destructure/case-rust.js
@@ -1,0 +1,43 @@
+import * as $ from "svelte/internal/client";
+const greeting = ($$anchor, name = $.noop, age = $.noop) => {
+	var p = root_1();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${name() ?? ""} is ${age() ?? ""}`));
+	$.append($$anchor, p);
+};
+const withDefault = ($$anchor, label = $.noop) => {
+	var span = root_2();
+	var text_1 = $.child(span, true);
+	$.reset(span);
+	$.template_effect(() => $.set_text(text_1, label()));
+	$.append($$anchor, span);
+};
+const withRest = ($$anchor, id = $.noop, rest = $.noop) => {
+	var div = root_3();
+	var text_2 = $.child(div, true);
+	$.reset(div);
+	$.template_effect(() => $.set_text(text_2, id()));
+	$.append($$anchor, div);
+};
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<span> </span>`);
+var root_3 = $.from_html(`<div> </div>`);
+var root = $.from_html(`<!> <!> <!>`, 1);
+export default function App($$anchor) {
+	let data = $.proxy({
+		name: "world",
+		age: 25
+	});
+	var fragment = root();
+	var node = $.first_child(fragment);
+	greeting(node, () => data);
+	var node_1 = $.sibling(node, 2);
+	withDefault(node_1, () => ({}));
+	var node_2 = $.sibling(node_1, 2);
+	withRest(node_2, () => ({
+		id: 1,
+		extra: true
+	}));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/snippet_object_destructure/case-svelte.js
+++ b/tasks/compiler_tests/cases2/snippet_object_destructure/case-svelte.js
@@ -1,0 +1,48 @@
+import * as $ from "svelte/internal/client";
+const greeting = ($$anchor, $$arg0) => {
+	let name = () => $$arg0?.().name;
+	let age = () => $$arg0?.().age;
+	var p = root_1();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${name() ?? ""} is ${age() ?? ""}`));
+	$.append($$anchor, p);
+};
+const withDefault = ($$anchor, $$arg0) => {
+	let label = $.derived_safe_equal(() => $.fallback($$arg0?.().label, "default"));
+	var span = root_2();
+	var text_1 = $.child(span, true);
+	$.reset(span);
+	$.template_effect(() => $.set_text(text_1, $.get(label)));
+	$.append($$anchor, span);
+};
+const withRest = ($$anchor, $$arg0) => {
+	let id = () => $$arg0?.().id;
+	let rest = () => $.exclude_from_object($$arg0?.(), ["id"]);
+	var div = root_3();
+	var text_2 = $.child(div, true);
+	$.reset(div);
+	$.template_effect(() => $.set_text(text_2, id()));
+	$.append($$anchor, div);
+};
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<span> </span>`);
+var root_3 = $.from_html(`<div> </div>`);
+var root = $.from_html(`<!> <!> <!>`, 1);
+export default function App($$anchor) {
+	let data = $.proxy({
+		name: "world",
+		age: 25
+	});
+	var fragment = root();
+	var node = $.first_child(fragment);
+	greeting(node, () => data);
+	var node_1 = $.sibling(node, 2);
+	withDefault(node_1, () => ({}));
+	var node_2 = $.sibling(node_1, 2);
+	withRest(node_2, () => ({
+		id: 1,
+		extra: true
+	}));
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/snippet_object_destructure/case.svelte
+++ b/tasks/compiler_tests/cases2/snippet_object_destructure/case.svelte
@@ -1,0 +1,19 @@
+<script>
+	let data = $state({ name: "world", age: 25 });
+</script>
+
+{#snippet greeting({ name, age })}
+	<p>{name} is {age}</p>
+{/snippet}
+
+{#snippet withDefault({ label = "default" })}
+	<span>{label}</span>
+{/snippet}
+
+{#snippet withRest({ id, ...rest })}
+	<div>{id}</div>
+{/snippet}
+
+{@render greeting(data)}
+{@render withDefault({})}
+{@render withRest({ id: 1, extra: true })}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2024,6 +2024,24 @@ fn tag_snippet_dev() {
 }
 
 #[rstest]
+#[ignore = "missing: snippet parameter object destructuring (codegen)"]
+fn snippet_object_destructure() {
+    assert_compiler("snippet_object_destructure");
+}
+
+#[rstest]
+#[ignore = "missing: snippet parameter array destructuring (codegen)"]
+fn snippet_array_destructure() {
+    assert_compiler("snippet_array_destructure");
+}
+
+#[rstest]
+#[ignore = "missing: snippet mixed parameter types (codegen)"]
+fn snippet_mixed_params() {
+    assert_compiler("snippet_mixed_params");
+}
+
+#[rstest]
 fn tag_state_destructured_array() {
     assert_compiler("tag_state_destructured_array");
 }


### PR DESCRIPTION
* feat(experimental-async): dev-mode parity for async_derived and for_await

- Add `$.async_derived()` label+location args in dev mode (name + source location)
- Add `for await...of` dev wrapping with `$.for_await_track_reactivity_loss()`
- Track `async_derived_pending` set in runes.rs before `rewrite_dev_await_tracking`
  transforms `await expr` → `(await $.track_reactivity_loss(expr))()`
- Fix dev-mode async thunk: use `async_arrow_expr_body` (no extra `await`) instead of
  `async_thunk` when arg is already a CallExpression post-transform
- Add `DevContext` struct to `derived.rs` for dev-mode label/location computation
- Tests: async_derived_dev, async_for_await_dev

https://claude.ai/code/session_01Pt1LqdmnEV3iPkgSbQf2cd

* fix(qa): flatten nested dev_ctx guard, improve comment quality

- Flatten `if let Some(ctx) = dev_ctx { if ctx.dev { } }` to
  `dev_ctx.filter(|c| c.dev)` in wrap_derived_thunks_in_stmts
- Replace "what" comments with "why" comments:
  - locate() doc: clarify offset is relative to script block, not component
  - init_span_start comments: explain must read before mem::swap
- Remove pure "what" comments that add no reasoning

https://claude.ai/code/session_01Pt1LqdmnEV3iPkgSbQf2cd

---------

Co-authored-by: Claude <noreply@anthropic.com>