### PR TITLE
Port store subscriptions: mark_store_binding + validation diagnostics

### DIFF
--- a/crates/svelte_analyze/src/passes/element_flags.rs
+++ b/crates/svelte_analyze/src/passes/element_flags.rs
@@ -189,11 +189,11 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
                     ComponentPropKind::BindThis { bind_id: b.id }
                 }
                 Attribute::BindDirective(b) => {
-                    // Determine the expression identifier for store-sub detection.
-                    // For shorthand `bind:count` the expression is `$count`;
-                    // for explicit `bind:value={$count}` it's the span text.
+                    // Store-sub detection: only possible with explicit expression
+                    // (`bind:value={$count}`). Shorthand `bind:count` binds to `count`,
+                    // never to `$count`, so it can't be a store sub.
                     let expr_text = if b.shorthand {
-                        Some(format!("${}", b.name))
+                        None
                     } else {
                         b.expression_span.map(|span| self.source_text(span).to_string())
                     };

--- a/crates/svelte_analyze/src/passes/element_flags.rs
+++ b/crates/svelte_analyze/src/passes/element_flags.rs
@@ -189,24 +189,49 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
                     ComponentPropKind::BindThis { bind_id: b.id }
                 }
                 Attribute::BindDirective(b) => {
-                    let root = data.scoping.root_scope_id();
-                    let mode = data
-                        .scoping
-                        .find_binding(root, &b.name)
-                        .map(|sym| {
-                            if data.scoping.is_prop_source(sym) {
-                                ComponentBindMode::PropSource
-                            } else if data.scoping.is_rune(sym) && data.scoping.is_mutated(sym) {
-                                ComponentBindMode::Rune
-                            } else {
-                                ComponentBindMode::Plain
-                            }
-                        })
-                        .unwrap_or(ComponentBindMode::Plain);
-                    ComponentPropKind::Bind {
-                        name: b.name.clone(),
-                        bind_id: b.id,
-                        mode,
+                    // Determine the expression identifier for store-sub detection.
+                    // For shorthand `bind:count` the expression is `$count`;
+                    // for explicit `bind:value={$count}` it's the span text.
+                    let expr_text = if b.shorthand {
+                        Some(format!("${}", b.name))
+                    } else {
+                        b.expression_span.map(|span| self.source_text(span).to_string())
+                    };
+
+                    let is_store = expr_text
+                        .as_deref()
+                        .is_some_and(|t| data.scoping.is_store_ref(t));
+
+                    if is_store {
+                        ComponentPropKind::Bind {
+                            name: b.name.clone(),
+                            bind_id: b.id,
+                            mode: ComponentBindMode::StoreSub,
+                            expr_name: expr_text,
+                        }
+                    } else {
+                        let root = data.scoping.root_scope_id();
+                        let mode = data
+                            .scoping
+                            .find_binding(root, &b.name)
+                            .map(|sym| {
+                                if data.scoping.is_prop_source(sym) {
+                                    ComponentBindMode::PropSource
+                                } else if data.scoping.is_rune(sym)
+                                    && data.scoping.is_mutated(sym)
+                                {
+                                    ComponentBindMode::Rune
+                                } else {
+                                    ComponentBindMode::Plain
+                                }
+                            })
+                            .unwrap_or(ComponentBindMode::Plain);
+                        ComponentPropKind::Bind {
+                            name: b.name.clone(),
+                            bind_id: b.id,
+                            mode,
+                            expr_name: None,
+                        }
                     }
                 }
                 Attribute::AttachTag(a) => ComponentPropKind::Attach { attr_id: a.id },

--- a/crates/svelte_analyze/src/scope.rs
+++ b/crates/svelte_analyze/src/scope.rs
@@ -544,6 +544,14 @@ impl ComponentScoping {
         self.scoping.symbol_names().map(|s| s.to_string()).collect()
     }
 
+    /// Check if a name exists as a symbol in any scope (not just root).
+    /// Used for `store_invalid_scoped_subscription` to detect nested declarations.
+    pub fn find_binding_in_any_scope(&self, name: &str) -> Option<SymbolId> {
+        self.scoping
+            .symbol_ids()
+            .find(|&id| self.scoping.symbol_name(id) == name)
+    }
+
     /// Check if a name is a store subscription (`$X` where `X` is marked as store in root scope).
     pub fn is_store_ref(&self, name: &str) -> bool {
         self.store_base_name(name).is_some()

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2200,3 +2200,28 @@ fn validate_attribute_contenteditable_missing() {
     );
     assert_has_error(&diags, "attribute_contenteditable_missing");
 }
+
+#[test]
+fn validate_store_invalid_scoped_subscription() {
+    let diags = analyze_with_diags(
+        r#"<script>
+function foo() {
+    let count = 0;
+    console.log($count);
+}
+</script>"#,
+    );
+    assert_has_error(&diags, "store_invalid_scoped_subscription");
+}
+
+#[test]
+fn validate_store_rune_conflict() {
+    let diags = analyze_with_diags(
+        r#"<script>
+import { writable } from 'svelte/store';
+let state = writable(0);
+let x = $state(0);
+</script>"#,
+    );
+    assert_has_warning(&diags, "store_rune_conflict");
+}

--- a/crates/svelte_analyze/src/types/data/elements.rs
+++ b/crates/svelte_analyze/src/types/data/elements.rs
@@ -43,6 +43,9 @@ pub enum ComponentPropKind {
         name: String,
         bind_id: NodeId,
         mode: ComponentBindMode,
+        /// For store-sub binds: the expression identifier (e.g., `"$count"`).
+        /// `None` for non-store binds where `name` is used directly.
+        expr_name: Option<String>,
     },
     Spread {
         attr_id: NodeId,
@@ -57,6 +60,9 @@ pub enum ComponentBindMode {
     PropSource,
     Rune,
     Plain,
+    /// Bind expression targets a store subscription (e.g. `bind:value={$count}`).
+    /// Codegen emits `$.mark_store_binding()` in the getter.
+    StoreSub,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/svelte_analyze/src/validate/mod.rs
+++ b/crates/svelte_analyze/src/validate/mod.rs
@@ -1,4 +1,5 @@
 mod runes;
+mod stores;
 
 use oxc_ast::ast::Program;
 use svelte_diagnostics::Diagnostic;
@@ -21,4 +22,5 @@ pub fn validate_program(
     diags: &mut Vec<Diagnostic>,
 ) {
     runes::validate(data, program, offset, diags);
+    stores::validate(data, program, offset, diags);
 }

--- a/crates/svelte_analyze/src/validate/stores.rs
+++ b/crates/svelte_analyze/src/validate/stores.rs
@@ -1,0 +1,96 @@
+//! Store subscription validation — scoped subscription, rune conflict.
+
+use oxc_ast::ast::{CallExpression, Expression, IdentifierReference};
+use oxc_ast_visit::walk::walk_call_expression;
+use oxc_ast_visit::Visit;
+use oxc_span::GetSpan;
+use svelte_diagnostics::{Diagnostic, DiagnosticKind};
+use svelte_span::Span;
+
+use crate::utils::script_info::is_rune_name;
+use crate::AnalysisData;
+
+pub(super) fn validate(
+    data: &AnalysisData,
+    program: &oxc_ast::ast::Program<'_>,
+    offset: u32,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let mut v = StoreValidator {
+        diags,
+        offset,
+        data,
+    };
+    v.visit_program(program);
+}
+
+struct StoreValidator<'a> {
+    diags: &'a mut Vec<Diagnostic>,
+    offset: u32,
+    data: &'a AnalysisData,
+}
+
+impl StoreValidator<'_> {
+    fn span(&self, oxc_span: oxc_span::Span) -> Span {
+        Span {
+            start: oxc_span.start + self.offset,
+            end: oxc_span.end + self.offset,
+        }
+    }
+
+    /// Check if `$X` where `X` is declared in a nested (non-root) scope.
+    fn check_scoped_subscription(&mut self, ident: &IdentifierReference<'_>) {
+        let name = ident.name.as_str();
+        if !name.starts_with('$') || name.len() <= 1 || name.starts_with("$$") {
+            return;
+        }
+        let base = &name[1..];
+
+        // Skip rune names — those are handled by rune validation
+        if is_rune_name(name) {
+            return;
+        }
+
+        let root = self.data.scoping.root_scope_id();
+
+        // If already resolved in root scope, it's a valid store subscription
+        if self.data.scoping.find_binding(root, base).is_some() {
+            return;
+        }
+
+        // Check if base name exists in any non-root scope
+        if self.data.scoping.find_binding_in_any_scope(base).is_some() {
+            self.diags.push(Diagnostic::error(
+                DiagnosticKind::StoreInvalidScopedSubscription,
+                self.span(ident.span()),
+            ));
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for StoreValidator<'_> {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'ast>) {
+        self.check_scoped_subscription(ident);
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
+        // store_rune_conflict: $X(...) where is_rune_name("$X") and X is a local binding
+        if let Expression::Identifier(callee) = &call.callee {
+            let name = callee.name.as_str();
+            if is_rune_name(name) && name.starts_with('$') && name.len() > 1 {
+                let base = &name[1..];
+                let root = self.data.scoping.root_scope_id();
+                if self.data.scoping.find_binding(root, base).is_some() {
+                    self.diags.push(Diagnostic::warning(
+                        DiagnosticKind::StoreRuneConflict {
+                            name: base.to_string(),
+                        },
+                        self.span(callee.span()),
+                    ));
+                }
+            }
+        }
+
+        walk_call_expression(self, call);
+    }
+}

--- a/crates/svelte_codegen_client/src/builder/mod.rs
+++ b/crates/svelte_codegen_client/src/builder/mod.rs
@@ -64,6 +64,8 @@ pub enum ObjProp<'a> {
     Spread(Expression<'a>),
     /// `get name() { return expr }`
     Getter(&'a str, Expression<'a>),
+    /// `get name() { stmts... }` — multi-statement getter body
+    GetterBody(&'a str, Vec<Statement<'a>>),
     /// `set name(param_name = default?) { body }`
     Setter(&'a str, &'a str, Option<Expression<'a>>, Vec<Statement<'a>>),
     /// `[computed_key]: value` — computed property key

--- a/crates/svelte_codegen_client/src/builder/objects.rs
+++ b/crates/svelte_codegen_client/src/builder/objects.rs
@@ -89,6 +89,43 @@ impl<'a> Builder<'a> {
                 );
                 ast::ObjectPropertyKind::ObjectProperty(self.alloc(obj_prop))
             }
+            ObjProp::GetterBody(name, stmts) => {
+                let name_atom = self.ast.atom(name);
+                let key_node = ast::PropertyKey::StaticIdentifier(
+                    self.alloc(self.ast.identifier_name(SPAN, name_atom)),
+                );
+                let mut body_stmts = self.ast.vec_with_capacity(stmts.len());
+                for s in stmts {
+                    body_stmts.push(s);
+                }
+                let body =
+                    self.ast
+                        .alloc_function_body(SPAN, self.ast.vec(), body_stmts);
+                let getter = self.ast.function(
+                    SPAN,
+                    FunctionType::FunctionExpression,
+                    None,
+                    false,
+                    false,
+                    false,
+                    NONE,
+                    NONE,
+                    self.no_params(),
+                    NONE,
+                    Some(body),
+                );
+                let value = Expression::FunctionExpression(self.alloc(getter));
+                let obj_prop = self.ast.object_property(
+                    SPAN,
+                    ast::PropertyKind::Get,
+                    key_node,
+                    value,
+                    false,
+                    false,
+                    false,
+                );
+                ast::ObjectPropertyKind::ObjectProperty(self.alloc(obj_prop))
+            }
             ObjProp::Computed(key_expr, value) => {
                 let key_node = ast::PropertyKey::from(key_expr);
                 let obj_prop = self.ast.object_property(

--- a/crates/svelte_codegen_client/src/template/component.rs
+++ b/crates/svelte_codegen_client/src/template/component.rs
@@ -108,6 +108,7 @@ pub(crate) fn gen_component<'a>(
                 name,
                 bind_id: _,
                 mode,
+                ref expr_name,
             } => {
                 let key = ctx.b.alloc_str(&name);
                 let name_ref = ctx.b.alloc_str(&name);
@@ -142,6 +143,34 @@ pub(crate) fn gen_component<'a>(
                         let set_body = ctx
                             .b
                             .assign_expr(AssignLeft::Ident(name), ctx.b.rid_expr("$$value"));
+                        items.push(PropOrSpread::Prop(ObjProp::Setter(
+                            key,
+                            "$$value",
+                            None,
+                            vec![ctx.b.expr_stmt(set_body)],
+                        )));
+                    }
+                    ComponentBindMode::StoreSub => {
+                        let store_ref = expr_name
+                            .as_deref()
+                            .unwrap_or_else(|| panic!("StoreSub bind must have expr_name"));
+                        let store_id = ctx.b.alloc_str(store_ref);
+                        // get value() { $.mark_store_binding(); return $count(); }
+                        let mark_stmt =
+                            ctx.b.expr_stmt(ctx.b.call_expr("$.mark_store_binding", []));
+                        let return_expr = ctx.b.call_expr(store_id, []);
+                        let return_stmt = ctx.b.return_stmt(return_expr);
+                        items.push(PropOrSpread::Prop(ObjProp::GetterBody(
+                            key,
+                            vec![mark_stmt, return_stmt],
+                        )));
+                        // set value($$value) { $.store_set(count, $$value); }
+                        let base_name = &store_ref[1..]; // strip '$' prefix
+                        let base_id: &str = ctx.b.alloc_str(base_name);
+                        let set_body = ctx.b.call_expr(
+                            "$.store_set",
+                            [Arg::Ident(base_id), Arg::Ident("$$value")],
+                        );
                         items.push(PropOrSpread::Prop(ObjProp::Setter(
                             key,
                             "$$value",

--- a/specs/store-subscriptions.md
+++ b/specs/store-subscriptions.md
@@ -1,15 +1,14 @@
 # $store subscriptions
 
 ## Current state
-- **Working**: 10/15 client use cases (was 7)
+- **Working**: 13/16 client use cases
 - **Fixed this session**:
-  - Dev-mode `$.validate_store` in store thunk (sequence expression)
-  - Store cleanup ordering: `var $$pop = $.pop($$exports); $$cleanup(); return $$pop;`
-  - Each-block flags: `EACH_ITEM_IMMUTABLE` not set when collection depends on store; `EACH_ITEM_REACTIVE` set when `has_store_ref`
-  - Each-block collection thunk optimization: `b.thunk()` collapses `() => $items()` to `$items`
-- **Missing**: `$.store_unsub` (legacy-only, needs non-runes mode), `$.invalidate_store` (legacy each-block mutation), `$.mark_store_binding` (component store bindings), store-specific diagnostics, module compilation validation
-- **Next**: `$.mark_store_binding` for component bindings (runes-compatible), then legacy-mode features
-- Last updated: 2026-04-02
+  - `$.mark_store_binding()` in component bind getter for store-backed bindings
+  - `store_invalid_scoped_subscription` diagnostic for nested-scope store refs
+  - `store_rune_conflict` warning for `$name` that shadows a rune
+- **Missing**: `$.store_unsub` (legacy-only), `$.invalidate_store` (legacy-only), `$store` in `<script module>` / module compilation (needs dual-script AST and module compilation infrastructure)
+- **Next**: legacy-mode features when non-runes infrastructure is added; module-level diagnostics when dual-script AST is available
+- Last updated: 2026-04-03
 
 ## Source
 
@@ -44,8 +43,9 @@
 - [x] Each-block with store-backed collection sets correct flags (`EACH_ITEM_REACTIVE`, no `EACH_ITEM_IMMUTABLE`)
 - [ ] Reassigning a store binding unsubscribes the prior subscription with `$.store_unsub` (legacy-only)
 - [ ] `{#each $items as item}` mutations invalidate the backing store with `$.invalidate_store` (legacy-only)
-- [ ] Component/store binding codegen marks store-backed bindings with `$.mark_store_binding`
-- [ ] Analyzer rejects subscriptions to stores not declared at component top level
+- [x] Component/store binding codegen marks store-backed bindings with `$.mark_store_binding`
+- [x] Analyzer rejects subscriptions to stores not declared at component top level
+- [x] Analyzer warns when `$name` shadows a rune (`store_rune_conflict`)
 - [ ] Analyzer rejects `$store` reads inside `<script module>`
 - [ ] Module compilation rejects `$store` reads outside `.svelte` components
 
@@ -54,7 +54,8 @@
 - [ ] SSR store subscription codegen and cleanup parity
 - [ ] `$.store_unsub` — only fires in legacy (non-runes) mode when store variable is promoted to reactive state
 - [ ] `$.invalidate_store` — only fires in legacy (non-runes) mode for each-block item mutations
-- [ ] `$.mark_store_binding` — component binding getter injection for store-backed bindings
+- [ ] `store_invalid_subscription` — needs dual-script AST (`<script module>` + `<script>`)
+- [ ] `store_invalid_subscription_module` — needs module compilation path (`.svelte.js`)
 
 ## Reference
 
@@ -116,7 +117,7 @@
 - FIXED: client codegen sets up store subscriptions but never emits `$.validate_store` in dev mode.
 - FIXED: when stores coexist with `$.pop($$exports)`, generated cleanup is emitted after `return` and becomes unreachable.
 - OPEN: the analyzer validation entrypoint only runs rune validation today, so store-specific diagnostics are currently absent.
-- OPEN: no Rust codegen path currently emits `$.invalidate_store`, `$.mark_store_binding`, or `$.store_unsub` (legacy-only features).
+- OPEN: no Rust codegen path currently emits `$.invalidate_store` or `$.store_unsub` (legacy-only features).
 
 ## Test cases
 
@@ -131,6 +132,7 @@
   - `store_validate_dev` — dev-mode `$.validate_store` + correct `$$cleanup()` ordering
   - `store_reassign_unsub` — store variable reassignment in runes mode (no legacy state promotion)
   - `store_each_invalidate` — each block with store-backed collection, correct flags
-- Recommended next cases after implementation starts:
-  - `store_each_invalidate`
-  - analyzer/unit tests for `store_invalid_scoped_subscription`, `store_invalid_subscription`, `store_invalid_subscription_module`, `store_rune_conflict`
+  - `store_mark_binding` — `bind:value={$count}` on component with `$.mark_store_binding()` in getter
+- Analyzer unit tests:
+  - `validate_store_invalid_scoped_subscription` — `$count` where `count` declared in nested function
+  - `validate_store_rune_conflict` — local `state` binding + `$state()` call warns about ambiguity

--- a/tasks/compiler_tests/cases2/store_mark_binding/case-rust.js
+++ b/tasks/compiler_tests/cases2/store_mark_binding/case-rust.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+import { count } from "./stores";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	const $count = () => $.store_get(count, "$count", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	Component($$anchor, {
+		get value() {
+			$.mark_store_binding();
+			return $count();
+		},
+		set value($$value) {
+			$.store_set(count, $$value);
+		}
+	});
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/store_mark_binding/case-svelte.js
+++ b/tasks/compiler_tests/cases2/store_mark_binding/case-svelte.js
@@ -1,0 +1,17 @@
+import * as $ from "svelte/internal/client";
+import { count } from "./stores";
+import Component from "./Component.svelte";
+export default function App($$anchor) {
+	const $count = () => $.store_get(count, "$count", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	Component($$anchor, {
+		get value() {
+			$.mark_store_binding();
+			return $count();
+		},
+		set value($$value) {
+			$.store_set(count, $$value);
+		}
+	});
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/store_mark_binding/case.svelte
+++ b/tasks/compiler_tests/cases2/store_mark_binding/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { count } from './stores';
+	import Component from './Component.svelte';
+</script>
+
+<Component bind:value={$count} />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -632,6 +632,11 @@ fn store_each_invalidate() {
 }
 
 #[rstest]
+fn store_mark_binding() {
+    assert_compiler("store_mark_binding");
+}
+
+#[rstest]
 fn const_tag() {
     assert_compiler("const_tag");
 }


### PR DESCRIPTION
- Add `$.mark_store_binding()` to component bind getter for store-backed
  bindings (e.g. `bind:value={$count}` on a component)
- Add `StoreSub` variant to `ComponentBindMode` with expression name
- Add `GetterBody` variant to `ObjProp` for multi-statement getter bodies
- Add store validation pass (`validate/stores.rs`):
  - `store_invalid_scoped_subscription` error for `$X` where `X` is
    declared in a nested scope
  - `store_rune_conflict` warning when `$name` shadows a rune name
- Add `find_binding_in_any_scope` to `ComponentScoping`
- New compiler test: `store_mark_binding`
- New analyzer tests: `validate_store_invalid_scoped_subscription`,
  `validate_store_rune_conflict`

Spec: 13/16 use cases complete. Remaining 3 deferred (legacy-only or
need module compilation infrastructure).

https://claude.ai/code/session_01NCR4c7gNNGF27yj1LqUKb4