### PR TITLE
Complete $state rune implementation: validation, dev transforms, and var-declared state

### DIFF
--- a/crates/svelte_analyze/src/passes/mark_runes.rs
+++ b/crates/svelte_analyze/src/passes/mark_runes.rs
@@ -9,7 +9,7 @@ use oxc_ast_visit::Visit;
 
 use crate::scope::{ComponentScoping, ScopeId, SymbolId};
 use crate::types::data::AnalysisData;
-use crate::types::script::RuneKind;
+use crate::types::script::{DeclarationKind, RuneKind};
 
 /// Mark runes declared at the root scope from ScriptInfo.
 pub(crate) fn mark_script_runes(data: &mut AnalysisData) {
@@ -20,6 +20,11 @@ pub(crate) fn mark_script_runes(data: &mut AnalysisData) {
         let Some(sym_id) = data.scoping.find_binding(root, &decl.name) else { continue };
         let is_proxy = data.proxy_state_inits.get(&decl.name).copied().unwrap_or(false);
         data.scoping.mark_rune_with_proxy(sym_id, rune_kind, is_proxy);
+        if decl.kind == DeclarationKind::Var
+            && matches!(rune_kind, RuneKind::State | RuneKind::StateRaw)
+        {
+            data.scoping.mark_var_state(sym_id);
+        }
         if rune_kind.is_derived() && !decl.rune_init_refs.is_empty() {
             let deps: Vec<SymbolId> = decl.rune_init_refs.iter()
                 .filter_map(|name| data.scoping.find_binding(root, name))

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -50,6 +50,10 @@ pub struct ComponentScoping {
     rest_prop_sym: Option<SymbolId>,
     /// Prop names explicitly destructured before the rest element (excluded from rewriting)
     rest_prop_excluded: FxHashSet<String>,
+    /// Symbols declared with `var` (as opposed to `let`/`const`) that are state runes.
+    /// `var`-declared state must use `$.safe_get` instead of `$.get` because `var` hoisting
+    /// means the binding may be read before its initializer runs.
+    var_state_syms: FxHashSet<SymbolId>,
 }
 
 impl ComponentScoping {
@@ -83,6 +87,7 @@ impl ComponentScoping {
             dynamic_sym_cache: None,
             rest_prop_sym: None,
             rest_prop_excluded: FxHashSet::default(),
+            var_state_syms: FxHashSet::default(),
         }
     }
 
@@ -173,6 +178,24 @@ impl ComponentScoping {
 
     pub fn is_rune(&self, id: SymbolId) -> bool {
         self.runes.contains_key(&id)
+    }
+
+    /// True when a `$state`/`$state.raw` init argument is non-primitive (proxy candidate).
+    /// Proxy-candidate state is still reactive through property mutations even without reassignment.
+    pub fn is_proxy_init_state(&self, id: SymbolId) -> bool {
+        self.runes.get(&id).is_some_and(|r| r.is_proxy_init)
+    }
+
+    /// Mark a state rune symbol as `var`-declared.
+    /// `var`-declared state requires `$.safe_get` instead of `$.get` because var hoisting means
+    /// the binding may be read before its initializer has run.
+    pub fn mark_var_state(&mut self, id: SymbolId) {
+        self.var_state_syms.insert(id);
+    }
+
+    /// True when the symbol is a state rune declared with `var`.
+    pub fn is_var_declared_state(&self, id: SymbolId) -> bool {
+        self.var_state_syms.contains(&id)
     }
 
     /// Store a Reference object and return its ReferenceId.

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -1257,6 +1257,112 @@ let x = $state(() => total);
 }
 
 #[test]
+fn validate_state_referenced_locally_for_reassigned_state() {
+    // Reassigned $state at the same function depth — should warn.
+    let diags = analyze_with_diags(
+        r#"<script>
+let count = $state(0);
+count = 1;
+const snapshot = count;
+</script>"#,
+    );
+    assert_has_warning(&diags, "state_referenced_locally");
+}
+
+#[test]
+fn validate_state_referenced_locally_for_primitive_state() {
+    // $state with primitive init and no reassignment: !is_proxy_init — should warn.
+    let diags = analyze_with_diags(
+        r#"<script>
+let count = $state(42);
+const snapshot = count;
+</script>"#,
+    );
+    assert_has_warning(&diags, "state_referenced_locally");
+}
+
+#[test]
+fn validate_state_referenced_locally_no_warning_for_proxy_state() {
+    // $state({}) has is_proxy_init = true and is not reassigned — no warning.
+    let diags = analyze_with_diags(
+        r#"<script>
+let obj = $state({ x: 1 });
+obj.x = 2;
+const ref_ = obj;
+</script>"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.kind.code() != "state_referenced_locally"),
+        "unexpected warning for proxy state: {diags:?}",
+    );
+}
+
+#[test]
+fn validate_state_referenced_locally_for_state_raw() {
+    // $state.raw is always warned at same function depth.
+    let diags = analyze_with_diags(
+        r#"<script>
+let items = $state.raw([1, 2, 3]);
+const snapshot = items;
+</script>"#,
+    );
+    assert_has_warning(&diags, "state_referenced_locally");
+}
+
+#[test]
+fn validate_state_referenced_locally_no_warning_across_fn_boundary_state() {
+    // Inside a function the depth differs — no warning for $state either.
+    let diags = analyze_with_diags(
+        r#"<script>
+let count = $state(0);
+count = 1;
+const fn_ = () => count;
+</script>"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.kind.code() != "state_referenced_locally"),
+        "unexpected warning across fn boundary: {diags:?}",
+    );
+}
+
+#[test]
+fn validate_state_invalid_export_for_reassigned_state() {
+    let diags = analyze_with_diags(
+        r#"<script>
+export let count = $state(0);
+count = 1;
+</script>"#,
+    );
+    assert_has_error(&diags, "state_invalid_export");
+}
+
+#[test]
+fn validate_state_invalid_export_for_reassigned_state_raw() {
+    let diags = analyze_with_diags(
+        r#"<script>
+export let items = $state.raw([]);
+items = [];
+</script>"#,
+    );
+    assert_has_error(&diags, "state_invalid_export");
+}
+
+#[test]
+fn validate_state_invalid_export_no_error_without_reassignment() {
+    // Property mutations do not count as reassignment.
+    let diags = analyze_with_diags(
+        r#"<script>
+export let obj = $state({ x: 0 });
+obj.x = 1;
+</script>"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.kind.code() != "state_invalid_export"),
+        "unexpected error: {diags:?}",
+    );
+}
+
+#[test]
 #[ignore = "missing: rune validation parity"]
 fn validate_effect_invalid_placement_fn_arg() {
     let diags = analyze_with_diags(

--- a/crates/svelte_analyze/src/validate/runes.rs
+++ b/crates/svelte_analyze/src/validate/runes.rs
@@ -43,6 +43,7 @@ pub(super) fn validate(
     };
     v.visit_program(program);
     validate_derived_invalid_export(data, program, offset, diags);
+    validate_state_invalid_export(data, program, offset, diags);
     validate_state_referenced_locally_derived(data, program, offset, diags);
 }
 
@@ -120,13 +121,40 @@ fn validate_derived_invalid_export(
     }
 }
 
+fn validate_state_invalid_export(
+    data: &AnalysisData,
+    program: &oxc_ast::ast::Program<'_>,
+    offset: u32,
+    diags: &mut Vec<Diagnostic>,
+) {
+    for stmt in &program.body {
+        let oxc_ast::ast::Statement::ExportNamedDeclaration(export) = stmt else { continue };
+        let Some(oxc_ast::ast::Declaration::VariableDeclaration(var_decl)) = &export.declaration else { continue };
+        let has_reassigned_state = var_decl.declarations.iter().any(|declarator| {
+            let oxc_ast::ast::BindingPattern::BindingIdentifier(ident) = &declarator.id else {
+                return false;
+            };
+            let Some(sym_id) = ident.symbol_id.get() else { return false };
+            data.scoping.rune_kind(sym_id)
+                .is_some_and(|k| matches!(k, RuneKind::State | RuneKind::StateRaw))
+                && data.scoping.is_mutated(sym_id)
+        });
+        if has_reassigned_state {
+            diags.push(Diagnostic::error(
+                DiagnosticKind::StateInvalidExport,
+                Span::new(export.span.start + offset, export.span.end + offset),
+            ));
+        }
+    }
+}
+
 fn validate_state_referenced_locally_derived(
     data: &AnalysisData,
     program: &oxc_ast::ast::Program<'_>,
     offset: u32,
     diags: &mut Vec<Diagnostic>,
 ) {
-    let mut v = StateRefLocallyValidator { data, offset, diags, in_state_rune_arg: false, _phantom: std::marker::PhantomData };
+    let mut v = StateRefLocallyValidator { data, offset, diags, in_state_rune_arg: false, derived_call_depth: 0, _phantom: std::marker::PhantomData };
     v.visit_program(program);
 }
 
@@ -137,6 +165,10 @@ struct StateRefLocallyValidator<'a, 'b> {
     /// True when currently inside arguments of a `$state`/`$state.raw` call,
     /// without a function boundary in between. Determines `type_` in the diagnostic.
     in_state_rune_arg: bool,
+    /// Incremented when entering `$derived`/`$derived.by` call arguments.
+    /// Mirrors the reference compiler's `function_depth += 1` for `$derived` calls:
+    /// references inside `$derived(...)` are semantically deeper and should not warn.
+    derived_call_depth: usize,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
@@ -145,11 +177,25 @@ impl<'a> Visit<'a> for StateRefLocallyValidator<'a, '_> {
         let Some(ref_id) = ident.reference_id.get() else { return };
         if self.data.scoping.is_template_reference(ref_id) { return }
         let reference = self.data.scoping.get_reference(ref_id);
-        if !reference.is_read() { return }
+        // Skip if not a read, or if it's a write context (UpdateExpression, compound assignment LHS).
+        // Mirrors reference compiler: only warn for pure reads, not read-write operations.
+        if !reference.is_read() || reference.is_write() { return }
         let Some(sym_id) = reference.symbol_id() else { return };
-        if !self.data.scoping.rune_kind(sym_id).is_some_and(|k| k.is_derived()) { return }
+        let should_warn = match self.data.scoping.rune_kind(sym_id) {
+            Some(k) if k.is_derived() => true,
+            Some(RuneKind::StateRaw) => true,
+            Some(RuneKind::State) => {
+                self.data.scoping.is_mutated(sym_id)
+                    || !self.data.scoping.is_proxy_init_state(sym_id)
+            }
+            _ => false,
+        };
+        if !should_warn { return }
         let decl_depth = self.data.scoping.function_depth(self.data.scoping.symbol_scope_id(sym_id));
-        if self.data.scoping.function_depth(reference.scope_id()) != decl_depth { return }
+        // Add derived_call_depth to mirror the reference compiler's function_depth += 1 for $derived:
+        // references inside $derived(...) are semantically one level deeper and should not warn.
+        let ref_depth = self.data.scoping.function_depth(reference.scope_id()) + self.derived_call_depth;
+        if ref_depth != decl_depth { return }
         let name = self.data.scoping.symbol_name(sym_id);
         let type_ = if self.in_state_rune_arg { "derived" } else { "closure" };
         self.diags.push(Diagnostic::warning(
@@ -162,28 +208,41 @@ impl<'a> Visit<'a> for StateRefLocallyValidator<'a, '_> {
     }
 
     fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
-        if detect_rune_from_call(call).is_some_and(|k| matches!(k, RuneKind::State | RuneKind::StateRaw)) {
-            self.visit_expression(&call.callee);
-            let prev = std::mem::replace(&mut self.in_state_rune_arg, true);
-            for arg in &call.arguments {
-                self.visit_argument(arg);
+        match detect_rune_from_call(call) {
+            Some(k) if matches!(k, RuneKind::State | RuneKind::StateRaw) => {
+                self.visit_expression(&call.callee);
+                let prev = std::mem::replace(&mut self.in_state_rune_arg, true);
+                for arg in &call.arguments {
+                    self.visit_argument(arg);
+                }
+                self.in_state_rune_arg = prev;
             }
-            self.in_state_rune_arg = prev;
-        } else {
-            walk_call_expression(self, call);
+            Some(k) if k.is_derived() => {
+                self.visit_expression(&call.callee);
+                self.derived_call_depth += 1;
+                for arg in &call.arguments {
+                    self.visit_argument(arg);
+                }
+                self.derived_call_depth -= 1;
+            }
+            _ => walk_call_expression(self, call),
         }
     }
 
     fn visit_arrow_function_expression(&mut self, arrow: &oxc_ast::ast::ArrowFunctionExpression<'a>) {
-        let prev = std::mem::replace(&mut self.in_state_rune_arg, false);
+        let prev_state_arg = std::mem::replace(&mut self.in_state_rune_arg, false);
+        let prev_derived_depth = std::mem::replace(&mut self.derived_call_depth, 0);
         walk_arrow_function_expression(self, arrow);
-        self.in_state_rune_arg = prev;
+        self.in_state_rune_arg = prev_state_arg;
+        self.derived_call_depth = prev_derived_depth;
     }
 
     fn visit_function(&mut self, func: &oxc_ast::ast::Function<'a>, flags: oxc_semantic::ScopeFlags) {
-        let prev = std::mem::replace(&mut self.in_state_rune_arg, false);
+        let prev_state_arg = std::mem::replace(&mut self.in_state_rune_arg, false);
+        let prev_derived_depth = std::mem::replace(&mut self.derived_call_depth, 0);
         walk_function(self, func, flags);
-        self.in_state_rune_arg = prev;
+        self.in_state_rune_arg = prev_state_arg;
+        self.derived_call_depth = prev_derived_depth;
     }
 }
 

--- a/crates/svelte_codegen_client/src/script/traverse/assignments.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/assignments.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::Expression;
-use oxc_traverse::TraverseCtx;
+use oxc_traverse::{Ancestor, TraverseCtx};
 use svelte_analyze::RuneKind;
 
 use crate::builder::Arg;
@@ -10,7 +10,7 @@ impl<'a> ScriptTransformer<'_, 'a> {
     pub(super) fn transform_assignment(
         &self,
         node: &mut Expression<'a>,
-        _ctx: &mut TraverseCtx<'a, ()>,
+        ctx: &mut TraverseCtx<'a, ()>,
     ) {
         let Expression::AssignmentExpression(assign) = node else {
             return;
@@ -59,13 +59,20 @@ impl<'a> ScriptTransformer<'_, 'a> {
             if let Some((kind, mutated)) = self.rune_for_ref(id) {
                 if mutated {
                     let name = id.name.as_str().to_string();
+                    // Resolve sym_id while `id` borrow is still available (before move_expr borrows assign).
+                    let is_var_state = id.reference_id.get()
+                        .and_then(|r| self.scoping.get_reference(r).symbol_id())
+                        .is_some_and(|s| self.component_scoping.is_var_declared_state(s));
                     let right = self.b.move_expr(&mut assign.right);
 
                     let value = if assign.operator.is_assign() {
                         right
                     } else {
-                        let left_get =
-                            svelte_transform::rune_refs::make_rune_get(self.b.ast.allocator, &name);
+                        let left_get = if is_var_state {
+                            svelte_transform::rune_refs::make_rune_safe_get(self.b.ast.allocator, &name)
+                        } else {
+                            svelte_transform::rune_refs::make_rune_get(self.b.ast.allocator, &name)
+                        };
                         if let Some(bin_op) = assign.operator.to_binary_operator() {
                             self.b
                                 .ast
@@ -106,6 +113,84 @@ impl<'a> ScriptTransformer<'_, 'a> {
             let untracked = svelte_transform::rune_refs::make_untrack(alloc, &root_name);
             *node = svelte_transform::rune_refs::make_store_mutate(
                 alloc, &base_name, mutation, untracked,
+            );
+            return;
+        }
+
+        // Dev-mode: rewrite non-statement member-expression assignments to $.assign_*(obj, key, rhs, loc)
+        if !self.dev {
+            return;
+        }
+        let Expression::AssignmentExpression(assign) = &*node else { return };
+        let fn_name = match assign.operator {
+            oxc_ast::ast::AssignmentOperator::Assign         => "$.assign",
+            oxc_ast::ast::AssignmentOperator::LogicalAnd     => "$.assign_and",
+            oxc_ast::ast::AssignmentOperator::LogicalOr      => "$.assign_or",
+            oxc_ast::ast::AssignmentOperator::LogicalNullish => "$.assign_nullish",
+            _ => return,
+        };
+        if !svelte_transform::rune_refs::should_proxy(&assign.right) {
+            return;
+        }
+        if matches!(ctx.parent(), Ancestor::ExpressionStatementExpression(_)) {
+            return;
+        }
+        let is_static = matches!(
+            &assign.left,
+            oxc_ast::ast::AssignmentTarget::StaticMemberExpression(_)
+        );
+        let is_computed = matches!(
+            &assign.left,
+            oxc_ast::ast::AssignmentTarget::ComputedMemberExpression(_)
+        );
+        if !is_static && !is_computed {
+            return;
+        }
+
+        // Capture span before moving (spans are Copy)
+        let left_span_start = assign.span.start;
+        let offset = self.script_content_start + left_span_start;
+        let (line, col) = crate::script::location::compute_line_col(self.component_source, offset);
+        let loc = format!(
+            "{}:{}:{}",
+            crate::script::location::sanitize_location(self.filename),
+            line,
+            col
+        );
+
+        // Move whole node to obtain ownership, then destructure
+        let whole = self.b.move_expr(node);
+        let Expression::AssignmentExpression(assign_box) = whole else { unreachable!() };
+        let assign = assign_box.unbox();
+
+        if is_static {
+            let oxc_ast::ast::AssignmentTarget::StaticMemberExpression(m) = assign.left else {
+                unreachable!()
+            };
+            let m = m.unbox();
+            let key = self.b.str_expr(m.property.name.as_str());
+            *node = self.b.call_expr(
+                fn_name,
+                [
+                    Arg::Expr(m.object),
+                    Arg::Expr(key),
+                    Arg::Expr(assign.right),
+                    Arg::Str(loc),
+                ],
+            );
+        } else {
+            let oxc_ast::ast::AssignmentTarget::ComputedMemberExpression(m) = assign.left else {
+                unreachable!()
+            };
+            let m = m.unbox();
+            *node = self.b.call_expr(
+                fn_name,
+                [
+                    Arg::Expr(m.object),
+                    Arg::Expr(m.expression),
+                    Arg::Expr(assign.right),
+                    Arg::Str(loc),
+                ],
             );
         }
     }

--- a/crates/svelte_codegen_client/src/script/traverse/runes.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/runes.rs
@@ -288,13 +288,19 @@ impl<'a> ScriptTransformer<'_, 'a> {
             *node = self.b.call_expr(&name, std::iter::empty::<Arg<'a, '_>>());
             return;
         }
-        let Some((kind, mutated)) = self.rune_for_ref(id) else {
-            return;
-        };
+        let Some(ref_id) = id.reference_id.get() else { return };
+        let Some(sym_id) = self.scoping.get_reference(ref_id).symbol_id() else { return };
+        let Some(kind) = self.component_scoping.rune_kind(sym_id) else { return };
+        let mutated = self.component_scoping.is_mutated(sym_id);
         let needs_get = mutated || kind.is_derived();
         if needs_get {
             let name = id.name.as_str().to_string();
-            *node = svelte_transform::rune_refs::make_rune_get(self.b.ast.allocator, &name);
+            let alloc = self.b.ast.allocator;
+            *node = if self.component_scoping.is_var_declared_state(sym_id) {
+                svelte_transform::rune_refs::make_rune_safe_get(alloc, &name)
+            } else {
+                svelte_transform::rune_refs::make_rune_get(alloc, &name)
+            };
         }
     }
 }

--- a/crates/svelte_transform/src/lib.rs
+++ b/crates/svelte_transform/src/lib.rs
@@ -394,7 +394,11 @@ impl<'a> VisitMut<'a> for ExprTransformer<'a, '_, '_> {
             } else if let Some(kind) = self.ctx.analysis.scoping.rune_kind(sym_id) {
                 let needs_get = self.ctx.analysis.scoping.is_mutated(sym_id) || kind.is_derived();
                 if needs_get {
-                    *it = rune_refs::make_rune_get(self.ctx.alloc, name);
+                    *it = if self.ctx.analysis.scoping.is_var_declared_state(sym_id) {
+                        rune_refs::make_rune_safe_get(self.ctx.alloc, name)
+                    } else {
+                        rune_refs::make_rune_get(self.ctx.alloc, name)
+                    };
                 }
             }
             return;

--- a/crates/svelte_transform/src/rune_refs.rs
+++ b/crates/svelte_transform/src/rune_refs.rs
@@ -14,6 +14,16 @@ pub fn make_rune_get<'a>(alloc: &'a Allocator, name: &str) -> Expression<'a> {
     ast.expression_call(SPAN, callee, NONE, ast.vec1(name_arg), false)
 }
 
+/// Build `$.safe_get(name)` call expression.
+/// Used instead of `$.get` for `var`-declared state, because `var` hoisting means the binding
+/// may be read before the initializer runs and the signal is set.
+pub fn make_rune_safe_get<'a>(alloc: &'a Allocator, name: &str) -> Expression<'a> {
+    let ast = AstBuilder::new(alloc);
+    let callee = make_dollar_member(&ast, "safe_get");
+    let name_arg = Argument::from(ast.expression_identifier(SPAN, ast.atom(name)));
+    ast.expression_call(SPAN, callee, NONE, ast.vec1(name_arg), false)
+}
+
 /// Build `$.set(name, value[, true])` call expression.
 /// If `proxy` is true, adds a third `true` argument.
 pub fn make_rune_set<'a>(

--- a/specs/state-rune.md
+++ b/specs/state-rune.md
@@ -1,17 +1,16 @@
 # $state rune
 
 ## Current state
-- **Working**: 39/43 use cases covered with passing tests (35 compiler tests, 12 analyze unit tests)
+- **Working**: 43/43 use cases covered — ALL items complete
 - **Bugs found**: 3 codegen bugs discovered → all 3 FIXED
-- **Missing (audit 2026-04-01)**:
-  - #37 `state_referenced_locally` warning — diagnostic defined but not emitted in analyze
-  - #38 `state_invalid_export` error — diagnostic defined but not emitted in analyze
-  - #39 Dev-mode `$.assign_*` transforms (`$.assign`, `$.assign_and`, `$.assign_or`, `$.assign_nullish`)
-  - #40 `$.safe_get` for `var`-declared state (currently uses `$.get`)
+- **Completed (2026-04-02)**:
+  - #37 `state_referenced_locally` warning for `$state`/`$state.raw` reads ✅
+  - #38 `state_invalid_export` error for exported reassigned state ✅
+  - #39 Dev-mode `$.assign_*` transforms for non-statement member assignments ✅
+  - #40 `$.safe_get` for `var`-declared state ✅
 - **Deferred**: #41 `$.deep_read_state()` — legacy-only (Svelte 4), Tier 7; #32 ObjectPattern dev labels
 - **Out of scope**: SSR, `immutable` compiler option
-- **Next**: implement #37-#40 via `/fix-test` or `/port`
-- Last updated: 2026-04-01
+- Last updated: 2026-04-02
 
 ## Source
 Audit of existing implementation

--- a/tasks/compiler_tests/cases2/state_assign_dev/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_assign_dev/case-rust.js
@@ -11,13 +11,13 @@ export default function App($$anchor, $$props) {
 		map: null
 	}), "obj");
 	// Non-statement assignment — should use $.assign_nullish in dev
-	(obj.items ??= []).push(1);
+	$.assign_nullish(obj, "items", [], "(unknown):5:2").push(1);
 	// Non-statement assignment — should use $.assign in dev
-	(obj.data = []).push(2);
+	$.assign(obj, "data", [], "(unknown):8:2").push(2);
 	// Non-statement — $.assign_and
-	(obj.list &&= []).length;
+	$.assign_and(obj, "list", [], "(unknown):11:2").length;
 	// Non-statement — $.assign_or
-	(obj.map ||= []).length;
+	$.assign_or(obj, "map", [], "(unknown):14:2").length;
 	var $$exports = { ...$.legacy_api() };
 	var p = root();
 	var text = $.child(p, true);

--- a/tasks/compiler_tests/cases2/state_var_safe_get/case-rust.js
+++ b/tasks/compiler_tests/cases2/state_var_safe_get/case-rust.js
@@ -3,10 +3,10 @@ var root = $.from_html(`<p> </p>`);
 export default function App($$anchor) {
 	var count = $.state(0);
 	var name = "hello";
-	$.set(count, $.get(count) + 1);
+	$.set(count, $.safe_get(count) + 1);
 	var p = root();
 	var text = $.child(p);
 	$.reset(p);
-	$.template_effect(() => $.set_text(text, `${$.get(count) ?? ""} hello`));
+	$.template_effect(() => $.set_text(text, `${$.safe_get(count) ?? ""} hello`));
 	$.append($$anchor, p);
 }

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2246,13 +2246,11 @@ fn tag_state_destructured_array() {
 }
 
 #[rstest]
-#[ignore = "missing: $.safe_get for var-declared state (codegen)"]
 fn state_var_safe_get() {
     assert_compiler("state_var_safe_get");
 }
 
 #[rstest]
-#[ignore = "missing: dev-mode $.assign_* transforms for non-statement member assignment (codegen)"]
 fn state_assign_dev() {
     assert_compiler("state_assign_dev");
 }


### PR DESCRIPTION
## Summary
This PR completes the `$state` rune implementation by adding missing validation diagnostics, dev-mode assignment transforms, and proper handling of `var`-declared state variables. All 43 use cases for the `$state` rune are now covered.

## Key Changes

### Validation & Diagnostics
- **`state_referenced_locally` warning**: Added validation to warn when `$state` or `$state.raw` variables are read at the same function depth where they're declared, with special handling for:
  - Reassigned state (always warns)
  - Primitive-initialized state (warns, as it's not a proxy)
  - Proxy-initialized state like `$state({})` (no warning, reactive through mutations)
  - References inside `$derived()` calls (no warning, treated as deeper scope)
  - References across function boundaries (no warning)

- **`state_invalid_export` error**: Added validation to error when exported variables with `$state` or `$state.raw` are reassigned, while allowing property mutations without reassignment

### Dev-Mode Assignment Transforms
- Implemented `$.assign_*` transforms for non-statement member-expression assignments in dev mode:
  - `$.assign()` for standard assignments
  - `$.assign_and()` for `&&=` operator
  - `$.assign_or()` for `||=` operator
  - `$.assign_nullish()` for `??=` operator
- These transforms include location information for better dev-mode debugging
- Only applied to non-statement contexts (statement assignments remain unchanged)

### `var`-Declared State Handling
- Added tracking of `var`-declared state symbols in `ComponentScoping`
- Implemented `$.safe_get()` function for reading `var`-declared state instead of `$.get()`
- This is necessary because `var` hoisting means the binding may be read before its initializer runs
- Applied in three places: identifier references, assignment compound operators, and general expression transforms

### Test Coverage
- Added 8 comprehensive test cases covering all `state_referenced_locally` and `state_invalid_export` scenarios
- Updated existing compiler tests to reflect new dev-mode transforms
- Removed `#[ignore]` attributes from previously skipped tests that now pass

## Implementation Details
- The `StateRefLocallyValidator` now tracks `derived_call_depth` to mirror the reference compiler's function depth semantics for `$derived` calls
- Assignment transforms check `should_proxy()` to avoid unnecessary wrapping of non-reactive values
- Location information for dev-mode transforms is computed from source positions and sanitized for display
- The implementation properly handles both static and computed member expressions

https://claude.ai/code/session_01RqEyD5AYKX9B3QDXehmVmX