### PR TITLE
Implement textarea value lowering, option synthetic values, and element validation

### DIFF
--- a/crates/svelte_analyze/src/passes/element_flags.rs
+++ b/crates/svelte_analyze/src/passes/element_flags.rs
@@ -1,6 +1,7 @@
 //! ElementFlagsVisitor — precompute element attribute flags in one walker pass.
 
-use svelte_ast::{Attribute, ComponentNode};
+use svelte_ast::{Attribute, ComponentNode, Element, Node, is_mathml, is_svg, is_void};
+use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
 
 use crate::types::data::{ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, EventHandlerMode};
@@ -21,6 +22,46 @@ impl<'src> ElementFlagsVisitor<'src> {
 }
 
 impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
+    fn visit_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
+        // Warn for non-void, non-SVG, non-MathML elements written as self-closing.
+        if el.self_closing && !is_void(&el.name) && !is_svg(&el.name) && !is_mathml(&el.name) {
+            ctx.warnings_mut().push(Diagnostic::warning(
+                DiagnosticKind::ElementInvalidSelfClosingTag { name: el.name.clone() },
+                el.span,
+            ));
+        }
+
+        let has_value_attr = el.attributes.iter().any(|a| {
+            matches!(a, Attribute::StringAttribute(sa) if sa.name == "value")
+                || matches!(a, Attribute::ExpressionAttribute(ea) if ea.name == "value")
+        });
+
+        // <textarea>: detect expression children
+        if el.name == "textarea" && !el.fragment.nodes.is_empty() {
+            let has_expr_children = el.fragment.nodes.iter().any(|&id| {
+                matches!(ctx.store.get(id), Node::ExpressionTag(_))
+            });
+            if has_expr_children {
+                if has_value_attr {
+                    ctx.warnings_mut().push(Diagnostic::error(
+                        DiagnosticKind::TextareaInvalidContent,
+                        el.span,
+                    ));
+                } else {
+                    ctx.data.element_flags.needs_textarea_value_lowering.insert(el.id);
+                }
+            }
+        }
+
+        // <option>: single ExpressionTag child, no explicit value attribute → synthetic __value
+        if el.name == "option" && !has_value_attr && el.fragment.nodes.len() == 1 {
+            let child_id = el.fragment.nodes[0];
+            if matches!(ctx.store.get(child_id), Node::ExpressionTag(_)) {
+                ctx.data.element_flags.option_synthetic_value_expr.insert(el.id, child_id);
+            }
+        }
+    }
+
     fn visit_attribute(&mut self, attr: &Attribute, ctx: &mut VisitContext<'_>) {
         let Some(el_id) = ctx.nearest_element() else { return };
         match attr {

--- a/crates/svelte_analyze/src/types/data/codegen_view.rs
+++ b/crates/svelte_analyze/src/types/data/codegen_view.rs
@@ -81,6 +81,8 @@ impl<'a> CodegenView<'a> {
     pub fn snippet_params(&self, id: NodeId) -> &[String] { self.data.snippets.params(id) }
     pub fn is_snippet_hoistable(&self, id: NodeId) -> bool { self.data.snippets.is_hoistable(id) }
     pub fn event_handler_mode(&self, id: NodeId) -> Option<EventHandlerMode> { self.data.element_flags.event_handler_mode(id) }
+    pub fn needs_textarea_value_lowering(&self, id: NodeId) -> bool { self.data.element_flags.needs_textarea_value_lowering(id) }
+    pub fn option_synthetic_value_expr(&self, id: NodeId) -> Option<NodeId> { self.data.element_flags.option_synthetic_value_expr(id) }
     pub fn render_tag_plan(&self, id: NodeId) -> Option<&RenderTagPlan> { self.data.render_tag_plan(id) }
     pub fn has_bind_group(&self, id: NodeId) -> bool { self.data.bind_semantics.has_bind_group(id) }
     pub fn bind_group_value_attr(&self, id: NodeId) -> Option<NodeId> { self.data.bind_semantics.bind_group_value_attr(id) }

--- a/crates/svelte_analyze/src/types/data/elements.rs
+++ b/crates/svelte_analyze/src/types/data/elements.rs
@@ -69,6 +69,12 @@ pub struct ElementFlags {
     pub(crate) expression_shorthand: NodeBitSet,
     pub(crate) component_props: NodeTable<Vec<ComponentPropInfo>>,
     pub(crate) event_handler_mode: NodeTable<EventHandlerMode>,
+    /// `<textarea>` with expression children and no explicit `value` attribute —
+    /// codegen emits `$.remove_textarea_child` + `$.set_value` instead of textContent.
+    pub(crate) needs_textarea_value_lowering: NodeBitSet,
+    /// `<option>` with a single ExpressionTag child and no explicit `value` attribute.
+    /// Maps option element NodeId → ExpressionTag NodeId for `__value` synthesis.
+    pub(crate) option_synthetic_value_expr: NodeTable<NodeId>,
 }
 
 impl ElementFlags {
@@ -91,6 +97,8 @@ impl ElementFlags {
             expression_shorthand: NodeBitSet::new(node_count),
             component_props: NodeTable::new(node_count),
             event_handler_mode: NodeTable::new(node_count),
+            needs_textarea_value_lowering: NodeBitSet::new(node_count),
+            option_synthetic_value_expr: NodeTable::new(node_count),
         }
     }
 
@@ -160,5 +168,11 @@ impl ElementFlags {
     }
     pub fn event_handler_mode(&self, attr_id: NodeId) -> Option<EventHandlerMode> {
         self.event_handler_mode.get(attr_id).copied()
+    }
+    pub fn needs_textarea_value_lowering(&self, id: NodeId) -> bool {
+        self.needs_textarea_value_lowering.contains(&id)
+    }
+    pub fn option_synthetic_value_expr(&self, id: NodeId) -> Option<NodeId> {
+        self.option_synthetic_value_expr.get(id).copied()
     }
 }

--- a/crates/svelte_codegen_client/src/context.rs
+++ b/crates/svelte_codegen_client/src/context.rs
@@ -434,6 +434,12 @@ impl<'a> Ctx<'a> {
     pub fn needs_input_defaults(&self, id: NodeId) -> bool {
         self.query.view.needs_input_defaults(id)
     }
+    pub fn needs_textarea_value_lowering(&self, id: NodeId) -> bool {
+        self.query.view.needs_textarea_value_lowering(id)
+    }
+    pub fn option_synthetic_value_expr(&self, id: NodeId) -> Option<NodeId> {
+        self.query.view.option_synthetic_value_expr(id)
+    }
     pub fn needs_var(&self, id: NodeId) -> bool {
         self.query.view.needs_var(id)
     }

--- a/crates/svelte_codegen_client/src/template/element.rs
+++ b/crates/svelte_codegen_client/src/template/element.rs
@@ -2,7 +2,7 @@
 
 use oxc_ast::ast::Statement;
 
-use svelte_analyze::{ContentStrategy, FragmentItem, FragmentKey};
+use svelte_analyze::{ContentStrategy, FragmentItem, FragmentKey, LoweredTextPart};
 use svelte_ast::NodeId;
 
 use crate::builder::Arg;
@@ -18,8 +18,8 @@ use super::events::{
     gen_use_directive,
 };
 use super::expression::{
-    build_concat, emit_memoized_text_effect, emit_trailing_next, item_has_local_blockers,
-    text_content_needs_memo, MemoAttr,
+    build_concat, emit_memoized_text_effect, emit_trailing_next, get_node_expr,
+    item_has_local_blockers, text_content_needs_memo, MemoAttr,
 };
 use super::html_tag::gen_html_tag;
 use super::traverse::traverse_items;
@@ -179,9 +179,17 @@ pub(crate) fn process_element<'a>(
         ContentStrategy::Empty | ContentStrategy::Static(_) => {}
 
         ContentStrategy::DynamicText if !has_state => {
-            // textContent shortcut
             let items: Vec<_> = ctx.lowered_fragment(&child_key).items.clone();
-            if !item_has_local_blockers(&items[0], ctx) {
+
+            if ctx.needs_textarea_value_lowering(el_id) {
+                // <textarea> with expression children: remove static child, set value property.
+                // Use the raw expression (bypasses build_concat constant folding) so the variable
+                // reference is preserved — $.set_value must receive the live binding, not a literal.
+                init.push(ctx.b.call_stmt("$.remove_textarea_child", [Arg::Ident(el_name)]));
+                let expr = extract_single_raw_expr_or_concat(ctx, &items[0]);
+                init.push(ctx.b.call_stmt("$.set_value", [Arg::Ident(el_name), Arg::Expr(expr)]));
+            } else if !item_has_local_blockers(&items[0], ctx) {
+                // textContent shortcut
                 let expr = build_concat(ctx, &items[0]);
                 init.push(ctx.b.assign_stmt(
                     crate::builder::AssignLeft::StaticMember(
@@ -189,6 +197,18 @@ pub(crate) fn process_element<'a>(
                     ),
                     expr,
                 ));
+                // <option> with expression child and no explicit value attr: synthesize __value.
+                // Uses the raw expression (bypasses constant folding) so the variable reference
+                // is preserved for select-binding value comparisons at runtime.
+                if let Some(expr_id) = ctx.option_synthetic_value_expr(el_id) {
+                    let raw_expr = get_node_expr(ctx, expr_id);
+                    init.push(ctx.b.assign_stmt(
+                        crate::builder::AssignLeft::StaticMember(
+                            ctx.b.static_member(ctx.b.rid_expr(el_name), "__value"),
+                        ),
+                        raw_expr,
+                    ));
+                }
             } else {
                 let text_name = ctx.gen_ident("text");
                 let child_call = ctx.b.call_expr("$.child", [Arg::Ident(el_name), Arg::Bool(true)]);
@@ -326,4 +346,21 @@ pub(crate) fn item_needs_var(item: &svelte_analyze::FragmentItem, ctx: &Ctx<'_>)
         | svelte_analyze::FragmentItem::SvelteBoundary(_)
         | svelte_analyze::FragmentItem::AwaitBlock(_) => true,
     }
+}
+
+/// Build a value expression from a fragment item without constant folding.
+///
+/// When a fragment item is a single expression tag, returns the raw node expression
+/// (variable reference preserved). Falls back to `build_concat` for multi-part items.
+/// Used where the live binding must be passed (e.g. `$.set_value` for textarea).
+fn extract_single_raw_expr_or_concat<'a>(
+    ctx: &mut Ctx<'a>,
+    item: &FragmentItem,
+) -> oxc_ast::ast::Expression<'a> {
+    if let FragmentItem::TextConcat { parts, .. } = item {
+        if let [LoweredTextPart::Expr(nid)] = parts.as_slice() {
+            return get_node_expr(ctx, *nid);
+        }
+    }
+    build_concat(ctx, item)
 }

--- a/specs/element.md
+++ b/specs/element.md
@@ -1,10 +1,11 @@
 # Element
 
 ## Current state
-- **Working**: 7/13 use cases are covered or already tracked by passing compiler cases
-- **Missing**: template validation for regular elements, textarea/option/select special handling, and several regular-element runtime special cases
-- **Next**: implement regular-element template validation first, then port form-element special handling in analyze/codegen order
-- Last updated: 2026-04-01
+- **Working**: 9/13 use cases covered (added textarea child-content lowering and option synthetic __value)
+- **Partial**: template validation — `element_invalid_self_closing_tag` warning and `textarea_invalid_content` error now emitted
+- **Missing**: customizable select subtree, autofocus already done; node_invalid_placement, slot_attribute_invalid_placement, component_name_lowercase diagnostics still absent
+- **Next**: port remaining validation diagnostics (node_invalid_placement, slot_attribute_invalid_placement), then customizable select
+- Last updated: 2026-04-02
 
 ## Source
 
@@ -51,16 +52,17 @@
   Existing tests: `svg_inner_whitespace_trimming`, `svg_text_preserves_whitespace`
 - `[~]` Regular-element directives and advanced attribute paths work, but coverage/spec ownership lives elsewhere
   See: `specs/bind-directives.md`, `specs/css-pipeline.md`, `specs/experimental-async.md`
-- `[ ]` Template validation for regular elements and element attributes
-  Missing today: `node_invalid_placement`, `slot_attribute_invalid_placement`, `textarea_invalid_content`, `component_name_lowercase`, `element_invalid_self_closing_tag`
-- `[ ]` `<textarea>` child-content lowering to a synthetic `value` attribute
-  Missing behavior: reference compiler rewrites dynamic child content and clears fragment children
-- `[ ]` `<option>{expr}</option>` synthetic value handling
-  Missing behavior: reference compiler preserves non-string values via synthetic value metadata / codegen
+- `[~]` Template validation for regular elements and element attributes
+  Working: `element_invalid_self_closing_tag` warning, `textarea_invalid_content` error now emitted from `ElementFlagsVisitor`.
+  Missing: `node_invalid_placement`, `slot_attribute_invalid_placement`, `component_name_lowercase`
+- `[x]` `<textarea>` child-content lowering to a synthetic `value` attribute
+  Implemented: `needs_textarea_value_lowering` flag in ElementFlags; codegen emits `$.remove_textarea_child` + `$.set_value` with raw expression (no constant folding). Test: `textarea_child_value_dynamic`.
+- `[x]` `<option>{expr}</option>` synthetic value handling
+  Implemented: `option_synthetic_value_expr` side table in ElementFlags; codegen emits `option.__value = expr` via `get_node_expr` after textContent. Test: `option_expr_child_value`.
 - `[ ]` Customizable select subtree handling
   Missing behavior: `select` / `option` / `optgroup` rich-content paths and `<selectedcontent>` handling
-- `[ ]` `autofocus` helper path on regular elements
-  Missing behavior: reference uses `$.autofocus(...)` instead of a generic attribute setter
+- `[x]` `autofocus` helper path on regular elements
+  Implemented: `$.autofocus(el, expr)` emitted from `attributes.rs`. Test: `element_autofocus`.
 - `[ ]` Full namespace parity for edge cases like ancestor-derived `<a>` / `<title>` switching
   Current coverage proves common cases only
 
@@ -97,23 +99,20 @@
 
 ## Tasks
 
-1. `[ ]` Add template-validation pass ownership in `svelte_analyze`
-   Files: new validate module(s) plus `crates/svelte_analyze/src/lib.rs`
-   Scope: regular-element placement, slot attribute placement, textarea conflict, self-closing warning, lowercase-component warning
-   Effort: needs infrastructure
-2. `[ ]` Port `<textarea>` dynamic child-content lowering into analyze-side metadata
-   Files: likely new element-side-table metadata in `svelte_analyze`, consumed by `crates/svelte_codegen_client/src/template/element.rs` / `attributes.rs`
-   Effort: moderate
-3. `[ ]` Port `<option>{expr}</option>` synthetic value handling
-   Files: analyze metadata + regular element codegen
-   Effort: moderate
-4. `[ ]` Port customizable select / selectedcontent behavior
+1. `[x]` Add `element_invalid_self_closing_tag` warning + `textarea_invalid_content` error in `ElementFlagsVisitor::visit_element`
+   Files: `crates/svelte_analyze/src/passes/element_flags.rs`
+2. `[x]` Port `<textarea>` dynamic child-content lowering into analyze-side metadata + codegen
+   Files: `crates/svelte_analyze/src/types/data/elements.rs`, `element_flags.rs`, `codegen_view.rs`, `context.rs`, `crates/svelte_codegen_client/src/template/element.rs`
+3. `[x]` Port `<option>{expr}</option>` synthetic value handling
+   Files: same as above
+4. `[x]` Port regular-element runtime special case `autofocus`
+   Files: `crates/svelte_codegen_client/src/template/attributes.rs`
+5. `[ ]` Port remaining template validation: `node_invalid_placement`, `slot_attribute_invalid_placement`, `component_name_lowercase`
+   Effort: moderate (needs component ancestor walk for slot, HTML tree validity table for placement)
+6. `[ ]` Port customizable select / selectedcontent behavior
    Files: analyze metadata + regular element codegen + maybe lowered fragment handling
    Effort: needs infrastructure
-5. `[ ]` Port regular-element runtime special cases such as `autofocus`
-   Files: `crates/svelte_codegen_client/src/template/attributes.rs`
-   Effort: quick fix
-6. `[ ]` Expand namespace edge-case coverage after the semantic gaps above land
+7. `[ ]` Expand namespace edge-case coverage
    Effort: moderate
 
 ## Implementation order

--- a/tasks/compiler_tests/cases2/option_expr_child_value/case-rust.js
+++ b/tasks/compiler_tests/cases2/option_expr_child_value/case-rust.js
@@ -5,6 +5,7 @@ export default function App($$anchor) {
 	var select = root();
 	var option = $.child(select);
 	option.textContent = "1";
+	option.__value = value;
 	$.reset(select);
 	$.append($$anchor, select);
 }

--- a/tasks/compiler_tests/cases2/textarea_child_value_dynamic/case-rust.js
+++ b/tasks/compiler_tests/cases2/textarea_child_value_dynamic/case-rust.js
@@ -3,6 +3,7 @@ var root = $.from_html(`<textarea></textarea>`);
 export default function App($$anchor) {
 	let value = "hello";
 	var textarea = root();
-	textarea.textContent = "hello";
+	$.remove_textarea_child(textarea);
+	$.set_value(textarea, value);
 	$.append($$anchor, textarea);
 }

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -143,13 +143,11 @@ fn element_autofocus() {
 }
 
 #[rstest]
-#[ignore = "missing: known v3 parity gap"]
 fn textarea_child_value_dynamic() {
     assert_compiler("textarea_child_value_dynamic");
 }
 
 #[rstest]
-#[ignore = "missing: known v3 parity gap"]
 fn option_expr_child_value() {
     assert_compiler("option_expr_child_value");
 }


### PR DESCRIPTION
## Summary
This PR implements three key element-handling features for regular elements: textarea child-content lowering to synthetic value attributes, option element synthetic `__value` synthesis, and template validation diagnostics for self-closing tags and textarea content conflicts.

## Key Changes

- **Textarea value lowering**: Added `needs_textarea_value_lowering` flag in `ElementFlags`. When a `<textarea>` has expression children and no explicit `value` attribute, codegen now emits `$.remove_textarea_child()` + `$.set_value()` instead of setting `textContent`. This preserves variable references for proper binding behavior.

- **Option synthetic values**: Implemented `option_synthetic_value_expr` side table mapping option elements to their expression child NodeIds. When an `<option>` has a single expression child and no explicit `value` attribute, codegen synthesizes `option.__value = expr` to enable proper select-binding value comparisons at runtime.

- **Element validation diagnostics**: Added `ElementFlagsVisitor::visit_element()` to emit:
  - `element_invalid_self_closing_tag` warning for non-void, non-SVG, non-MathML elements written as self-closing
  - `textarea_invalid_content` error when textarea has both expression children and explicit `value` attribute

- **Autofocus helper**: Already implemented in `attributes.rs` to emit `$.autofocus(el, expr)` instead of generic attribute setter.

- **Test updates**: Removed `#[ignore]` from `textarea_child_value_dynamic` and `option_expr_child_value` tests, which now pass with the new codegen behavior.

## Implementation Details

- New metadata fields in `ElementFlags` use `NodeBitSet` (for boolean flags) and `NodeTable<NodeId>` (for expression mappings) to track element-specific lowering requirements.
- `extract_single_raw_expr_or_concat()` helper in `element.rs` bypasses constant folding to preserve variable references where live bindings are required.
- Validation logic walks element children to detect expression tags and checks for conflicting attributes.
- Context methods in `Ctx` and `CodegenView` provide codegen access to the new metadata.

https://claude.ai/code/session_01PYNeVY3cQJYCTfSWnQJDZB