### PR TITLE
port(events): fix nonpassive codegen + add analyzer event diagnostics

### DIFF
--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -12,7 +12,7 @@ use oxc_ast_visit::{walk, Visit};
 use oxc_span::GetSpan;
 use svelte_ast::{
     AnimateDirective, EachBlock, Element, ExpressionAttribute, ExpressionTag, Node, NodeId,
-    OnDirectiveLegacy, Text,
+    OnDirectiveLegacy, SvelteElement, Text,
 };
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
@@ -62,14 +62,8 @@ impl TemplateValidationVisitor {
             self.current_expr_offset + span.end,
         )
     }
-}
 
-impl TemplateVisitor for TemplateValidationVisitor {
-    fn visit_element(&mut self, _el: &Element, _ctx: &mut VisitContext<'_>) {
-        self.element_event_state.push(ElementEventState::default());
-    }
-
-    fn leave_element(&mut self, _el: &Element, ctx: &mut VisitContext<'_>) {
+    fn emit_mixed_syntax_if_needed(&mut self, ctx: &mut VisitContext<'_>) {
         if let Some(state) = self.element_event_state.pop() {
             if state.has_s5_events {
                 if let Some((span, name)) = state.first_on_directive {
@@ -80,6 +74,24 @@ impl TemplateVisitor for TemplateValidationVisitor {
                 }
             }
         }
+    }
+}
+
+impl TemplateVisitor for TemplateValidationVisitor {
+    fn visit_element(&mut self, _el: &Element, _ctx: &mut VisitContext<'_>) {
+        self.element_event_state.push(ElementEventState::default());
+    }
+
+    fn leave_element(&mut self, _el: &Element, ctx: &mut VisitContext<'_>) {
+        self.emit_mixed_syntax_if_needed(ctx);
+    }
+
+    fn visit_svelte_element(&mut self, _el: &SvelteElement, _ctx: &mut VisitContext<'_>) {
+        self.element_event_state.push(ElementEventState::default());
+    }
+
+    fn leave_svelte_element(&mut self, _el: &SvelteElement, ctx: &mut VisitContext<'_>) {
+        self.emit_mixed_syntax_if_needed(ctx);
     }
 
     fn visit_expression_attribute(

--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -10,23 +10,49 @@
 use oxc_ast::ast::{AssignmentTarget, Expression, SimpleAssignmentTarget};
 use oxc_ast_visit::{walk, Visit};
 use oxc_span::GetSpan;
-use svelte_ast::{AnimateDirective, EachBlock, ExpressionTag, Node, NodeId, Text};
+use svelte_ast::{
+    AnimateDirective, EachBlock, Element, ExpressionAttribute, ExpressionTag, Node, NodeId,
+    OnDirectiveLegacy, Text,
+};
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
 
 use crate::scope::ComponentScoping;
 use crate::walker::{ParentKind, TemplateVisitor, VisitContext};
 
+const EVENT_MODIFIERS: &[&str] = &[
+    "preventDefault",
+    "stopPropagation",
+    "stopImmediatePropagation",
+    "self",
+    "trusted",
+    "once",
+    "capture",
+    "passive",
+    "nonpassive",
+];
+
+/// Per-element state for detecting mixed event syntax (S5 attributes + legacy on:).
+#[derive(Default)]
+struct ElementEventState {
+    has_s5_events: bool,
+    /// Span and event name of the first `on:` directive seen on this element.
+    first_on_directive: Option<(Span, String)>,
+}
+
 pub(crate) struct TemplateValidationVisitor {
     /// Source-absolute start of the current expression being visited.
     /// Set by `visit_expression`, used in `visit_js_expression` to offset OXC sub-spans.
     current_expr_offset: u32,
+    /// Stack of per-element event state, pushed on `visit_element` and popped on `leave_element`.
+    element_event_state: Vec<ElementEventState>,
 }
 
 impl TemplateValidationVisitor {
     pub(crate) fn new() -> Self {
         Self {
             current_expr_offset: 0,
+            element_event_state: Vec::new(),
         }
     }
 
@@ -39,6 +65,89 @@ impl TemplateValidationVisitor {
 }
 
 impl TemplateVisitor for TemplateValidationVisitor {
+    fn visit_element(&mut self, _el: &Element, _ctx: &mut VisitContext<'_>) {
+        self.element_event_state.push(ElementEventState::default());
+    }
+
+    fn leave_element(&mut self, _el: &Element, ctx: &mut VisitContext<'_>) {
+        if let Some(state) = self.element_event_state.pop() {
+            if state.has_s5_events {
+                if let Some((span, name)) = state.first_on_directive {
+                    ctx.warnings_mut().push(Diagnostic::error(
+                        DiagnosticKind::MixedEventHandlerSyntaxes { name },
+                        span,
+                    ));
+                }
+            }
+        }
+    }
+
+    fn visit_expression_attribute(
+        &mut self,
+        attr: &ExpressionAttribute,
+        _ctx: &mut VisitContext<'_>,
+    ) {
+        if attr.event_name.is_some() {
+            if let Some(state) = self.element_event_state.last_mut() {
+                state.has_s5_events = true;
+            }
+        }
+    }
+
+    // Use cases: event_handler_invalid_modifier, event_handler_invalid_modifier_combination,
+    // event_directive_deprecated, mixed_event_handler_syntaxes
+    fn visit_on_directive_legacy(
+        &mut self,
+        dir: &OnDirectiveLegacy,
+        ctx: &mut VisitContext<'_>,
+    ) {
+        let is_component =
+            ctx.parent().is_some_and(|p| p.kind == ParentKind::ComponentNode);
+
+        if !is_component {
+            // Invalid modifier check
+            let list = EVENT_MODIFIERS.join(", ");
+            for modifier in &dir.modifiers {
+                if !EVENT_MODIFIERS.contains(&modifier.as_str()) {
+                    ctx.warnings_mut().push(Diagnostic::error(
+                        DiagnosticKind::EventHandlerInvalidModifier { list: list.clone() },
+                        dir.name_span,
+                    ));
+                }
+            }
+
+            // passive + nonpassive conflict
+            let has_passive = dir.modifiers.iter().any(|m| m == "passive");
+            let has_nonpassive = dir.modifiers.iter().any(|m| m == "nonpassive");
+            if has_passive && has_nonpassive {
+                ctx.warnings_mut().push(Diagnostic::error(
+                    DiagnosticKind::EventHandlerInvalidModifierCombination {
+                        modifier1: "passive".to_string(),
+                        modifier2: "nonpassive".to_string(),
+                    },
+                    dir.name_span,
+                ));
+            }
+        }
+
+        // Runes-mode deprecation — all non-component on: directives
+        if ctx.runes && !is_component {
+            ctx.warnings_mut().push(Diagnostic::warning(
+                DiagnosticKind::EventDirectiveDeprecated { name: dir.name.clone() },
+                dir.name_span,
+            ));
+        }
+
+        // Record first on: directive for mixed-syntax check (DOM elements only)
+        if !is_component {
+            if let Some(state) = self.element_event_state.last_mut() {
+                state
+                    .first_on_directive
+                    .get_or_insert((dir.name_span, dir.name.clone()));
+            }
+        }
+    }
+
     fn visit_text(&mut self, text: &Text, ctx: &mut VisitContext<'_>) {
         let value = text.value(ctx.source);
 

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2345,3 +2345,55 @@ const props = $props();
     );
     assert_no_warning(&diags, "custom_element_props_identifier");
 }
+
+// -----------------------------------------------------------------------
+// Event directive diagnostics
+// -----------------------------------------------------------------------
+
+#[test]
+fn on_directive_invalid_modifier() {
+    let diags = analyze_with_diags(
+        "<script>function f(){}</script><div on:click|invalid={f}></div>",
+    );
+    assert_has_error(&diags, "event_handler_invalid_modifier");
+}
+
+#[test]
+fn on_directive_passive_nonpassive_conflict() {
+    let diags = analyze_with_diags(
+        "<script>function f(){}</script><div on:touchmove|passive|nonpassive={f}></div>",
+    );
+    assert_has_error(&diags, "event_handler_invalid_modifier_combination");
+}
+
+#[test]
+fn on_directive_deprecated_in_runes_mode() {
+    let diags = analyze_with_options_diags(
+        "<script>function f(){}</script><div on:click={f}></div>",
+        AnalyzeOptions {
+            runes: true,
+            ..Default::default()
+        },
+    );
+    assert_has_warning(&diags, "event_directive_deprecated");
+}
+
+#[test]
+fn on_directive_not_deprecated_in_non_runes_mode() {
+    let diags = analyze_with_options_diags(
+        "<script>function f(){}</script><div on:click={f}></div>",
+        AnalyzeOptions {
+            runes: false,
+            ..Default::default()
+        },
+    );
+    assert_no_warning(&diags, "event_directive_deprecated");
+}
+
+#[test]
+fn on_directive_mixed_syntax() {
+    let diags = analyze_with_diags(
+        "<script>function f(){} function g(){}</script><div onclick={f} on:click={g}></div>",
+    );
+    assert_has_error(&diags, "mixed_event_handler_syntaxes");
+}

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2397,3 +2397,11 @@ fn on_directive_mixed_syntax() {
     );
     assert_has_error(&diags, "mixed_event_handler_syntaxes");
 }
+
+#[test]
+fn on_directive_mixed_syntax_svelte_element() {
+    let diags = analyze_with_diags(
+        r#"<script>let tag = $state("div"); function f(){} function g(){}</script><svelte:element this={tag} onclick={f} on:click={g}></svelte:element>"#,
+    );
+    assert_has_error(&diags, "mixed_event_handler_syntaxes");
+}

--- a/crates/svelte_analyze/src/walker/traverse.rs
+++ b/crates/svelte_analyze/src/walker/traverse.rs
@@ -194,6 +194,9 @@ pub(crate) fn walk_template(
                 walk_template(&el.fragment, ctx, visitors);
                 ctx.scope = saved;
                 ctx.pop();
+                for v in visitors.iter_mut() {
+                    v.leave_svelte_element(el, ctx);
+                }
             }
             Node::SvelteWindow(w) => {
                 for v in visitors.iter_mut() {

--- a/crates/svelte_analyze/src/walker/visitor.rs
+++ b/crates/svelte_analyze/src/walker/visitor.rs
@@ -71,6 +71,7 @@ pub(crate) trait TemplateVisitor {
     }
 
     fn leave_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {}
+    fn leave_svelte_element(&mut self, el: &SvelteElement, ctx: &mut VisitContext<'_>) {}
     fn leave_each_block(&mut self, block: &EachBlock, ctx: &mut VisitContext<'_>) {}
     fn leave_snippet_block(&mut self, block: &SnippetBlock, ctx: &mut VisitContext<'_>) {}
     fn leave_concatenation_attribute(

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -751,6 +751,8 @@ pub struct OnDirectiveLegacy {
     pub id: NodeId,
     /// Event name (e.g., "click" in `on:click`).
     pub name: String,
+    /// Span of the event name in source (e.g., "click" span in `on:click`).
+    pub name_span: Span,
     /// Span of the JS expression. None if no expression (bubble event).
     pub expression_span: Option<Span>,
     /// Modifiers like "preventDefault", "stopPropagation", "capture", etc.

--- a/crates/svelte_codegen_client/src/template/events/emit.rs
+++ b/crates/svelte_codegen_client/src/template/events/emit.rs
@@ -48,7 +48,11 @@ pub(crate) fn gen_on_directive_legacy<'a>(
         Arg::Expr(wrapped),
     ];
     if mods.capture || mods.passive.is_some() {
-        args.push(Arg::Bool(mods.capture));
+        args.push(if mods.capture {
+            Arg::Bool(true)
+        } else {
+            Arg::Expr(ctx.b.void_zero_expr())
+        });
     }
     if let Some(p) = mods.passive {
         args.push(Arg::Bool(p));
@@ -98,7 +102,11 @@ pub(crate) fn gen_legacy_event_on<'a>(
         Arg::Expr(wrapped),
     ];
     if mods.capture || mods.passive.is_some() {
-        args.push(Arg::Bool(mods.capture));
+        args.push(if mods.capture {
+            Arg::Bool(true)
+        } else {
+            Arg::Expr(ctx.b.void_zero_expr())
+        });
     }
     if let Some(p) = mods.passive {
         args.push(Arg::Bool(p));

--- a/crates/svelte_parser/src/attr_convert.rs
+++ b/crates/svelte_parser/src/attr_convert.rs
@@ -157,6 +157,7 @@ impl<'a> Parser<'a> {
                     attributes.push(Attribute::OnDirectiveLegacy(OnDirectiveLegacy {
                         id: self.reserve_id(),
                         name: od.name_span.source_text(self.source).to_string(),
+                        name_span: od.name_span,
                         expression_span,
                         modifiers: od
                             .modifiers

--- a/specs/events.md
+++ b/specs/events.md
@@ -1,10 +1,10 @@
 # Events
 
 ## Current state
-- **Working**: 7/10 event use cases
-- **Missing**: legacy `nonpassive` lowering is off by one argument, and analyzer-side event diagnostics/warnings for DOM event handling are still absent
-- **Next**: fix the narrow `nonpassive` lowering mismatch first, then port analyze validation for legacy `on:` modifiers, mixed old/new syntax, and runes-mode deprecation warnings; keep component `$$events` work in the existing component spec
-- Last updated: 2026-04-01
+- **Working**: 9/10 event use cases
+- **Done this session**: fixed `nonpassive` codegen (`void 0` capture slot), added `name_span` to `OnDirectiveLegacy` AST, implemented analyzer event diagnostics (`EventHandlerInvalidModifier`, `EventHandlerInvalidModifierCombination`, `EventDirectiveDeprecated`, `MixedEventHandlerSyntaxes`)
+- **Remaining**: component `$$events` forwarding tracked in `specs/component-node.md`
+- Last updated: 2026-04-03
 
 ## Source
 
@@ -32,8 +32,8 @@
 - [x] Legacy `on:` directives on DOM elements lower through `$.event(...)` and bubble forms work on special elements (tests: `on_directive`, `svelte_document_bubble`, `svelte_body_event_legacy`, `svelte_window_event_legacy`)
 - [x] Legacy modifier wrappers that are already covered match reference output (`preventDefault`, `capture`, `once`) (tests: `on_directive_modifiers`, `svelte_document_events`)
 - [x] `<svelte:window>`, `<svelte:document>`, and `<svelte:body>` accept both Svelte 5 event attributes and legacy `on:` syntax in the same special-element code paths (tests: `svelte_window_event_attr`, `svelte_document_events`, `svelte_body_event_attr`)
-- [ ] Legacy `nonpassive` modifier should preserve an undefined capture slot and pass explicit passive `false`; the new compiler case currently fails (`on_directive_nonpassive`)
-- [ ] Analyze emits DOM-event diagnostics and warnings that the reference compiler already has: invalid modifiers, invalid passive/nonpassive combinations, mixed legacy/new syntax, and runes-mode `on:` deprecation warnings
+- [x] Legacy `nonpassive` modifier preserves an undefined capture slot and passes explicit passive `false` (`on_directive_nonpassive`)
+- [x] Analyze emits DOM-event diagnostics and warnings: invalid modifiers, invalid passive/nonpassive combinations, mixed legacy/new syntax, and runes-mode `on:` deprecation warnings
 - [~] Event work that targets components is split across specs: DOM events are covered here, while `<Component on:done={...} />` -> `$$events` remains open in [component-node.md](/Users/klobkov/personal-code/svelte-rs-2/specs/component-node.md)
 
 ### Deferred
@@ -68,10 +68,10 @@
 
 ## Tasks
 
-- [ ] Analyze: add DOM-event validation/warning coverage for legacy modifiers and mixed syntax, matching the reference compiler's DOM-element-only behavior
-- [ ] Analyze: track whether a component/template uses event attributes versus legacy `on:` so `mixed_event_handler_syntaxes` can be emitted at the correct node
-- [ ] Analyze: warn on legacy `on:` directives in runes mode for DOM elements and `<svelte:element>`, but keep component `on:` warnings suppressed like the reference compiler
-- [ ] Tests: add focused analyzer or integration coverage for `event_handler_invalid_modifier`, passive conflict errors, mixed syntax, and `event_directive_deprecated`
+- [x] Analyze: add DOM-event validation/warning coverage for legacy modifiers and mixed syntax, matching the reference compiler's DOM-element-only behavior
+- [x] Analyze: track whether a component/template uses event attributes versus legacy `on:` so `mixed_event_handler_syntaxes` can be emitted at the correct node
+- [x] Analyze: warn on legacy `on:` directives in runes mode for DOM elements, keep component `on:` warnings suppressed
+- [x] Tests: add focused analyzer unit tests for `event_handler_invalid_modifier`, passive conflict errors, mixed syntax, and `event_directive_deprecated`
 - [ ] Follow-up separately in [component-node.md](/Users/klobkov/personal-code/svelte-rs-2/specs/component-node.md): component `on:` forwarding into `$$events`
 
 ## Implementation order
@@ -82,8 +82,8 @@
 
 ## Discovered bugs
 
-- OPEN: `crates/svelte_analyze` does not currently emit `EventDirectiveDeprecated`, `MixedEventHandlerSyntaxes`, legacy modifier validation errors, or passive-conflict errors for DOM event handling.
-- OPEN: `crates/svelte_codegen_client/src/template/events/emit.rs` emits `$.event("touchmove", el, handler, false, false)` for `on:touchmove|nonpassive`, but the reference compiler emits `$.event("touchmove", el, handler, void 0, false)`.
+- FIXED: `crates/svelte_analyze` now emits `EventDirectiveDeprecated`, `MixedEventHandlerSyntaxes`, legacy modifier validation errors, and passive-conflict errors for DOM event handling.
+- FIXED: `crates/svelte_codegen_client/src/template/events/emit.rs` now emits `$.event("touchmove", el, handler, void 0, false)` for `on:touchmove|nonpassive`.
 - OPEN: `<Component on:done={handler} />` still drops `$$events` in client codegen; this is tracked in `specs/component-node.md` and reproduced by `component_events`.
 
 ## Test cases

--- a/specs/events.md
+++ b/specs/events.md
@@ -39,7 +39,6 @@
 ### Deferred
 
 - Dev-mode-only parity from the roadmap item `$.apply() + event handler naming` belongs under Dev Mode rather than this client-output audit
-- [ ] Mixed-syntax detection (`MixedEventHandlerSyntaxes`) is not implemented for `<svelte:element>` — requires a `leave_svelte_element` hook in `TemplateVisitor` which does not yet exist
 
 ## Reference
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -39,6 +39,7 @@
 ### Deferred
 
 - Dev-mode-only parity from the roadmap item `$.apply() + event handler naming` belongs under Dev Mode rather than this client-output audit
+- [ ] Mixed-syntax detection (`MixedEventHandlerSyntaxes`) is not implemented for `<svelte:element>` — requires a `leave_svelte_element` hook in `TemplateVisitor` which does not yet exist
 
 ## Reference
 

--- a/tasks/compiler_tests/cases2/on_directive_nonpassive/case-rust.js
+++ b/tasks/compiler_tests/cases2/on_directive_nonpassive/case-rust.js
@@ -5,6 +5,6 @@ export default function App($$anchor) {
 		console.log("move");
 	}
 	var div = root();
-	$.event("touchmove", div, handleMove, false, false);
+	$.event("touchmove", div, handleMove, void 0, false);
 	$.append($$anchor, div);
 }

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -559,7 +559,6 @@ fn on_directive_modifiers() {
 }
 
 #[rstest]
-#[ignore = "missing: known v3 parity gap"]
 fn on_directive_nonpassive() {
     assert_compiler("on_directive_nonpassive");
 }


### PR DESCRIPTION
- Fix nonpassive capture-slot: legacy on: path now emits `void 0` instead
  of `false` for the capture argument when passive modifier is present but
  capture is absent, matching reference compiler output
- Add `name_span: Span` to `OnDirectiveLegacy` AST node so diagnostics
  can report accurate source locations
- Implement `visit_on_directive_legacy` in `TemplateValidationVisitor`:
  invalid modifier check, passive+nonpassive conflict, runes-mode
  deprecation warning, and mixed old/new event syntax detection
- Add 5 unit tests covering all four new diagnostic paths
- Un-ignore `on_directive_nonpassive` compiler test

Closes 9/10 events use cases (component $$events remains in component-node.md).

https://claude.ai/code/session_01QUos5aULiHd3KEpHBR44hg