### PR TITLE
fix: store subscription codegen — validate_store, cleanup ordering, each-block flags

### DIFF
--- a/crates/svelte_codegen_client/src/builder/base.rs
+++ b/crates/svelte_codegen_client/src/builder/base.rs
@@ -74,8 +74,8 @@ impl<'a> Builder<'a> {
         self.ast.expression_boolean_literal(SPAN, false)
     }
 
-    /// `(a, b, ...)` — sequence (comma) expression.
-    pub fn seq_expr(&self, exprs: impl IntoIterator<Item = Expression<'a>>) -> Expression<'a> {
+    /// `(a, b, ...)` — sequence (comma) expression. Requires ≥2 expressions.
+    pub fn seq_expr(&self, exprs: [Expression<'a>; 2]) -> Expression<'a> {
         self.ast.expression_sequence(SPAN, self.ast.vec_from_iter(exprs))
     }
 }

--- a/crates/svelte_codegen_client/src/builder/base.rs
+++ b/crates/svelte_codegen_client/src/builder/base.rs
@@ -73,4 +73,9 @@ impl<'a> Builder<'a> {
     pub fn cheap_expr(&self) -> Expression<'a> {
         self.ast.expression_boolean_literal(SPAN, false)
     }
+
+    /// `(a, b, ...)` — sequence (comma) expression.
+    pub fn seq_expr(&self, exprs: impl IntoIterator<Item = Expression<'a>>) -> Expression<'a> {
+        self.ast.expression_sequence(SPAN, self.ast.vec_from_iter(exprs))
+    }
 }

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -89,13 +89,23 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
             dollar_name.push_str(base_name);
             let dollar_name_str: &str = ctx.b.alloc_str(&dollar_name);
             let base_str: &str = ctx.b.alloc_str(base_name);
-            // const $name = () => $.store_get(name, "$name", $$stores)
             let store_get = ctx.b.call_expr("$.store_get", [
                 Arg::Ident(base_str),
                 Arg::Str(dollar_name.clone()),
                 Arg::Ident("$$stores"),
             ]);
-            let thunk = ctx.b.thunk(store_get);
+            // Dev mode: ($.validate_store(name, "name"), $.store_get(...))
+            // Prod mode: $.store_get(...)
+            let thunk_body = if ctx.state.dev {
+                let validate = ctx.b.call_expr("$.validate_store", [
+                    Arg::Ident(base_str),
+                    Arg::StrRef(ctx.b.alloc_str(base_name)),
+                ]);
+                ctx.b.seq_expr([validate, store_get])
+            } else {
+                store_get
+            };
+            let thunk = ctx.b.thunk(thunk_body);
             fn_body.push(ctx.b.const_stmt(dollar_name_str, thunk));
         }
 
@@ -167,15 +177,23 @@ pub fn generate<'a>(alloc: &'a Allocator, component: &'a Component, analysis: &'
     fn_body.extend(template_body);
 
     if runtime.needs_push {
-        if runtime.needs_pop_with_return {
+        if runtime.needs_pop_with_return && runtime.has_stores {
+            // var $$pop = $.pop($$exports); $$cleanup(); return $$pop;
+            let pop_call = ctx.b.call_expr("$.pop", [Arg::Ident("$$exports")]);
+            fn_body.push(ctx.b.var_stmt("$$pop", pop_call));
+            fn_body.push(ctx.b.call_stmt("$$cleanup", std::iter::empty::<Arg<'_, '_>>()));
+            fn_body.push(ctx.b.return_stmt(ctx.b.rid_expr("$$pop")));
+        } else if runtime.needs_pop_with_return {
             fn_body.push(ctx.b.return_stmt(ctx.b.call_expr("$.pop", [Arg::Ident("$$exports")])));
         } else {
             fn_body.push(ctx.b.expr_stmt(ctx.b.call_expr("$.pop", std::iter::empty::<Arg<'_, '_>>())));
+            // Store cleanup: $$cleanup() — runs after $.pop()
+            if runtime.has_stores {
+                fn_body.push(ctx.b.call_stmt("$$cleanup", std::iter::empty::<Arg<'_, '_>>()));
+            }
         }
-    }
-
-    // Store cleanup: $$cleanup() — runs after $.pop()
-    if runtime.has_stores {
+    } else if runtime.has_stores {
+        // No push/pop but still have stores — just cleanup
         fn_body.push(ctx.b.call_stmt("$$cleanup", std::iter::empty::<Arg<'_, '_>>()));
     }
 

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -58,9 +58,6 @@ pub(crate) fn gen_each_block<'a>(
     // Compute flags
     let mut flags: u32 = 0;
 
-    // EACH_ITEM_IMMUTABLE: runes mode without store (always set for now)
-    flags |= EACH_ITEM_IMMUTABLE;
-
     // EACH_INDEX_REACTIVE: keyed block with user-declared index
     if has_key && has_index {
         flags |= EACH_INDEX_REACTIVE;
@@ -73,10 +70,16 @@ pub(crate) fn gen_each_block<'a>(
         .unwrap_or_else(|| panic!("missing expression deps for each block {:?}", block_id));
     let async_plan = AsyncEmissionPlan::for_node(ctx, block_id);
     let expr_has_refs = !expr_deps.info.ref_symbols.is_empty();
+    let uses_store = expr_deps.info.has_store_ref;
     let has_await = async_plan.has_await();
     let needs_async = async_plan.needs_async();
-    if expr_has_refs && !key_is_item {
+    if uses_store || (expr_has_refs && !key_is_item) {
         flags |= EACH_ITEM_REACTIVE;
+    }
+
+    // EACH_ITEM_IMMUTABLE: runes mode without store dependency
+    if !uses_store {
+        flags |= EACH_ITEM_IMMUTABLE;
     }
 
     if is_controlled {
@@ -125,8 +128,7 @@ pub(crate) fn gen_each_block<'a>(
         ctx.b.rid_expr(expr_source)
     } else {
         let collection = get_node_expr(ctx, block_id);
-        ctx.b
-            .arrow_expr(ctx.b.no_params(), [ctx.b.expr_stmt(collection)])
+        ctx.b.thunk(collection)
     };
 
     // Key function: keyed each uses (pattern[, index]) => key_expr, unkeyed uses $.index

--- a/crates/svelte_codegen_client/src/template/each_block.rs
+++ b/crates/svelte_codegen_client/src/template/each_block.rs
@@ -63,8 +63,10 @@ pub(crate) fn gen_each_block<'a>(
         flags |= EACH_INDEX_REACTIVE;
     }
 
-    // EACH_ITEM_REACTIVE: collection references external state
-    // In runes mode: skip when key_is_item (item identity is the key)
+    // EACH_ITEM_REACTIVE: collection references external state.
+    // Reference also filters deps by function_depth (only external deps count),
+    // but our ref_symbols already excludes each-local bindings via scope resolution.
+    // In runes mode: skip when key_is_item unless store deps are present.
     let expr_deps = ctx
         .expr_deps(ExprSite::Node(block_id))
         .unwrap_or_else(|| panic!("missing expression deps for each block {:?}", block_id));
@@ -77,7 +79,8 @@ pub(crate) fn gen_each_block<'a>(
         flags |= EACH_ITEM_REACTIVE;
     }
 
-    // EACH_ITEM_IMMUTABLE: runes mode without store dependency
+    // EACH_ITEM_IMMUTABLE: runes mode without store dependency.
+    // Reference: `runes && !uses_store`. We only compile runes mode currently.
     if !uses_store {
         flags |= EACH_ITEM_IMMUTABLE;
     }

--- a/specs/store-subscriptions.md
+++ b/specs/store-subscriptions.md
@@ -1,10 +1,15 @@
 # $store subscriptions
 
 ## Current state
-- **Working**: 7/15 client use cases
-- **Missing**: dev validation, store cleanup ordering when `$.push`/`$.pop` is active, subscription teardown on reassignment, each-block store invalidation, component prop store binding marking, store-specific diagnostics, module compilation validation, nested-scope subscription validation
-- **Next**: port analyzer validation for store subscriptions first, then fill the missing client codegen hooks (`validate_store`, `invalidate_store`, `mark_store_binding`, `store_unsub`)
-- Last updated: 2026-04-01
+- **Working**: 10/15 client use cases (was 7)
+- **Fixed this session**:
+  - Dev-mode `$.validate_store` in store thunk (sequence expression)
+  - Store cleanup ordering: `var $$pop = $.pop($$exports); $$cleanup(); return $$pop;`
+  - Each-block flags: `EACH_ITEM_IMMUTABLE` not set when collection depends on store; `EACH_ITEM_REACTIVE` set when `has_store_ref`
+  - Each-block collection thunk optimization: `b.thunk()` collapses `() => $items()` to `$items`
+- **Missing**: `$.store_unsub` (legacy-only, needs non-runes mode), `$.invalidate_store` (legacy each-block mutation), `$.mark_store_binding` (component store bindings), store-specific diagnostics, module compilation validation
+- **Next**: `$.mark_store_binding` for component bindings (runes-compatible), then legacy-mode features
+- Last updated: 2026-04-02
 
 ## Source
 
@@ -34,10 +39,11 @@
 - [x] Deep member assignment rewrites to `$.store_mutate`
 - [x] Deep member update rewrites to `$.store_mutate`
 - [x] Runtime plan marks store setup without forcing component context by default
-- [ ] Dev-mode store setup validates the underlying store with `$.validate_store`
-- [ ] Store cleanup runs after `$.pop(...)` without becoming unreachable when stores and component return values coexist
-- [ ] Reassigning a store binding unsubscribes the prior subscription with `$.store_unsub`
-- [ ] `{#each $items as item}` mutations invalidate the backing store with `$.invalidate_store`
+- [x] Dev-mode store setup validates the underlying store with `$.validate_store`
+- [x] Store cleanup runs after `$.pop(...)` without becoming unreachable when stores and component return values coexist
+- [x] Each-block with store-backed collection sets correct flags (`EACH_ITEM_REACTIVE`, no `EACH_ITEM_IMMUTABLE`)
+- [ ] Reassigning a store binding unsubscribes the prior subscription with `$.store_unsub` (legacy-only)
+- [ ] `{#each $items as item}` mutations invalidate the backing store with `$.invalidate_store` (legacy-only)
 - [ ] Component/store binding codegen marks store-backed bindings with `$.mark_store_binding`
 - [ ] Analyzer rejects subscriptions to stores not declared at component top level
 - [ ] Analyzer rejects `$store` reads inside `<script module>`
@@ -45,7 +51,10 @@
 
 ### Deferred
 
-- SSR store subscription codegen and cleanup parity
+- [ ] SSR store subscription codegen and cleanup parity
+- [ ] `$.store_unsub` — only fires in legacy (non-runes) mode when store variable is promoted to reactive state
+- [ ] `$.invalidate_store` — only fires in legacy (non-runes) mode for each-block item mutations
+- [ ] `$.mark_store_binding` — component binding getter injection for store-backed bindings
 
 ## Reference
 
@@ -104,10 +113,10 @@
 
 ## Discovered bugs
 
-- OPEN: client codegen sets up store subscriptions but never emits `$.validate_store` in dev mode.
-- OPEN: when stores coexist with `$.pop($$exports)`, generated cleanup is emitted after `return` and becomes unreachable.
+- FIXED: client codegen sets up store subscriptions but never emits `$.validate_store` in dev mode.
+- FIXED: when stores coexist with `$.pop($$exports)`, generated cleanup is emitted after `return` and becomes unreachable.
 - OPEN: the analyzer validation entrypoint only runs rune validation today, so store-specific diagnostics are currently absent.
-- OPEN: no Rust codegen path currently emits `$.invalidate_store`, `$.mark_store_binding`, or `$.store_unsub`.
+- OPEN: no Rust codegen path currently emits `$.invalidate_store`, `$.mark_store_binding`, or `$.store_unsub` (legacy-only features).
 
 ## Test cases
 
@@ -119,9 +128,9 @@
   - `store_update_template`
   - `store_deep_mutation`
   - `store_deep_update`
-- Added during this audit:
-  - `store_validate_dev` — captures missing `$.validate_store` dev-mode output and broken `$$cleanup()` ordering in push/pop mode
+  - `store_validate_dev` — dev-mode `$.validate_store` + correct `$$cleanup()` ordering
+  - `store_reassign_unsub` — store variable reassignment in runes mode (no legacy state promotion)
+  - `store_each_invalidate` — each block with store-backed collection, correct flags
 - Recommended next cases after implementation starts:
-  - `store_reassign_unsub`
   - `store_each_invalidate`
   - analyzer/unit tests for `store_invalid_scoped_subscription`, `store_invalid_subscription`, `store_invalid_subscription_module`, `store_rune_conflict`

--- a/tasks/compiler_tests/cases2/store_each_invalidate/case-rust.js
+++ b/tasks/compiler_tests/cases2/store_each_invalidate/case-rust.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+import { items } from "./stores";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const $items = () => $.store_get(items, "$items", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 1, $items, $.index, ($$anchor, item) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(item)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/store_each_invalidate/case-svelte.js
+++ b/tasks/compiler_tests/cases2/store_each_invalidate/case-svelte.js
@@ -1,0 +1,18 @@
+import * as $ from "svelte/internal/client";
+import { items } from "./stores";
+var root_1 = $.from_html(`<p> </p>`);
+export default function App($$anchor) {
+	const $items = () => $.store_get(items, "$items", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	var fragment = $.comment();
+	var node = $.first_child(fragment);
+	$.each(node, 1, $items, $.index, ($$anchor, item) => {
+		var p = root_1();
+		var text = $.child(p, true);
+		$.reset(p);
+		$.template_effect(() => $.set_text(text, $.get(item)));
+		$.append($$anchor, p);
+	});
+	$.append($$anchor, fragment);
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/store_each_invalidate/case.svelte
+++ b/tasks/compiler_tests/cases2/store_each_invalidate/case.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { items } from './stores';
+</script>
+
+{#each $items as item}
+	<p>{item}</p>
+{/each}

--- a/tasks/compiler_tests/cases2/store_reassign_unsub/case-rust.js
+++ b/tasks/compiler_tests/cases2/store_reassign_unsub/case-rust.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+import { writable } from "svelte/store";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const $count = () => $.store_get(count, "$count", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	let count = writable(0);
+	function swap() {
+		count = writable(10);
+	}
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $count()));
+	$.append($$anchor, p);
+	$.pop();
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/store_reassign_unsub/case-svelte.js
+++ b/tasks/compiler_tests/cases2/store_reassign_unsub/case-svelte.js
@@ -1,0 +1,19 @@
+import * as $ from "svelte/internal/client";
+import { writable } from "svelte/store";
+var root = $.from_html(`<p> </p>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const $count = () => $.store_get(count, "$count", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	let count = writable(0);
+	function swap() {
+		count = writable(10);
+	}
+	var p = root();
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $count()));
+	$.append($$anchor, p);
+	$.pop();
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/store_reassign_unsub/case.svelte
+++ b/tasks/compiler_tests/cases2/store_reassign_unsub/case.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { writable } from 'svelte/store';
+	let count = writable(0);
+
+	function swap() {
+		count = writable(10);
+	}
+</script>
+
+<p>{$count}</p>

--- a/tasks/compiler_tests/cases2/store_validate_dev/case-rust.js
+++ b/tasks/compiler_tests/cases2/store_validate_dev/case-rust.js
@@ -5,7 +5,7 @@ var root = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[5, 0]]);
 export default function App($$anchor, $$props) {
 	$.check_target(new.target);
 	$.push($$props, true, App);
-	const $count = () => $.store_get(count, "$count", $$stores);
+	const $count = () => ($.validate_store(count, "count"), $.store_get(count, "$count", $$stores));
 	const [$$stores, $$cleanup] = $.setup_stores();
 	var $$exports = { ...$.legacy_api() };
 	var p = root();
@@ -13,6 +13,7 @@ export default function App($$anchor, $$props) {
 	$.reset(p);
 	$.template_effect(() => $.set_text(text, $count()));
 	$.append($$anchor, p);
-	return $.pop($$exports);
+	var $$pop = $.pop($$exports);
 	$$cleanup();
+	return $$pop;
 }

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -610,9 +610,18 @@ fn store_write() {
 }
 
 #[rstest]
-#[ignore = "missing: known v3 parity gap"]
 fn store_validate_dev() {
     assert_compiler("store_validate_dev");
+}
+
+#[rstest]
+fn store_reassign_unsub() {
+    assert_compiler("store_reassign_unsub");
+}
+
+#[rstest]
+fn store_each_invalidate() {
+    assert_compiler("store_each_invalidate");
 }
 
 #[rstest]


### PR DESCRIPTION
- Add dev-mode $.validate_store in store thunk via sequence expression
- Fix unreachable $$cleanup() after return by using var $$pop pattern
- Fix each-block EACH_ITEM_IMMUTABLE/EACH_ITEM_REACTIVE flags for store-backed collections
- Optimize each-block collection thunk: use b.thunk() to collapse () => $items() to $items
- Add seq_expr builder method for comma expressions
- Un-ignore store_validate_dev test, add store_reassign_unsub and store_each_invalidate tests

https://claude.ai/code/session_01BQKpHaEz498bRMug7MfYQW