### PR TITLE
Add template validation for key block empty and unexpected character

### DIFF
--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -11,8 +11,8 @@ use oxc_ast::ast::{AssignmentTarget, Expression, SimpleAssignmentTarget};
 use oxc_ast_visit::{walk, Visit};
 use oxc_span::GetSpan;
 use svelte_ast::{
-    AnimateDirective, EachBlock, Element, ExpressionAttribute, ExpressionTag, Node, NodeId,
-    OnDirectiveLegacy, SvelteElement, Text,
+    AnimateDirective, EachBlock, Element, ExpressionAttribute, ExpressionTag, KeyBlock, Node,
+    NodeId, OnDirectiveLegacy, SvelteElement, Text,
 };
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
@@ -197,6 +197,33 @@ impl TemplateVisitor for TemplateValidationVisitor {
                 DiagnosticKind::NodeInvalidPlacement { message },
                 tag.span,
             ));
+        }
+    }
+
+    // Use cases: block_empty, block_unexpected_character
+    fn visit_key_block(&mut self, block: &KeyBlock, ctx: &mut VisitContext<'_>) {
+        // block_empty: exactly one whitespace-only text node in the fragment
+        if block.fragment.nodes.len() == 1 {
+            let node_id = block.fragment.nodes[0];
+            if let Node::Text(text) = ctx.store.get(node_id) {
+                if text.value(ctx.source).trim().is_empty() {
+                    ctx.warnings_mut().push(Diagnostic::warning(
+                        DiagnosticKind::BlockEmpty,
+                        text.span,
+                    ));
+                }
+            }
+        }
+
+        // block_unexpected_character: runes mode only — char after `{` must be `#`
+        if ctx.runes {
+            let start = block.span.start as usize;
+            if ctx.source.as_bytes().get(start + 1) != Some(&b'#') {
+                ctx.warnings_mut().push(Diagnostic::error(
+                    DiagnosticKind::BlockUnexpectedCharacter { character: "#".to_string() },
+                    Span::new(block.span.start, block.span.start + 5),
+                ));
+            }
         }
     }
 

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -1366,7 +1366,6 @@ let count = 1;
     assert_has_warning(&diags, "block_empty");
 }
 
-
 #[test]
 fn validate_state_invalid_placement_fn_arg() {
     let diags = analyze_with_diags(

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -1355,7 +1355,6 @@ $state(1);
 }
 
 #[test]
-#[ignore = "missing: rune validation parity"]
 fn validate_key_block_empty_warns() {
     let diags = analyze_with_diags(
         r#"<script>
@@ -1366,6 +1365,7 @@ let count = 1;
     );
     assert_has_warning(&diags, "block_empty");
 }
+
 
 #[test]
 fn validate_state_invalid_placement_fn_arg() {

--- a/specs/key-block.md
+++ b/specs/key-block.md
@@ -1,11 +1,11 @@
 # Key Block
 
 ## Current state
-- **Working**: 3/6 use cases
-- **Missing**: 2 use cases
-- **Partial**: 1 use case
-- **Next**: add template validation for `block_empty` and runes-mode opening-tag diagnostics, then decide whether `KeyBlock` should be marked dynamic in analysis for stricter parity with the reference compiler
-- Last updated: 2026-04-01
+- **Working**: 4/6 use cases (`block_empty` warning now implemented and tested)
+- **Missing**: 1 use case (`dynamic_nodes` parity)
+- **Partial**: 1 use case (`block_unexpected_character` — implemented in analyzer but unreachable: our parser rejects malformed `{ #key ...}` at parse time, stricter than reference JS parser)
+- **Next**: decide whether `KeyBlock` ids should be added to `dynamic_nodes` to match reference analyzer behavior
+- Last updated: 2026-04-03
 
 ## Source
 
@@ -25,8 +25,8 @@
 - `[x]` Generate client code for a basic reactive key expression with `$.key(...)`.
 - `[x]` Generate async client code for awaited key expressions via `$.async(...)` and `$.get($$key)`.
 - `[x]` Handle `{#key}` nested inside element children without breaking parent fragment traversal or DOM anchors.
-- `[ ]` Emit `block_empty` when the key block body contains only whitespace.
-- `[ ]` In runes mode, emit `block_unexpected_character` when the opening tag is malformed (reference `validate_opening_tag` parity).
+- `[x]` Emit `block_empty` when the key block body contains only whitespace.
+- `[~]` In runes mode, emit `block_unexpected_character` when the opening tag is malformed — implemented in analyzer but effectively dead code: our Rust parser rejects `{ #key ...}` (space after `{`) at parse time, stricter than the reference JS parser which accepts it in legacy mode.
 - `[~]` Reference analyzer marks key-block subtrees dynamic; this repo lowers and codegens `{#key}` correctly for audited cases, but does not explicitly insert `KeyBlock` ids into `dynamic_nodes`.
 
 ## Reference
@@ -52,8 +52,8 @@
 
 ## Tasks
 
-- `[ ]` quick fix: add template validation coverage for whitespace-only `{#key}` bodies (`block_empty`).
-- `[ ]` quick fix: add runes-mode opening-tag validation coverage for `{#key}`.
+- `[x]` quick fix: add template validation coverage for whitespace-only `{#key}` bodies (`block_empty`).
+- `[x]` quick fix: `block_unexpected_character` check implemented in analyzer; untestable because our parser is stricter than reference (rejects malformed `{` at parse time).
 - `[ ]` moderate: decide whether `ReactivityVisitor` should mark `KeyBlock` as dynamic to match reference analyzer behavior, then add the smallest test that proves the need.
 - `[ ]` quick fix: keep expanding `{#key}` coverage only with narrowly scoped cases; avoid broad refactors.
 


### PR DESCRIPTION
## Summary
Implements template validation diagnostics for Svelte `{#key}` blocks, specifically handling empty block detection and opening tag validation in runes mode.

## Key Changes
- **Added `visit_key_block` method** to `TemplateValidationVisitor` that validates:
  - `block_empty`: Detects when a key block contains only whitespace and emits a warning
  - `block_unexpected_character`: In runes mode, validates that the opening tag starts with `{#` (though this is effectively unreachable since the parser already rejects malformed syntax)

- **Updated imports** in `template_validation.rs` to include `KeyBlock` from `svelte_ast`

- **Enabled previously ignored test** `validate_key_block_empty_warns` now that the validation is implemented

- **Updated specification document** (`specs/key-block.md`) to reflect:
  - Progress from 3/6 to 4/6 working use cases
  - Clarification that `block_unexpected_character` is implemented but unreachable due to stricter parser validation
  - Updated task checklist to mark completed items

## Implementation Details
The `visit_key_block` method checks if the key block's fragment contains a single text node with only whitespace content, and if so, emits a `BlockEmpty` diagnostic warning. The `block_unexpected_character` check is included for completeness and runes mode parity with the reference compiler, though it cannot be triggered in practice since the Rust parser rejects malformed opening tags at parse time (stricter than the reference JavaScript parser).

https://claude.ai/code/session_01U3a4NVWZCVWy9xXX2TjmzG