### PR TITLE
Add await block duplicate clause and whitespace validation

### DIFF
--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -1310,7 +1310,7 @@ impl<'a> Visit<'a> for InvalidSnippetParamAssignmentVisitor<'_> {
 /// Returns true when `window` (the source slice just before a binding pattern) contains
 /// whitespace between the opening `{` and the clause keyword (`:then` or `:catch`).
 /// Catches patterns like `{ :then val}` where a space precedes the colon.
-pub(crate) fn has_whitespace_before_clause(window: &str, clause: &str) -> bool {
+fn has_whitespace_before_clause(window: &str, clause: &str) -> bool {
     if let Some(brace_pos) = window.rfind('{') {
         let between = &window[brace_pos + 1..];
         let ws_len = between.len() - between.trim_start().len();

--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -11,9 +11,10 @@ use oxc_ast::ast::{AssignmentTarget, Expression, SimpleAssignmentTarget};
 use oxc_ast_visit::{walk, Visit};
 use oxc_span::GetSpan;
 use svelte_ast::{
-    is_svg, AnimateDirective, Attribute, BindDirective, ComponentNode, ConcatPart, EachBlock,
-    Element, ExpressionAttribute, ExpressionTag, Fragment, IfBlock, KeyBlock, Node, NodeId,
-    OnDirectiveLegacy, SnippetBlock, SvelteBody, SvelteDocument, SvelteElement, SvelteWindow, Text,
+    is_svg, AnimateDirective, Attribute, AwaitBlock, BindDirective, ComponentNode, ConcatPart,
+    EachBlock, Element, ExpressionAttribute, ExpressionTag, Fragment, IfBlock, KeyBlock, Node,
+    NodeId, OnDirectiveLegacy, SnippetBlock, SvelteBody, SvelteDocument, SvelteElement,
+    SvelteWindow, Text,
 };
 use svelte_diagnostics::codes::fuzzymatch;
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
@@ -317,6 +318,31 @@ impl TemplateVisitor for TemplateValidationVisitor {
                     },
                     Span::new(block.span.start, block.span.start + 5),
                 ));
+            }
+        }
+    }
+
+    // Use case: block_unexpected_character for {:then val} / {:catch err} with whitespace before `:`
+    fn visit_await_block(&mut self, block: &AwaitBlock, ctx: &mut VisitContext<'_>) {
+        if !ctx.runes {
+            return;
+        }
+        for (span_opt, clause) in [
+            (block.value_span, ":then"),
+            (block.error_span, ":catch"),
+        ] {
+            if let Some(span) = span_opt {
+                let start = span.start as usize;
+                let win_start = start.saturating_sub(10);
+                let window = &ctx.source[win_start..start];
+                if has_whitespace_before_clause(window, clause) {
+                    ctx.warnings_mut().push(Diagnostic::error(
+                        DiagnosticKind::BlockUnexpectedCharacter {
+                            character: ":".to_string(),
+                        },
+                        Span::new(win_start as u32, start as u32),
+                    ));
+                }
             }
         }
     }
@@ -1278,6 +1304,51 @@ impl<'a> Visit<'a> for InvalidSnippetParamAssignmentVisitor<'_> {
             return;
         }
         walk::walk_expression(self, expr);
+    }
+}
+
+/// Returns true when `window` (the source slice just before a binding pattern) contains
+/// whitespace between the opening `{` and the clause keyword (`:then` or `:catch`).
+/// Catches patterns like `{ :then val}` where a space precedes the colon.
+pub(crate) fn has_whitespace_before_clause(window: &str, clause: &str) -> bool {
+    if let Some(brace_pos) = window.rfind('{') {
+        let between = &window[brace_pos + 1..];
+        let ws_len = between.len() - between.trim_start().len();
+        let rest = &between[ws_len..];
+        rest.starts_with(clause) && ws_len > 0
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_whitespace_before_clause;
+
+    #[test]
+    fn no_whitespace_before_then() {
+        assert!(!has_whitespace_before_clause("{:then ", ":then"));
+    }
+
+    #[test]
+    fn whitespace_before_then() {
+        assert!(has_whitespace_before_clause("{ :then ", ":then"));
+    }
+
+    #[test]
+    fn multiple_spaces_before_catch() {
+        assert!(has_whitespace_before_clause("{  :catch ", ":catch"));
+    }
+
+    #[test]
+    fn no_brace_in_window() {
+        assert!(!has_whitespace_before_clause(":then val", ":then"));
+    }
+
+    #[test]
+    fn shorthand_then_form() {
+        // {#await expr then val} — no `{:then` pattern before binding
+        assert!(!has_whitespace_before_clause(" expr then ", ":then"));
     }
 }
 

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2697,3 +2697,25 @@ fn slot_attribute_invalid_placement_root() {
     let diags = analyze_with_diags(r#"<script></script><div slot="foo">content</div>"#);
     assert_has_error(&diags, "slot_attribute_invalid_placement");
 }
+
+// ---------------------------------------------------------------------------
+// AwaitBlock diagnostics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn await_valid_then_catch_no_unexpected_character() {
+    // Well-formed {#await}{:then val}{:catch e}{/await} must not emit block_unexpected_character.
+    let diags = analyze_with_options_diags(
+        r#"{#await p}{:then val}ok{:catch e}err{/await}"#,
+        AnalyzeOptions {
+            runes: true,
+            ..AnalyzeOptions::default()
+        },
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.kind.code() == "block_unexpected_character"),
+        "unexpected block_unexpected_character: {diags:?}"
+    );
+}

--- a/crates/svelte_parser/src/handlers.rs
+++ b/crates/svelte_parser/src/handlers.rs
@@ -295,7 +295,11 @@ impl<'a> Parser<'a> {
             AwaitPhase::Then => {
                 ab.then_children = Some(current_children);
             }
-            AwaitPhase::Catch => unreachable!("duplicate catch handled above"),
+            // {:then} after {:catch} with no prior {:then} — out-of-order clauses.
+            // Save the catch content so handle_end_await_tag can still produce a catch fragment.
+            AwaitPhase::Catch => {
+                ab.catch_children = Some(current_children);
+            }
         }
 
         match clause_tag.clause {
@@ -337,7 +341,9 @@ impl<'a> Parser<'a> {
             AwaitPhase::Pending => (Some(Fragment::new(current_children)), None, None),
             AwaitPhase::Then => {
                 let pending = ab.pending_children.map(Fragment::new);
-                (pending, Some(Fragment::new(current_children)), None)
+                // catch_children is Some when {:catch} preceded {:then} (out-of-order).
+                let catch = ab.catch_children.map(Fragment::new);
+                (pending, Some(Fragment::new(current_children)), catch)
             }
             AwaitPhase::Catch => {
                 let pending = ab.pending_children.map(Fragment::new);
@@ -502,7 +508,7 @@ impl<'a> Parser<'a> {
                     AwaitPhase::Then => (
                         ab.pending_children.map(Fragment::new),
                         Some(Fragment::new(current_children)),
-                        None,
+                        ab.catch_children.map(Fragment::new),
                     ),
                     AwaitPhase::Catch => (
                         ab.pending_children.map(Fragment::new),

--- a/crates/svelte_parser/src/handlers.rs
+++ b/crates/svelte_parser/src/handlers.rs
@@ -2,7 +2,7 @@ use svelte_ast::{
     AwaitBlock, ComponentNode, EachBlock, Element, Fragment, IfBlock, KeyBlock, Node, NodeId,
     SnippetBlock,
 };
-use svelte_diagnostics::Diagnostic;
+use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
 
 use crate::scanner::{self, token};
@@ -252,6 +252,7 @@ impl<'a> Parser<'a> {
     pub(crate) fn handle_await_clause_tag(
         &mut self,
         clause_tag: &scanner::token::AwaitClauseTag,
+        span: Span,
         entry_stack: &mut Vec<StackEntry>,
         children_stack: &mut Vec<Vec<NodeId>>,
     ) {
@@ -262,7 +263,30 @@ impl<'a> Parser<'a> {
             return;
         };
 
-        // Save current children to the appropriate phase
+        // Detect duplicate clauses before touching the children stack.
+        // Duplicate :then = a then clause was already started or completed.
+        // Duplicate :catch = a catch clause was already started.
+        let is_dup = match clause_tag.clause {
+            token::AwaitClause::Then => {
+                matches!(ab.phase, AwaitPhase::Then) || ab.then_children.is_some()
+            }
+            token::AwaitClause::Catch => matches!(ab.phase, AwaitPhase::Catch),
+        };
+        if is_dup {
+            let name = match clause_tag.clause {
+                token::AwaitClause::Then => "{:then}",
+                token::AwaitClause::Catch => "{:catch}",
+            };
+            self.recover(Diagnostic::error(
+                DiagnosticKind::BlockDuplicateClause {
+                    name: name.to_string(),
+                },
+                span,
+            ));
+            return;
+        }
+
+        // Save current children to the appropriate phase bucket.
         let current_children = pop_children(children_stack);
         match ab.phase {
             AwaitPhase::Pending => {
@@ -271,26 +295,21 @@ impl<'a> Parser<'a> {
             AwaitPhase::Then => {
                 ab.then_children = Some(current_children);
             }
-            AwaitPhase::Catch => {
-                // Shouldn't happen — {:catch} after {:catch}
-                self.recover(Diagnostic::unexpected_token(Span::new(0, 0)));
-                children_stack.push(vec![]);
-                return;
-            }
+            AwaitPhase::Catch => unreachable!("duplicate catch handled above"),
         }
 
         match clause_tag.clause {
-            scanner::token::AwaitClause::Then => {
+            token::AwaitClause::Then => {
                 ab.value_span = clause_tag.binding_span;
                 ab.phase = AwaitPhase::Then;
             }
-            scanner::token::AwaitClause::Catch => {
+            token::AwaitClause::Catch => {
                 ab.error_span = clause_tag.binding_span;
                 ab.phase = AwaitPhase::Catch;
             }
         }
 
-        // Push new children list for the next phase
+        // Push new children list for the next phase.
         children_stack.push(vec![]);
     }
 

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -123,10 +123,12 @@ struct AwaitBlockEntry {
     error_span: Option<Span>,
     /// Which phase we are currently collecting children for.
     phase: AwaitPhase,
-    /// Pending children (collected before {:then}).
+    /// Pending children (collected before {:then} or {:catch}).
     pending_children: Option<Vec<NodeId>>,
-    /// Then children (collected between {:then} and {:catch}).
+    /// Then children (collected between {:then} and a following {:catch}).
     then_children: Option<Vec<NodeId>>,
+    /// Catch children saved when {:then} follows {:catch} (out-of-order clauses).
+    catch_children: Option<Vec<NodeId>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +335,7 @@ impl<'a> Parser<'a> {
                         phase,
                         pending_children: None,
                         then_children: None,
+                        catch_children: None,
                     }));
                     children_stack.push(vec![]);
                 }

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -339,6 +339,7 @@ impl<'a> Parser<'a> {
                 TokenType::AwaitClauseTag(clause_tag) => {
                     self.handle_await_clause_tag(
                         &clause_tag,
+                        token.span,
                         &mut entry_stack,
                         &mut children_stack,
                     );

--- a/crates/svelte_parser/src/tests.rs
+++ b/crates/svelte_parser/src/tests.rs
@@ -878,6 +878,35 @@ fn debug_tag_call_expression_error() {
     );
 }
 
+// --- AwaitBlock diagnostic tests ---
+
+#[test]
+fn await_duplicate_then_clause() {
+    let (_, diags) = parse_with_diagnostics("{#await p}{:then a}text{:then b}more{/await}");
+    assert!(
+        diags.iter().any(|d| d.kind.code() == "block_duplicate_clause"),
+        "expected block_duplicate_clause, got: {diags:?}"
+    );
+}
+
+#[test]
+fn await_duplicate_catch_clause() {
+    let (_, diags) = parse_with_diagnostics("{#await p}{:catch e}err{:catch e2}err2{/await}");
+    assert!(
+        diags.iter().any(|d| d.kind.code() == "block_duplicate_clause"),
+        "expected block_duplicate_clause, got: {diags:?}"
+    );
+}
+
+#[test]
+fn await_valid_then_catch_no_duplicate() {
+    let (_, diags) = parse_with_diagnostics("{#await p}{:then a}ok{:catch e}err{/await}");
+    assert!(
+        !diags.iter().any(|d| d.kind.code() == "block_duplicate_clause"),
+        "unexpected block_duplicate_clause: {diags:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // JS parsing tests (moved from svelte_types)
 // ---------------------------------------------------------------------------

--- a/crates/svelte_parser/src/tests.rs
+++ b/crates/svelte_parser/src/tests.rs
@@ -907,6 +907,27 @@ fn await_valid_then_catch_no_duplicate() {
     );
 }
 
+#[test]
+fn await_duplicate_then_after_catch_then() {
+    // {:then}{:catch}{:then} — the third clause triggers the then_children.is_some() branch
+    let (_, diags) =
+        parse_with_diagnostics("{#await p}{:then a}t{:catch e}err{:then b}more{/await}");
+    assert!(
+        diags.iter().any(|d| d.kind.code() == "block_duplicate_clause"),
+        "expected block_duplicate_clause, got: {diags:?}"
+    );
+}
+
+#[test]
+fn await_catch_before_then_no_panic() {
+    // {:catch} before {:then} with no prior {:then} must not panic
+    let (_, diags) = parse_with_diagnostics("{#await p}{:catch e}err{:then a}ok{/await}");
+    assert!(
+        !diags.iter().any(|d| d.kind.code() == "block_duplicate_clause"),
+        "unexpected block_duplicate_clause for out-of-order catch/then: {diags:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // JS parsing tests (moved from svelte_types)
 // ---------------------------------------------------------------------------

--- a/specs/await-block.md
+++ b/specs/await-block.md
@@ -1,10 +1,9 @@
 # Await Block
 
 ## Current state
-- **Working**: 16/18 use cases
-- **Missing**: 2 diagnostics (`block_duplicate_clause`, `block_unexpected_character`)
-- **Next**: implement diagnostics
-- Last updated: 2026-04-01
+- **Complete**: all 25 use cases done (2026-04-03)
+- **Note**: `block_unexpected_character` for `{ :then}` / `{ :catch}` whitespace is structurally implemented in the analyzer but cannot be triggered: the scanner does not parse `{ :then val}` (whitespace between `{` and `:`) as an AwaitClauseTag. The check will fire when the scanner is made permissive.
+- Last updated: 2026-04-03
 
 ## Source
 Audit of existing implementation (2026-04-01)
@@ -34,8 +33,8 @@ Audit of existing implementation (2026-04-01)
 21. [x] Nested await (await inside await) (test: `await_nested_await`)
 22. [x] `$.async()` wrapping with blockers (test: `async_await_has_await`)
 23. [x] Pickled await in template (test: `async_pickled_await_template`)
-- [ ] `block_duplicate_clause` error for duplicate `:then`/`:catch`
-- [ ] `block_unexpected_character` validation for whitespace before `:then`/`:catch`
+- [x] `block_duplicate_clause` error for duplicate `:then`/`:catch`
+- [~] `block_unexpected_character` validation for whitespace before `:then`/`:catch` (analyzer check implemented; blocked on scanner not parsing `{ :then val}` — scanner gap)
 
 ## Reference
 

--- a/specs/await-block.md
+++ b/specs/await-block.md
@@ -1,8 +1,8 @@
 # Await Block
 
 ## Current state
-- **Complete**: all 25 use cases done (2026-04-03)
-- **Note**: `block_unexpected_character` for `{ :then}` / `{ :catch}` whitespace is structurally implemented in the analyzer but cannot be triggered: the scanner does not parse `{ :then val}` (whitespace between `{` and `:`) as an AwaitClauseTag. The check will fire when the scanner is made permissive.
+- **Working**: 24/25 use cases. One partial (`block_unexpected_character`).
+- `block_unexpected_character` for `{ :then}` / `{ :catch}` whitespace is structurally implemented in the analyzer but cannot be triggered: the scanner dispatches immediately on the char after `{` and does not skip whitespace before `:`. The check will fire when the scanner is made permissive. Tracked as `[~]` below.
 - Last updated: 2026-04-03
 
 ## Source


### PR DESCRIPTION
## Summary
Implement validation for Svelte await blocks to detect duplicate `:then`/`:catch` clauses and validate whitespace before clause keywords. This includes parser-level duplicate detection and analyzer-level whitespace validation.

## Key Changes

### Parser (`svelte_parser`)
- **Duplicate clause detection**: Added logic in `handle_await_clause_tag` to detect and report `block_duplicate_clause` errors when `:then` or `:catch` clauses are duplicated
- **Out-of-order clause handling**: Improved handling of out-of-order clauses (e.g., `:catch` before `:then`) by properly saving catch children when `:then` follows `:catch`
- **AwaitBlockEntry structure**: Added `catch_children` field to track catch clause content when clauses appear out-of-order
- **Test coverage**: Added 5 comprehensive tests for duplicate clause scenarios in `svelte_parser/src/tests.rs`

### Analyzer (`svelte_analyze`)
- **Whitespace validation**: Implemented `visit_await_block` method to detect whitespace before `:then` and `:catch` keywords (e.g., `{ :then val}`)
- **Helper function**: Added `has_whitespace_before_clause` utility with comprehensive unit tests to detect whitespace patterns between `{` and clause keywords
- **Import updates**: Added `AwaitBlock` to imports for proper AST traversal
- **Test coverage**: Added validation test in `svelte_analyze/src/tests.rs`

### Documentation
- Updated `specs/await-block.md` to reflect implementation status: 24/25 use cases working, with one partial implementation (`block_unexpected_character` awaiting scanner improvements)

## Implementation Details
- The whitespace validation check is structurally complete but cannot be triggered by the current scanner, which dispatches immediately on the character after `{` without skipping whitespace. This is documented as a known limitation pending scanner improvements.
- Duplicate clause detection works at parse time and prevents further processing of duplicate clauses via early return.
- Out-of-order clause handling gracefully saves content rather than panicking, improving robustness.

https://claude.ai/code/session_01XYXMoztfmDTAPQbHUZJh3K