### PR TITLE
Add test cases for sync destructured $derived patterns

### DIFF
--- a/specs/derived-state.md
+++ b/specs/derived-state.md
@@ -1,0 +1,106 @@
+# $derived / $derived.by
+
+## Current state
+
+**Updated: 2026-04-01**
+
+Core `$derived` and `$derived.by` are fully implemented for simple identifier bindings (sync and async), class fields, nested functions, and dev mode. 21 existing tests all pass.
+
+**Gaps found:**
+1. Sync destructured `$derived(expr)` — not implemented (codegen skips non-Identifier patterns in `wrap_derived_thunks`)
+2. Sync destructured `$derived.by(fn)` — same gap
+3. `derived_invalid_export` diagnostic — defined but never emitted from analyze
+4. `state_referenced_locally` warning — not emitted for derived bindings
+5. `$.save()` for nested async derived (`function_depth > 1`) — unknown, no test
+
+**Next:** Add test cases for gaps, then fix starting with sync destructured `$derived`.
+
+## Source
+
+ROADMAP.md — `$derived` rune (core reactivity)
+
+## Use cases
+
+### Implemented
+- [x] Basic `$derived(expr)` → `$.derived(() => expr)`
+- [x] `$derived.by(fn)` → `$.derived(fn)`
+- [x] `$derived` in nested function scope
+- [x] `$derived.by` in nested function scope
+- [x] `$derived` class field (`area = $derived(this.width * this.height)`)
+- [x] Constructor assignment `this.x = $derived(...)`
+- [x] Read access rewritten to `$.get(x)`
+- [x] Dev mode `$.tag($.derived(...), "name")` wrapping
+- [x] Async `$derived(await expr)` → `await $.async_derived(async () => expr)`
+- [x] Async destructured `$derived(await expr)` with intermediate variable
+- [x] Async dev mode with label and location args
+- [x] Async dev mode with `svelte-ignore await_waterfall` suppression
+- [x] `@const` tag bindings treated as derived
+
+### In scope
+- [ ] Sync destructured `$derived(expr)` where arg is plain Identifier (no intermediate var)
+- [ ] Sync destructured `$derived(expr)` where arg is NOT plain Identifier (intermediate `$$d` var)
+- [ ] Sync destructured `$derived.by(fn)` (intermediate `$$d` var)
+- [ ] `derived_invalid_export` diagnostic when `export`ing derived binding
+- [ ] `state_referenced_locally` warning for derived bindings read at same function depth
+
+### Deferred
+- `$.save()` for nested async derived (`function_depth > 1`) — needs async infrastructure
+- `rune_invalid_usage` in non-runes mode — broader runes validation scope
+
+## Reference
+
+### Reference compiler files
+- `reference/compiler/phases/3-transform/client/visitors/VariableDeclaration.js:192-291` — all transform paths
+- `reference/compiler/phases/2-analyze/visitors/CallExpression.js:117-135` — placement validation
+- `reference/compiler/phases/2-analyze/visitors/CallExpression.js:245-257` — async_deriveds detection
+- `reference/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js:40-42` — derived_invalid_export
+- `reference/compiler/phases/2-analyze/visitors/Identifier.js:117` — state_referenced_locally warning
+- `reference/compiler/phases/2-analyze/visitors/VariableDeclarator.js:29-65` — binding.kind = 'derived'
+- `reference/compiler/phases/2-analyze/visitors/shared/declarations.js:22-23` — read transform registration
+
+### Our files
+- `crates/svelte_analyze/src/types/script.rs` — `RuneKind::Derived`, `RuneKind::DerivedBy`
+- `crates/svelte_analyze/src/utils/script_info.rs` — `detect_rune`, `collect_derived_refs`
+- `crates/svelte_analyze/src/passes/mark_runes.rs` — `mark_script_runes`, `mark_nested_runes`
+- `crates/svelte_analyze/src/scope.rs` — `Rune.derived_deps`, `is_dynamic_by_id`
+- `crates/svelte_analyze/src/validate/runes.rs` — placement and argument validation
+- `crates/svelte_codegen_client/src/script/traverse/runes.rs` — `rewrite_variable_rune_init`, `rewrite_identifier_expression`
+- `crates/svelte_codegen_client/src/script/traverse/derived.rs` — `wrap_derived_thunks` (only handles BindingIdentifier)
+- `crates/svelte_codegen_client/src/script/state.rs` — `process_async_derived_destructuring`, `gen_derived_destructure_assignments`
+- `crates/svelte_diagnostics/src/lib.rs` — `DerivedInvalidExport`, `StateReferencedLocally`
+
+## Tasks
+
+### Codegen: Sync destructured $derived
+- **File:** `crates/svelte_codegen_client/src/script/traverse/derived.rs`
+- Extend `wrap_derived_thunks` to handle destructured patterns (ObjectPattern/ArrayPattern)
+- Reference: `VariableDeclaration.js:227-288` — Path 4 (Identifier arg, no intermediate) and Path 5 (non-Identifier arg, intermediate `$$d`)
+- Need `extract_paths` equivalent for destructuring into individual `$.derived(() => path)` declarations
+
+### Analyze: derived_invalid_export diagnostic
+- **File:** `crates/svelte_analyze/src/validate/runes.rs` (or export validation pass)
+- Emit `DerivedInvalidExport` when an `ExportNamedDeclaration` contains a derived binding
+- Reference: `ExportNamedDeclaration.js:40-42`
+
+### Analyze: state_referenced_locally warning for derived
+- **File:** `crates/svelte_analyze/src/` (identifier visitor or validation)
+- Emit `StateReferencedLocally` when a derived binding is read at the same function depth as its declaration
+- Reference: `Identifier.js:117`
+
+## Test cases
+
+### Existing (all pass)
+- `derived_basic`, `derived_by`, `derived_by_inside_function`
+- `derived_class_field`, `derived_dynamic`, `derived_in_nested_function`
+- `derived_inside_function`, `derived_local_signal_get`, `derived_nested_getter`
+- `derived_shorthand_property`, `tag_derived_basic`, `tag_derived_by`
+- `state_constructor_read_derived`
+- `event_handler_derived_with_class_directives`, `event_handler_derived_with_class_object`
+- `async_derived_basic`, `async_derived_destructured`
+- `async_derived_dev`, `async_derived_dev_ignored`, `async_derived_dev_ignored_destructured`
+- `async_const_derived_chain`
+
+### Planned
+- `derived_destructured_object` — sync destructured `$derived` with object pattern
+- `derived_destructured_array` — sync destructured `$derived` with array pattern
+- `derived_destructured_by` — sync destructured `$derived.by` with object pattern

--- a/tasks/compiler_tests/cases2/derived_destructured_array/case-svelte.js
+++ b/tasks/compiler_tests/cases2/derived_destructured_array/case-svelte.js
@@ -1,0 +1,15 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let items = $.proxy([
+		1,
+		2,
+		3
+	]);
+	let $$array = $.derived(() => $.to_array(items)), first = $.derived(() => $.get($$array)[0]), second = $.derived(() => $.get($$array)[1]), rest = $.derived(() => $.get($$array).slice(2));
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(first) ?? ""},${$.get(second) ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/derived_destructured_array/case.svelte
+++ b/tasks/compiler_tests/cases2/derived_destructured_array/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let items = $state([1, 2, 3]);
+	let [first, second, ...rest] = $derived(items);
+</script>
+
+<p>{first},{second}</p>

--- a/tasks/compiler_tests/cases2/derived_destructured_by/case-svelte.js
+++ b/tasks/compiler_tests/cases2/derived_destructured_by/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let data = $.proxy({
+		a: 1,
+		b: 2
+	});
+	let $$d = $.derived(() => data), a = $.derived(() => $.get($$d).a), b = $.derived(() => $.get($$d).b);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(a) ?? ""},${$.get(b) ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/derived_destructured_by/case.svelte
+++ b/tasks/compiler_tests/cases2/derived_destructured_by/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let data = $state({ a: 1, b: 2 });
+	let { a, b } = $derived.by(() => data);
+</script>
+
+<p>{a},{b}</p>

--- a/tasks/compiler_tests/cases2/derived_destructured_object/case-rust.js
+++ b/tasks/compiler_tests/cases2/derived_destructured_object/case-rust.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let coords = $.proxy({
+		x: 0,
+		y: 0
+	});
+	let { x, y } = $derived(coords);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(x) ?? ""},${$.get(y) ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/derived_destructured_object/case-svelte.js
+++ b/tasks/compiler_tests/cases2/derived_destructured_object/case-svelte.js
@@ -1,0 +1,14 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	let coords = $.proxy({
+		x: 0,
+		y: 0
+	});
+	let x = $.derived(() => coords.x), y = $.derived(() => coords.y);
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$.get(x) ?? ""},${$.get(y) ?? ""}`));
+	$.append($$anchor, p);
+}

--- a/tasks/compiler_tests/cases2/derived_destructured_object/case.svelte
+++ b/tasks/compiler_tests/cases2/derived_destructured_object/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	let coords = $state({ x: 0, y: 0 });
+	let { x, y } = $derived(coords);
+</script>
+
+<p>{x},{y}</p>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1989,6 +1989,24 @@ fn tag_derived_by() {
 }
 
 #[rstest]
+#[ignore = "missing: sync destructured $derived with object pattern (codegen)"]
+fn derived_destructured_object() {
+    assert_compiler("derived_destructured_object");
+}
+
+#[rstest]
+#[ignore = "missing: sync destructured $derived with array pattern (codegen)"]
+fn derived_destructured_array() {
+    assert_compiler("derived_destructured_array");
+}
+
+#[rstest]
+#[ignore = "missing: sync destructured $derived.by (codegen)"]
+fn derived_destructured_by() {
+    assert_compiler("derived_destructured_by");
+}
+
+#[rstest]
 fn tag_state_unmutated() {
     assert_compiler("tag_state_unmutated");
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive test cases and documentation for sync destructured `$derived` and `$derived.by` patterns, which are currently not implemented in the codegen. Three new test cases are introduced with both Svelte source and expected compiled output, along with a detailed specification document tracking implementation gaps and next steps.

## Key Changes

- **Added specification document** (`specs/derived-state.md`):
  - Documents current implementation status of `$derived` and `$derived.by` runes
  - Identifies 5 specific gaps including sync destructured patterns, missing diagnostics, and warnings
  - Maps reference compiler implementation paths to our codebase files
  - Provides detailed task breakdown for remaining work with file locations and references

- **Added three new test cases** (all marked as ignored pending implementation):
  - `derived_destructured_object`: Tests object destructuring with `$derived(expr)`
    - Expected output: Individual `$.derived()` calls for each destructured property
  - `derived_destructured_array`: Tests array destructuring with `$derived(expr)`
    - Expected output: Intermediate `$$array` variable with individual derived bindings for each element
  - `derived_destructured_by`: Tests object destructuring with `$derived.by(fn)`
    - Expected output: Intermediate `$$d` variable with individual derived bindings for each property

- **Updated test runner** (`tasks/compiler_tests/test_v3.rs`):
  - Registered three new test cases with appropriate ignore messages indicating missing codegen support

## Implementation Details

Each test case includes:
- **case.svelte**: The source Svelte component using destructured `$derived` patterns
- **case-svelte.js**: Expected compiled output showing the transformation to individual `$.derived()` calls
- **case-rust.js** (object only): Alternative representation for reference

The test cases follow the reference compiler's transformation patterns:
- Sync destructured `$derived(expr)` with plain Identifier → direct property access in derived thunks
- Sync destructured `$derived(expr)` with non-Identifier → intermediate `$$d` variable
- Sync destructured `$derived.by(fn)` → intermediate `$$d` variable with derived property accessors

These tests are ready to pass once `wrap_derived_thunks` in `crates/svelte_codegen_client/src/script/traverse/derived.rs` is extended to handle destructured patterns.

https://claude.ai/code/session_01BPbMrhY4Q5iSZ87G2Fkk69