### PR TITLE
fix: if-block call memoization, else-if flattening, and async nesting

### DIFF
--- a/crates/svelte_codegen_client/src/template/async_plan.rs
+++ b/crates/svelte_codegen_client/src/template/async_plan.rs
@@ -37,6 +37,11 @@ impl AsyncEmissionPlan {
         &self.blockers
     }
 
+    /// Returns true if this plan's blockers are a superset of `other`.
+    pub(crate) fn blockers_contain_all(&self, other: &[u32]) -> bool {
+        other.iter().all(|b| self.blockers.contains(b))
+    }
+
     pub(crate) fn async_thunk<'a>(
         &self,
         ctx: &mut Ctx<'a>,
@@ -49,7 +54,8 @@ impl AsyncEmissionPlan {
         &self,
         ctx: &mut Ctx<'a>,
         anchor: Expression<'a>,
-        param_name: &str,
+        node_param: &str,
+        condition_param: &str,
         async_thunk: Option<Expression<'a>>,
         inner_stmts: Vec<Statement<'a>>,
     ) -> Statement<'a> {
@@ -64,9 +70,9 @@ impl AsyncEmissionPlan {
             Arg::Expr(ctx.b.void_zero_expr())
         };
         let callback_params = if self.has_await {
-            ctx.b.params(["node", param_name])
+            ctx.b.params([node_param, condition_param])
         } else {
-            ctx.b.params(["node"])
+            ctx.b.params([node_param])
         };
         let callback = ctx.b.arrow_block_expr(callback_params, inner_stmts);
         ctx.b.call_stmt(

--- a/crates/svelte_codegen_client/src/template/async_plan.rs
+++ b/crates/svelte_codegen_client/src/template/async_plan.rs
@@ -21,7 +21,7 @@ impl AsyncEmissionPlan {
         };
         Self {
             has_await: deps.has_await(),
-            blockers: deps.blockers.into_iter().collect(),
+            blockers: deps.blockers.to_vec(),
         }
     }
 

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -213,6 +213,7 @@ pub(crate) fn gen_each_block<'a>(
         body.push(async_plan.wrap_async_block(
             ctx,
             anchor,
+            "node",
             "$$collection",
             async_collection_thunk,
             vec![each_stmt],

--- a/crates/svelte_codegen_client/src/template/html_tag.rs
+++ b/crates/svelte_codegen_client/src/template/html_tag.rs
@@ -46,7 +46,7 @@ pub(crate) fn gen_html_tag<'a>(
         let html_stmt = ctx.b.call_stmt("$.html", html_args);
 
         let async_thunk = async_plan.async_thunk(ctx, expression);
-        stmts.push(async_plan.wrap_async_block(ctx, anchor_expr, "$$html", async_thunk, vec![html_stmt]));
+        stmts.push(async_plan.wrap_async_block(ctx, anchor_expr, "node", "$$html", async_thunk, vec![html_stmt]));
     } else {
         let thunk = super::expression::build_node_thunk(ctx, id);
 

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -56,16 +56,31 @@ pub(crate) fn gen_if_block<'a>(
                 .lowered_fragment(&alternate_key)
                 .first_if_block_id()
                 .unwrap();
+
+            // Don't flatten if the else-if has await or introduces blockers
+            // not present in the parent — it needs its own $.async() wrapper.
+            let nested_plan = AsyncEmissionPlan::for_node(ctx, nested_id);
+            let can_flatten = !nested_plan.has_await() && {
+                let parent_plan = AsyncEmissionPlan::for_node(ctx, current);
+                parent_plan.blockers_contain_all(nested_plan.blockers())
+            };
+            if !can_flatten {
+                final_alternate = Some(alternate_key);
+                break;
+            }
+
             current = nested_id;
             continue;
-        } else {
-            final_alternate = Some(alternate_key);
-            break;
         }
+
+        final_alternate = Some(alternate_key);
+        break;
     }
 
-    // Build the expression for the root condition (needed before stmts consume it)
-    let expression = if needs_async {
+    // Build the expression for the root condition async thunk (only when has_await).
+    // Blocker-only async doesn't need the expression here — it uses the raw
+    // condition in the $.if callback.
+    let expression = if has_await {
         Some(get_node_expr(ctx, block_id))
     } else {
         None
@@ -73,15 +88,40 @@ pub(crate) fn gen_if_block<'a>(
 
     let mut stmts = Vec::new();
 
-    // 2. Generate all arrow functions at the same scope level.
+    // 2. Generate consequent arrows interleaved with derived declarations per branch.
     let mut branch_names: Vec<String> = Vec::new();
+    let mut derived_names: Vec<Option<String>> = Vec::new();
 
-    for branch in branches.iter() {
+    for (i, branch) in branches.iter().enumerate() {
+        // Consequent arrow
         let body = gen_fragment(ctx, branch.consequent_key);
         let name = ctx.gen_ident("consequent");
         let arrow = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), body);
         stmts.push(ctx.b.var_stmt(&name, arrow));
         branch_names.push(name);
+
+        // Derived memoization (emitted right after its consequent, matching reference order)
+        if i == 0 && has_await {
+            // Root async condition: resolved via $.get($$condition) inside $.async callback
+            derived_names.push(None);
+        } else {
+            let needs_memo = ctx
+                .expr_deps(ExprSite::Node(branch.block_id))
+                .is_some_and(|deps| deps.needs_memo);
+            if needs_memo {
+                let expr = get_node_expr(ctx, branch.block_id);
+                // Always wrap in arrow for $.derived() — do not use thunk() which
+                // strips no-arg calls (e.g. is_even() -> is_even), but $.derived
+                // requires the call to be preserved inside the arrow.
+                let thunk = ctx.b.arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(expr)]);
+                let derived = ctx.b.call_expr("$.derived", [Arg::Expr(thunk)]);
+                let name = ctx.gen_ident("d");
+                stmts.push(ctx.b.var_stmt(&name, derived));
+                derived_names.push(Some(name));
+            } else {
+                derived_names.push(None);
+            }
+        }
     }
 
     let alt_name = if let Some(alt_key) = final_alternate {
@@ -93,29 +133,6 @@ pub(crate) fn gen_if_block<'a>(
     } else {
         None
     };
-
-    // 2b. Pre-compute memoization for each branch condition.
-    let mut derived_names: Vec<Option<String>> = Vec::new();
-    for (i, branch) in branches.iter().enumerate() {
-        if i == 0 && has_await {
-            // Root async condition: resolved via $.get($$condition) inside $.async callback
-            derived_names.push(None);
-        } else {
-            let needs_memo = ctx
-                .expr_deps(ExprSite::Node(branch.block_id))
-                .is_some_and(|deps| deps.needs_memo);
-            if needs_memo {
-                let expr = get_node_expr(ctx, branch.block_id);
-                let thunk = ctx.b.thunk(expr);
-                let derived = ctx.b.call_expr("$.derived", [Arg::Expr(thunk)]);
-                let name = ctx.gen_ident("d");
-                stmts.push(ctx.b.var_stmt(&name, derived));
-                derived_names.push(Some(name));
-            } else {
-                derived_names.push(None);
-            }
-        }
-    }
 
     // 3. Build the if/else-if/else chain (bottom-up)
     let num_branches = branches.len();
@@ -147,12 +164,22 @@ pub(crate) fn gen_if_block<'a>(
     let render_fn = ctx.b.arrow(ctx.b.params(["$$render"]), [render_body_stmt]);
 
     // 4. $.if() call + optional $.async() wrapping
-    let span_start = ctx.query.if_block(block_id).span.start;
+    let block = ctx.query.if_block(block_id);
+    let span_start = block.span.start;
+    let is_elseif = block.elseif;
 
     if needs_async {
-        // Inside $.async callback: use "node" param as anchor
-        let if_anchor = ctx.b.rid_expr("node");
-        let if_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(if_anchor), Arg::Arrow(render_fn)];
+        // Reuse the anchor's identifier name for the $.async callback parameter,
+        // so the callback param shadows the outer variable (node, node_1, etc.).
+        let node_name = match &anchor {
+            Expression::Identifier(id) => id.name.to_string(),
+            _ => ctx.gen_ident("node"),
+        };
+        let if_anchor = ctx.b.rid_expr(&node_name);
+        let mut if_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(if_anchor), Arg::Arrow(render_fn)];
+        if is_elseif {
+            if_args.push(Arg::Bool(true));
+        }
         let if_call = ctx.b.call_expr("$.if", if_args);
         stmts.push(super::add_svelte_meta(ctx, if_call, span_start, "if"));
 
@@ -160,12 +187,16 @@ pub(crate) fn gen_if_block<'a>(
         vec![async_plan.wrap_async_block(
             ctx,
             anchor,
+            &node_name,
             "$$condition",
             async_thunk,
             stmts,
         )]
     } else {
-        let if_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor), Arg::Arrow(render_fn)];
+        let mut if_args: Vec<Arg<'a, '_>> = vec![Arg::Expr(anchor), Arg::Arrow(render_fn)];
+        if is_elseif {
+            if_args.push(Arg::Bool(true));
+        }
         let if_call = ctx.b.call_expr("$.if", if_args);
         stmts.push(super::add_svelte_meta(ctx, if_call, span_start, "if"));
         stmts

--- a/crates/svelte_codegen_client/src/template/if_block.rs
+++ b/crates/svelte_codegen_client/src/template/if_block.rs
@@ -93,7 +93,6 @@ pub(crate) fn gen_if_block<'a>(
     let mut derived_names: Vec<Option<String>> = Vec::new();
 
     for (i, branch) in branches.iter().enumerate() {
-        // Consequent arrow
         let body = gen_fragment(ctx, branch.consequent_key);
         let name = ctx.gen_ident("consequent");
         let arrow = ctx.b.arrow_block_expr(ctx.b.params(["$$anchor"]), body);

--- a/crates/svelte_codegen_client/src/template/key_block.rs
+++ b/crates/svelte_codegen_client/src/template/key_block.rs
@@ -37,7 +37,7 @@ pub(crate) fn gen_key_block<'a>(
         let key_stmt = super::add_svelte_meta(ctx, key_call, span_start, "key");
 
         let async_thunk = async_plan.async_thunk(ctx, expression);
-        stmts.push(async_plan.wrap_async_block(ctx, anchor, "$$key", async_thunk, vec![key_stmt]));
+        stmts.push(async_plan.wrap_async_block(ctx, anchor, "node", "$$key", async_thunk, vec![key_stmt]));
     } else {
         let key_thunk = super::expression::build_node_thunk(ctx, id);
 

--- a/crates/svelte_codegen_client/src/template/svelte_element.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_element.rs
@@ -137,7 +137,7 @@ pub(crate) fn gen_svelte_element<'a>(
         }
 
         let element_stmt = ctx.b.call_stmt("$.element", args);
-        stmts.push(async_plan.wrap_async_block(ctx, anchor, "$$tag", async_tag_thunk, vec![element_stmt]));
+        stmts.push(async_plan.wrap_async_block(ctx, anchor, "node", "$$tag", async_tag_thunk, vec![element_stmt]));
     } else {
         // Build tag thunk: () => tag_expression (or () => "literal" for static tags)
         let tag_expr = if let Some(ref value) = tag_value {

--- a/specs/if-block.md
+++ b/specs/if-block.md
@@ -1,14 +1,10 @@
 # If Block
 
 ## Current state
-- **Working**: 5/8 use cases
-- **Missing**: 3/8 use cases
-- **Next**: use `/port specs/if-block.md` to fix the reproduced call-memoization mismatch and the async `else if` flattening mismatch, then add one blocker-changing `{:else if}` snapshot to close the remaining audit gap.
-- **Risk**: client codegen currently flattens structural `{:else if}` chains unconditionally, while the reference only flattens when the nested branch does not introduce `await` or new blockers.
-- **Confirmed mismatches**:
-- `if_call_condition`: Rust emits `$.derived(is_even)` while the reference emits `$.derived(() => is_even())`.
-- `async_if_else_if_condition`: Rust flattens `{:else if await second()}` into the parent `$.if`, while the reference keeps it nested in a transparent else-if branch.
-- Last updated: 2026-04-01
+- **Working**: 8/8 use cases
+- **Missing**: None — all client-side use cases covered and passing
+- **Next**: Feature complete. Diagnostics deferred.
+- Last updated: 2026-04-02
 
 ## Source
 
@@ -32,9 +28,14 @@
 - `[x]` `{@const}` inside `if` / `else if` branches.
 - `[x]` Root async condition `{#if await expr}` with `experimental.async`.
 - `[x]` Nested blocks under `{#if}` such as `{#await}`, `<svelte:boundary>`, `<svelte:element>`, `use:` and transitions.
-- `[ ]` Condition expressions containing calls and tracked symbols should memoize exactly like the reference. Reproduced mismatch: `if_call_condition`.
-- `[ ]` `{:else if await expr}` under `experimental.async` should remain a nested transparent else-if instead of being flattened into the parent branch chain.
-- `[ ]` `{:else if expr}` that introduces blockers not present in the parent branch should follow the same non-flattened path as the reference compiler.
+- `[x]` Condition expressions containing calls and tracked symbols memoize exactly like the reference (`$.derived(() => expr)`).
+- `[x]` `{:else if await expr}` under `experimental.async` remains a nested transparent else-if instead of being flattened into the parent branch chain.
+- `[x]` `{:else if expr}` that introduces blockers not present in the parent branch follows the same non-flattened path as the reference compiler.
+
+### Deferred
+
+- `[ ]` Analyzer validation: `validate_block_not_empty` for consequent/alternate
+- `[ ]` Analyzer validation: `validate_opening_tag` for runes mode
 
 ## Reference
 
@@ -50,32 +51,33 @@
 - `crates/svelte_analyze/src/passes/lower.rs`
 - `crates/svelte_analyze/src/types/data/analysis.rs`
 - `crates/svelte_codegen_client/src/template/if_block.rs`
-- Existing and new compiler tests:
+- `crates/svelte_codegen_client/src/template/async_plan.rs`
+- Existing compiler tests:
 - `tasks/compiler_tests/cases2/single_if_block/case.svelte`
 - `tasks/compiler_tests/cases2/single_if_else_block/case.svelte`
 - `tasks/compiler_tests/cases2/if_else_chain_with_const/case.svelte`
 - `tasks/compiler_tests/cases2/async_if_basic/case.svelte`
 - `tasks/compiler_tests/cases2/if_call_condition/case.svelte`
 - `tasks/compiler_tests/cases2/async_if_else_if_condition/case.svelte`
+- `tasks/compiler_tests/cases2/if_elseif_new_blockers/case.svelte`
 
 ## Tasks
 
-- `[ ]` Compare generated Rust snapshot for `async_if_else_if_condition` against the reference snapshot and capture the exact structural mismatch.
-- `[ ]` Fix condition call memoization in `crates/svelte_codegen_client/src/template/if_block.rs` so memoized call conditions always wrap the expression in a thunk, matching the reference `$.derived(() => expr)` shape.
-- `[ ]` Move else-if flattening ownership from structural lowering to analysis/codegen data that can respect `has_await` and blocker comparisons.
-- `[ ]` Preserve the current sync flattening fast path for plain `{:else if}` chains.
-- `[ ]` Keep `elseif` transition locality behavior aligned with the reference when the alternate remains nested.
-
-## Implementation order
-
-- 1. Reproduce on `async_if_else_if_condition`.
-- 2. Fix flattening eligibility for else-if branches.
-- 3. Re-run the focused compiler tests and existing `if` snapshots.
+- `[x]` Fix condition call memoization: always wrap in arrow for `$.derived()`, don't use `thunk()` which strips no-arg calls.
+- `[x]` Fix statement ordering: interleave consequent arrows with derived declarations per branch (matching reference order).
+- `[x]` Move else-if flattening guard to codegen: check `has_await` and `has_more_blockers_than` before flattening.
+- `[x]` Add `elseif` flag (`true` third arg) on `$.if()` for non-flattened else-if blocks.
+- `[x]` Fix expression consumption for blocker-only async: only consume at root for `has_await`, not `needs_async`.
+- `[x]` Add unique `node` parameter naming in `$.async` callbacks to support nesting.
+- `[x]` Add `if_elseif_new_blockers` test case for blocker-changing else-if.
 
 ## Discovered bugs
 
-- OPEN: `crates/svelte_codegen_client/src/template/if_block.rs` follows `alt_is_elseif` structurally and therefore cannot distinguish sync-flattenable `{:else if}` from async or blocker-changing branches that must stay nested.
-- OPEN: `crates/svelte_codegen_client/src/template/if_block.rs` emits `$.derived(expr)` for memoized `if` call conditions instead of the reference `$.derived(() => expr)` form.
+- FIXED: `thunk()` strips no-arg calls (`is_even()` → `is_even`) but `$.derived` requires the call preserved inside an arrow.
+- FIXED: Statement ordering: all consequent arrows emitted first, then all deriveds; reference interleaves per-branch.
+- FIXED: `alt_is_elseif` flattened unconditionally — no check for `has_await` or new blockers on the nested else-if.
+- FIXED: `$.async` callback always used hardcoded `"node"` parameter, causing name collisions when nested.
+- FIXED: Root expression consumed when `needs_async` even for blocker-only async where it's not needed for the thunk.
 
 ## Test cases
 
@@ -85,6 +87,8 @@
 - `if_else_chain_with_const`
 - `async_if_basic`
 - `await_in_if`
-- Added during this audit:
-- `if_call_condition`
-- `async_if_else_if_condition`
+- Fixed during this port:
+- `if_call_condition` — condition call memoization
+- `async_if_else_if_condition` — async else-if flattening
+- Added during this port:
+- `if_elseif_new_blockers` — blocker-changing else-if

--- a/tasks/compiler_tests/cases2/if_call_condition/case-rust.js
+++ b/tasks/compiler_tests/cases2/if_call_condition/case-rust.js
@@ -13,11 +13,11 @@ export default function App($$anchor) {
 			var p = root_1();
 			$.append($$anchor, p);
 		};
+		var d = $.derived(() => is_even());
 		var alternate = ($$anchor) => {
 			var p_1 = root_2();
 			$.append($$anchor, p_1);
 		};
-		var d = $.derived(is_even);
 		$.if(node, ($$render) => {
 			if ($.get(d)) $$render(consequent);
 			else $$render(alternate, -1);

--- a/tasks/compiler_tests/cases2/if_elseif_new_blockers/case-rust.js
+++ b/tasks/compiler_tests/cases2/if_elseif_new_blockers/case-rust.js
@@ -1,18 +1,14 @@
 import "svelte/internal/flags/async";
 import * as $ from "svelte/internal/client";
-var root_1 = $.from_html(`<p>first</p>`);
-var root_3 = $.from_html(`<p>second</p>`);
+var root_1 = $.from_html(`<p>a</p>`);
+var root_3 = $.from_html(`<p>b</p>`);
 var root_4 = $.from_html(`<p>fallback</p>`);
 export default function App($$anchor) {
-	async function first() {
-		return false;
-	}
-	async function second() {
-		return true;
-	}
+	var a, b;
+	var $$promises = $.run([async () => a = await first_fetch(), async () => b = await second_fetch()]);
 	var fragment = $.comment();
 	var node = $.first_child(fragment);
-	$.async(node, [], [first], (node, $$condition) => {
+	$.async(node, [$$promises[0]], void 0, (node) => {
 		var consequent = ($$anchor) => {
 			var p = root_1();
 			$.append($$anchor, p);
@@ -20,7 +16,7 @@ export default function App($$anchor) {
 		var alternate_1 = ($$anchor) => {
 			var fragment_1 = $.comment();
 			var node_1 = $.first_child(fragment_1);
-			$.async(node_1, [], [second], (node_1, $$condition) => {
+			$.async(node_1, [$$promises[1]], void 0, (node_1) => {
 				var consequent_1 = ($$anchor) => {
 					var p_1 = root_3();
 					$.append($$anchor, p_1);
@@ -30,14 +26,14 @@ export default function App($$anchor) {
 					$.append($$anchor, p_2);
 				};
 				$.if(node_1, ($$render) => {
-					if ($.get($$condition)) $$render(consequent_1);
+					if (b) $$render(consequent_1);
 					else $$render(alternate, -1);
 				}, true);
 			});
 			$.append($$anchor, fragment_1);
 		};
 		$.if(node, ($$render) => {
-			if ($.get($$condition)) $$render(consequent);
+			if (a) $$render(consequent);
 			else $$render(alternate_1, -1);
 		});
 	});

--- a/tasks/compiler_tests/cases2/if_elseif_new_blockers/case-svelte.js
+++ b/tasks/compiler_tests/cases2/if_elseif_new_blockers/case-svelte.js
@@ -1,18 +1,14 @@
 import "svelte/internal/flags/async";
 import * as $ from "svelte/internal/client";
-var root_1 = $.from_html(`<p>first</p>`);
-var root_3 = $.from_html(`<p>second</p>`);
+var root_1 = $.from_html(`<p>a</p>`);
+var root_3 = $.from_html(`<p>b</p>`);
 var root_4 = $.from_html(`<p>fallback</p>`);
 export default function App($$anchor) {
-	async function first() {
-		return false;
-	}
-	async function second() {
-		return true;
-	}
+	var a, b;
+	var $$promises = $.run([async () => a = await first_fetch(), async () => b = await second_fetch()]);
 	var fragment = $.comment();
 	var node = $.first_child(fragment);
-	$.async(node, [], [first], (node, $$condition) => {
+	$.async(node, [$$promises[0]], void 0, (node) => {
 		var consequent = ($$anchor) => {
 			var p = root_1();
 			$.append($$anchor, p);
@@ -20,7 +16,7 @@ export default function App($$anchor) {
 		var alternate_1 = ($$anchor) => {
 			var fragment_1 = $.comment();
 			var node_1 = $.first_child(fragment_1);
-			$.async(node_1, [], [second], (node_1, $$condition) => {
+			$.async(node_1, [$$promises[1]], void 0, (node_1) => {
 				var consequent_1 = ($$anchor) => {
 					var p_1 = root_3();
 					$.append($$anchor, p_1);
@@ -30,14 +26,14 @@ export default function App($$anchor) {
 					$.append($$anchor, p_2);
 				};
 				$.if(node_1, ($$render) => {
-					if ($.get($$condition)) $$render(consequent_1);
+					if (b) $$render(consequent_1);
 					else $$render(alternate, -1);
 				}, true);
 			});
 			$.append($$anchor, fragment_1);
 		};
 		$.if(node, ($$render) => {
-			if ($.get($$condition)) $$render(consequent);
+			if (a) $$render(consequent);
 			else $$render(alternate_1, -1);
 		});
 	});

--- a/tasks/compiler_tests/cases2/if_elseif_new_blockers/case.svelte
+++ b/tasks/compiler_tests/cases2/if_elseif_new_blockers/case.svelte
@@ -1,0 +1,12 @@
+<script>
+	const a = await first_fetch();
+	const b = await second_fetch();
+</script>
+
+{#if a}
+	<p>a</p>
+{:else if b}
+	<p>b</p>
+{:else}
+	<p>fallback</p>
+{/if}

--- a/tasks/compiler_tests/cases2/if_elseif_new_blockers/config.json
+++ b/tasks/compiler_tests/cases2/if_elseif_new_blockers/config.json
@@ -1,0 +1,1 @@
+{"experimental": {"async": true}}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -128,7 +128,6 @@ fn single_if_else_block() {
 }
 
 #[test]
-#[ignore = "missing: known v3 parity gap"]
 fn if_call_condition() {
     assert_compiler("if_call_condition");
 }
@@ -1915,9 +1914,13 @@ fn async_if_basic() {
 }
 
 #[test]
-#[ignore = "missing: known v3 parity gap"]
 fn async_if_else_if_condition() {
     assert_compiler("async_if_else_if_condition");
+}
+
+#[test]
+fn if_elseif_new_blockers() {
+    assert_compiler("if_elseif_new_blockers");
 }
 
 #[rstest]


### PR DESCRIPTION
- Always wrap condition in arrow for $.derived() instead of using thunk()
  which strips no-arg calls (is_even() -> is_even)
- Interleave consequent arrows with derived declarations per branch to
  match reference compiler statement ordering
- Guard else-if flattening in codegen: check has_await and blocker sets
  before flattening, keeping nested async blocks separate
- Add elseif flag (true 3rd arg) on $.if() for non-flattened else-if
- Generate unique node param names in $.async callbacks for nesting
- Fix expression consumption for blocker-only async (has_await vs needs_async)

Tests fixed: if_call_condition, async_if_else_if_condition
Tests added: if_elseif_new_blockers

https://claude.ai/code/session_01HtrWw2HjjXocdFhcoeHavB