### PR TITLE
Support sync destructured `$derived` / `$derived.by` codegen and enable related tests

### DIFF
--- a/crates/svelte_codegen_client/src/script/state.rs
+++ b/crates/svelte_codegen_client/src/script/state.rs
@@ -99,6 +99,36 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
         }
     }
 
+    /// Rewrite destructured sync `$derived(...)` / `$derived.by(...)` declarations.
+    pub(super) fn process_sync_derived_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
+        let dev = self.dev;
+        self.rewrite_destructured_rune_decls(
+            stmts,
+            |declarator, rune_kind| {
+                !matches!(declarator.id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
+                    && matches!(rune_kind, Some(RuneKind::Derived | RuneKind::DerivedBy))
+                    && declarator.init.as_ref().is_some_and(|init| {
+                        if let Expression::CallExpression(call) = init {
+                            call.arguments.first()
+                                .and_then(|arg| arg.as_expression())
+                                .is_some_and(|expr| {
+                                    !matches!(expr, Expression::AwaitExpression(_))
+                                        && !(dev
+                                            && matches!(expr, Expression::CallExpression(c)
+                                                if c.arguments.is_empty() && matches!(&c.callee, Expression::AwaitExpression(_))))
+                                })
+                        } else {
+                            false
+                        }
+                    })
+            },
+            |this, decl_kind, _decl_span_start, mut declarator, rune_kind| {
+                let init = declarator.init.take().unwrap();
+                this.gen_sync_derived_destructuring(&declarator.id, init, rune_kind, decl_kind)
+            },
+        );
+    }
+
     /// Rewrite destructured async `$derived(await expr)` into a single block statement
     /// so async instance splitting keeps the original blocker metadata indexing.
     pub(super) fn process_async_derived_destructuring(&mut self, stmts: &mut oxc_allocator::Vec<'a, Statement<'a>>) {
@@ -129,6 +159,68 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
                 this.gen_async_derived_destructuring(&declarator.id, init, decl_span_start)
             },
         );
+    }
+
+    fn gen_sync_derived_destructuring(
+        &mut self,
+        pattern: &oxc_ast::ast::BindingPattern<'a>,
+        init: Expression<'a>,
+        rune_kind: RuneKind,
+        decl_kind: oxc_ast::ast::VariableDeclarationKind,
+    ) -> Statement<'a> {
+        let Expression::CallExpression(mut call) = init else {
+            unreachable!("sync derived destructuring should be a call");
+        };
+        call.callee = self.b.rid_expr("$.derived");
+
+        let mut declarators = Vec::new();
+
+        let arg_expr = call.arguments.remove(0).into_expression();
+
+        let use_direct_access = matches!(rune_kind, RuneKind::Derived)
+            && matches!(arg_expr, Expression::Identifier(_));
+        let access_root = if use_direct_access {
+            arg_expr
+        } else {
+            let derived_arg = if matches!(rune_kind, RuneKind::DerivedBy) {
+                arg_expr
+            } else {
+                self.b.thunk(arg_expr)
+            };
+            call.arguments.push(oxc_ast::ast::Argument::from(derived_arg));
+            let tmp_name = self.gen_unique_name("$$d");
+            let tmp_name_str = self.b.alloc_str(&tmp_name);
+            let derived_call = Expression::CallExpression(call);
+            let tmp_declarator = self.b.ast.variable_declarator(
+                oxc_span::SPAN,
+                decl_kind,
+                self.b.ast.binding_pattern_binding_identifier(
+                    oxc_span::SPAN,
+                    self.b.ast.atom(tmp_name_str),
+                ),
+                NONE,
+                Some(derived_call),
+                false,
+            );
+            declarators.push(tmp_declarator);
+            self.b.call_expr("$.get", [Arg::Ident(tmp_name_str)])
+        };
+
+        self.gen_destructure_declarators(
+            pattern,
+            access_root,
+            RuneKind::Derived,
+            decl_kind,
+            &mut declarators,
+        );
+
+        let decl = self.b.ast.variable_declaration(
+            oxc_span::SPAN,
+            decl_kind,
+            self.b.ast.vec_from_iter(declarators),
+            false,
+        );
+        Statement::VariableDeclaration(self.b.alloc(decl))
     }
 
     /// Expand destructured `$state`/`$state.raw` declarations into expanded form.

--- a/crates/svelte_codegen_client/src/script/traverse/statement_passes.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/statement_passes.rs
@@ -12,6 +12,7 @@ impl<'a> ScriptTransformer<'_, 'a> {
         self.strip_export_keywords(stmts);
         self.strip_prod_inspect(stmts);
         self.strip_props_id_declarations(stmts);
+        self.process_sync_derived_destructuring(stmts);
         self.process_async_derived_destructuring(stmts);
         self.expand_state_destructuring(stmts);
         self.replace_props_declaration(stmts);

--- a/specs/derived-state.md
+++ b/specs/derived-state.md
@@ -7,13 +7,11 @@
 Core `$derived` and `$derived.by` are fully implemented for simple identifier bindings (sync and async), class fields, nested functions, and dev mode. 21 existing tests all pass.
 
 **Gaps found:**
-1. Sync destructured `$derived(expr)` — not implemented (codegen skips non-Identifier patterns in `wrap_derived_thunks`)
-2. Sync destructured `$derived.by(fn)` — same gap
-3. `derived_invalid_export` diagnostic — defined but never emitted from analyze
-4. `state_referenced_locally` warning — not emitted for derived bindings
-5. `$.save()` for nested async derived (`function_depth > 1`) — unknown, no test
+1. `derived_invalid_export` diagnostic — defined but never emitted from analyze
+2. `state_referenced_locally` warning — not emitted for derived bindings
+3. `$.save()` for nested async derived (`function_depth > 1`) — unknown, no test
 
-**Next:** Add test cases for gaps, then fix starting with sync destructured `$derived`.
+**Next:** port analyzer diagnostics (`derived_invalid_export`, `state_referenced_locally`) and add focused tests.
 
 ## Source
 
@@ -37,9 +35,9 @@ ROADMAP.md — `$derived` rune (core reactivity)
 - [x] `@const` tag bindings treated as derived
 
 ### In scope
-- [ ] Sync destructured `$derived(expr)` where arg is plain Identifier (no intermediate var)
-- [ ] Sync destructured `$derived(expr)` where arg is NOT plain Identifier (intermediate `$$d` var)
-- [ ] Sync destructured `$derived.by(fn)` (intermediate `$$d` var)
+- [x] Sync destructured `$derived(expr)` where arg is plain Identifier (no intermediate var)
+- [x] Sync destructured `$derived(expr)` where arg is NOT plain Identifier (intermediate `$$d` var)
+- [x] Sync destructured `$derived.by(fn)` (intermediate `$$d` var)
 - [ ] `derived_invalid_export` diagnostic when `export`ing derived binding
 - [ ] `state_referenced_locally` warning for derived bindings read at same function depth
 
@@ -104,3 +102,8 @@ ROADMAP.md — `$derived` rune (core reactivity)
 - `derived_destructured_object` — sync destructured `$derived` with object pattern
 - `derived_destructured_array` — sync destructured `$derived` with array pattern
 - `derived_destructured_by` — sync destructured `$derived.by` with object pattern
+
+### Completed in this session
+- `derived_destructured_object`
+- `derived_destructured_array`
+- `derived_destructured_by`

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2170,19 +2170,16 @@ fn tag_derived_by() {
 }
 
 #[rstest]
-#[ignore = "missing: sync destructured $derived with object pattern (codegen)"]
 fn derived_destructured_object() {
     assert_compiler("derived_destructured_object");
 }
 
 #[rstest]
-#[ignore = "missing: sync destructured $derived with array pattern (codegen)"]
 fn derived_destructured_array() {
     assert_compiler("derived_destructured_array");
 }
 
 #[rstest]
-#[ignore = "missing: sync destructured $derived.by (codegen)"]
 fn derived_destructured_by() {
     assert_compiler("derived_destructured_by");
 }


### PR DESCRIPTION
### Motivation

- Fill the gap where sync destructured `$derived(expr)` and `$derived.by(fn)` were skipped by codegen, enabling correct transformation of non-Identifier patterns.
- Integrate the new handling into statement transformation so destructured derived declarations are rewritten before other passes.
- Un-ignore and validate the previously failing/disabled tests for destructured derived cases.

### Description

- Added `process_sync_derived_destructuring` to `script/state.rs` which rewrites sync destructured `$derived(...)` and `$derived.by(...)` declarations using `rewrite_destructured_rune_decls` with a predicate tuned for sync calls and dev-mode considerations.
- Implemented `gen_sync_derived_destructuring` to emit proper variable declarators for destructured derived patterns, optimizing direct identifier access and creating an intermediate `$$d` temporary when necessary, and rewiring the call callee to `$.derived`.
- Hooked the new pass into the main statement pipeline by calling `process_sync_derived_destructuring` from `process_statement_block` in `traverse/statement_passes.rs` so it runs alongside async derived and state destructuring passes.
- Updated `specs/derived-state.md` to reflect the implemented cases and marked the three destructured-derived tests as completed, and re-enabled the tests by removing `#[ignore]` attributes in `tasks/compiler_tests/test_v3.rs` for `derived_destructured_object`, `derived_destructured_array`, and `derived_destructured_by`.

### Testing

- Ran the compiler test suite via `cargo test` and the relevant test harness; the three previously ignored tests `derived_destructured_object`, `derived_destructured_array`, and `derived_destructured_by` now execute and succeed. 
- Existing derived-related tests (listed in `specs/derived-state.md`) were run and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd8be9c6688321893b12210ab64009)