### PR TITLE
Add missing await block test cases for pending/catch variants

### DIFF
--- a/specs/await-block.md
+++ b/specs/await-block.md
@@ -1,0 +1,77 @@
+# Await Block
+
+## Current state
+- **Working**: 16/16 use cases (100%)
+- **Missing**: None — all use cases covered and passing
+- **Next**: Feature complete. Diagnostics deferred.
+- Last updated: 2026-04-01
+
+## Source
+Audit of existing implementation (2026-04-01)
+
+## Use cases
+
+### Parser variants
+1. [x] Full form: `{#await expr}...{:then val}...{:catch err}...{/await}` (test: `await_basic`)
+2. [x] Pending only: `{#await expr}...{/await}` (test: `await_pending_only`)
+3. [x] Shorthand then: `{#await expr then val}...{/await}` (test: `await_short_then`)
+4. [x] Shorthand catch: `{#await expr catch err}...{/await}` (test: `await_short_catch`)
+5. [x] Shorthand then + separate catch: `{#await expr then val}...{:catch err}...{/await}` (test: `await_then_catch`)
+6. [x] No bindings (separate): `{#await expr}...{:then}...{:catch}...{/await}` (test: `await_no_bindings`)
+7. [x] Pending + separate then (no catch): `{#await expr}...{:then val}...{/await}` (test: `await_pending_then`)
+8. [x] Pending + separate catch (no then): `{#await expr}...{:catch err}...{/await}` (test: `await_pending_catch`)
+9. [x] Shorthand catch without binding: `{#await expr catch}...{/await}` (test: `await_short_catch_no_binding`)
+
+### Codegen variants
+10. [x] Basic `$.await(anchor, thunk, pending, then, catch)` (test: `await_basic`)
+11. [x] Thunk optimization for call expressions (test: `await_thunk_optimization`)
+12. [x] Async thunk when expression has `await` keyword (test: `async_await_has_await`)
+13. [x] Destructured then: object `{a, b}` (test: `await_destructured`)
+14. [x] Destructured then: array `[a, b]` (test: `await_array_destructured`)
+15. [x] Reactive expression (test: `await_reactive`)
+
+### Nesting / composition
+16. [x] Await inside each (test: `await_in_each`)
+17. [x] Await inside if (test: `await_in_if`)
+18. [x] Each inside await (test: `await_each_nested`)
+19. [x] Rich content in all branches (test: `await_nested_content`)
+20. [x] Text before element in then (test: `await_then_text_before_element`)
+21. [x] Nested await (await inside await) (test: `await_nested_await`)
+
+### Experimental async
+22. [x] `$.async()` wrapping with blockers (test: `async_await_has_await`)
+23. [x] Pickled await in template (test: `async_pickled_await_template`)
+
+### Deferred
+- SSR: `$.await()` server-side rendering — separate phase
+- Diagnostics: `block_duplicate_clause` error for duplicate `:then`/`:catch`
+- Diagnostics: `block_unexpected_character` validation for whitespace before `:then`/`:catch`
+
+## Reference
+
+### Svelte (reference compiler)
+- `reference/compiler/phases/1-parse/state/tag.js` — `{#await}`, `{:then}`, `{:catch}` parsing
+- `reference/compiler/phases/2-analyze/visitors/AwaitBlock.js` — validation, `mark_subtree_dynamic`
+- `reference/compiler/phases/3-transform/client/visitors/AwaitBlock.js` — `$.await()` codegen, `create_derived_block_argument`
+- `reference/compiler/types/template.d.ts` — `AwaitBlock` AST type definition
+
+### Our code
+- `crates/svelte_ast/src/lib.rs` — `AwaitBlock` AST node
+- `crates/svelte_parser/src/scanner/token.rs` — `StartAwaitTag`, `AwaitClauseTag`
+- `crates/svelte_parser/src/handlers.rs` — `handle_await_clause_tag`, `handle_end_await_tag`
+- `crates/svelte_analyze/src/passes/reactivity.rs` — marks await as dynamic
+- `crates/svelte_analyze/src/passes/template_scoping.rs` — then/catch variable scoping
+- `crates/svelte_analyze/src/passes/lower.rs` — fragment lowering for pending/then/catch
+- `crates/svelte_codegen_client/src/template/await_block.rs` — `gen_await_block`, `gen_await_callback`
+
+## Tasks
+
+### Parser
+- All parser variants working — no changes needed
+
+### Analysis
+- All analysis working — no changes needed
+
+### Codegen
+- All codegen patterns working — no changes needed
+- Missing tests are for existing code paths, not missing implementation

--- a/tasks/compiler_tests/cases2/await_nested_await/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_nested_await/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const outer = fetch("/api/list");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => outer, null, ($$anchor, items) => {
+		var fragment_1 = $.comment();
+		var node_1 = $.first_child(fragment_1);
+		$.await(node_1, () => $.get(items)[0], null, ($$anchor, detail) => {
+			var p = root_2();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, $.get(detail)));
+			$.append($$anchor, p);
+		});
+		$.append($$anchor, fragment_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_nested_await/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_nested_await/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_2 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const outer = fetch("/api/list");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => outer, null, ($$anchor, items) => {
+		var fragment_1 = $.comment();
+		var node_1 = $.first_child(fragment_1);
+		$.await(node_1, () => $.get(items)[0], null, ($$anchor, detail) => {
+			var p = root_2();
+			var text = $.child(p, true);
+			$.reset(p);
+			$.template_effect(() => $.set_text(text, $.get(detail)));
+			$.append($$anchor, p);
+		});
+		$.append($$anchor, fragment_1);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_nested_await/case.svelte
+++ b/tasks/compiler_tests/cases2/await_nested_await/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	const outer = fetch('/api/list');
+</script>
+
+{#await outer then items}
+	{#await items[0] then detail}
+		<p>{detail}</p>
+	{/await}
+{/await}

--- a/tasks/compiler_tests/cases2/await_pending_catch/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_pending_catch/case-rust.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_1 = root_2();
+		$.append($$anchor, p_1);
+	}, void 0, ($$anchor, error) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(error).message));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_pending_catch/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_pending_catch/case-svelte.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_1 = root_2();
+		$.append($$anchor, p_1);
+	}, void 0, ($$anchor, error) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(error).message));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_pending_catch/case.svelte
+++ b/tasks/compiler_tests/cases2/await_pending_catch/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise}
+	<p>Loading...</p>
+{:catch error}
+	<p>{error.message}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_pending_then/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_pending_then/case-rust.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_1 = root_2();
+		$.append($$anchor, p_1);
+	}, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_pending_then/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_pending_then/case-svelte.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p> </p>`);
+var root_2 = $.from_html(`<p>Loading...</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, ($$anchor) => {
+		var p_1 = root_2();
+		$.append($$anchor, p_1);
+	}, ($$anchor, value) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(value)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_pending_then/case.svelte
+++ b/tasks/compiler_tests/cases2/await_pending_then/case.svelte
@@ -1,0 +1,9 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise}
+	<p>Loading...</p>
+{:then value}
+	<p>{value}</p>
+{/await}

--- a/tasks/compiler_tests/cases2/await_short_catch_no_binding/case-rust.js
+++ b/tasks/compiler_tests/cases2/await_short_catch_no_binding/case-rust.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Something went wrong</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, void 0, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_short_catch_no_binding/case-svelte.js
+++ b/tasks/compiler_tests/cases2/await_short_catch_no_binding/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<p>Something went wrong</p>`);
+export default function App($$anchor) {
+	const promise = fetch("/api");
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.await(node, () => promise, null, void 0, ($$anchor) => {
+		var p = root_1();
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/await_short_catch_no_binding/case.svelte
+++ b/tasks/compiler_tests/cases2/await_short_catch_no_binding/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	const promise = fetch('/api');
+</script>
+
+{#await promise catch}
+	<p>Something went wrong</p>
+{/await}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -1929,6 +1929,26 @@ fn await_each_nested() {
 }
 
 #[rstest]
+fn await_pending_then() {
+    assert_compiler("await_pending_then");
+}
+
+#[rstest]
+fn await_pending_catch() {
+    assert_compiler("await_pending_catch");
+}
+
+#[rstest]
+fn await_short_catch_no_binding() {
+    assert_compiler("await_short_catch_no_binding");
+}
+
+#[rstest]
+fn await_nested_await() {
+    assert_compiler("await_nested_await");
+}
+
+#[rstest]
 fn fragment_counter_with_nested_if() {
     assert_compiler("fragment_counter_with_nested_if");
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for await block variants that were previously untested, including pending-only with separate then/catch clauses, catch without binding, and nested await blocks.

## Changes
- **Test spec update** (`specs/await-block.md`): Documents feature-complete await block implementation with all 23 use cases passing
- **New test cases added**:
  - `await_pending_then`: Pending state + separate then clause (no catch)
  - `await_pending_catch`: Pending state + separate catch clause (no then)
  - `await_short_catch_no_binding`: Catch clause without error binding
  - `await_nested_await`: Nested await blocks (await inside await's then clause)
- **Test runner** (`test_v3.rs`): Registered 4 new compiler test cases

## Implementation Details
All test cases include both Svelte source files and expected Rust/JavaScript codegen output. The tests validate:
- Correct `$.await()` call signature with appropriate `null`/`void 0` placeholders for omitted branches
- Proper fragment and node management for nested structures
- Variable scoping and reactivity in nested await contexts
- Correct handling of optional error/value bindings

No changes to parser, analyzer, or codegen logic were needed—these variants were already fully implemented and working.

https://claude.ai/code/session_01H81Nrpp2CBdqhNaUxTX72p