### PR TITLE
Support dual top-level scripts and validate snippet exports

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,6 +103,7 @@ Details per feature live in `specs/` — run `/audit <feature>` to generate or u
 ## Compiler Infrastructure
 
 - [ ] Module compilation (`.svelte.js` / `.svelte.ts`)
+- [ ] `<script module>` compilation inside `.svelte` components (analyze + codegen separate from instance script)
 - [ ] WASM target
 - [ ] Custom elements
 - [ ] `discloseVersion` option

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,13 +103,21 @@ Details per feature live in `specs/` — run `/audit <feature>` to generate or u
 ## Compiler Infrastructure
 
 - [ ] Module compilation (`.svelte.js` / `.svelte.ts`)
-- [ ] `<script module>` compilation inside `.svelte` components (analyze + codegen separate from instance script)
 - [ ] WASM target
 - [ ] Custom elements
 - [ ] `discloseVersion` option
 - [ ] `preserveComments` option
 - [ ] Source maps (JS + CSS)
 - [ ] HMR
+
+## `<script module>` in Components
+
+Parser infrastructure is in place (`Component.instance_script` / `Component.module_script`, `ParserResult.module_program`). Missing: analyze and codegen for module script content.
+
+- [ ] Analyze pass: scoping, rune detection, exports collection for module script body
+- [ ] Codegen: emit module script body as module-level output (separate from component function)
+- [ ] `export_undefined` diagnostic for unresolved module export specifiers
+- [ ] Interaction with instance script: module-scope bindings visible to instance, not vice versa
 
 ## Legacy Svelte 4
 

--- a/crates/svelte_analyze/src/lib.rs
+++ b/crates/svelte_analyze/src/lib.rs
@@ -325,7 +325,7 @@ pub fn analyze_with_options<'a>(
                 );
             }
             passes::PassKey::Validate => {
-                validate::validate(&data, &parsed, runes, &mut diags);
+                validate::validate(component, &data, &parsed, runes, &mut diags);
             }
         }
     }

--- a/crates/svelte_analyze/src/passes/lower.rs
+++ b/crates/svelte_analyze/src/passes/lower.rs
@@ -796,7 +796,7 @@ mod tests {
     fn make_component(source: &str, nodes: Vec<Node>) -> Component {
         let mut store = AstStore::new();
         let ids: Vec<NodeId> = nodes.into_iter().map(|n| store.push(n)).collect();
-        Component::new(source.to_string(), Fragment::new(ids), store, None, None)
+        Component::new(source.to_string(), Fragment::new(ids), store, None, None, None)
     }
 
     fn collect_text_parts(items: &[FragmentItem], source: &str) -> Vec<String> {

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2288,6 +2288,38 @@ fn validate_snippet_conflict() {
 }
 
 #[test]
+fn validate_snippet_invalid_export() {
+    let diags = analyze_with_diags(
+        r#"<script module>
+    export { greeting };
+</script>
+
+<script>
+    let message = 'hello';
+</script>
+
+{#snippet greeting(name)}
+    <p>{message} {name}!</p>
+{/snippet}"#,
+    );
+    assert_has_error(&diags, "snippet_invalid_export");
+}
+
+#[test]
+fn validate_snippet_invalid_export_no_false_positive() {
+    // Exporting a non-snippet name from module script is not a snippet_invalid_export.
+    let diags = analyze_with_diags(
+        r#"<script module>
+    export const PI = 3.14;
+</script>"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.kind.code() == "snippet_invalid_export"),
+        "should not fire snippet_invalid_export for a non-snippet export"
+    );
+}
+
+#[test]
 fn validate_each_item_invalid_assignment_nested_object_destructure() {
     let diags = analyze_with_diags(
         r#"<script>let items = $state([1, 2, 3]); let value = { nested: { current: 1 } };</script>

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2320,6 +2320,26 @@ fn validate_snippet_invalid_export_no_false_positive() {
 }
 
 #[test]
+fn validate_snippet_invalid_export_module_bound_no_fire() {
+    // If the exported name is declared in <script module>, it is NOT snippet_invalid_export
+    // (matches reference compiler: only fires when the name has no module-scope binding).
+    let diags = analyze_with_diags(
+        r#"<script module>
+    const greeting = () => "module fn";
+    export { greeting };
+</script>
+
+{#snippet greeting()}
+    <p>template snippet</p>
+{/snippet}"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.kind.code() == "snippet_invalid_export"),
+        "should not fire snippet_invalid_export when name is declared in module scope"
+    );
+}
+
+#[test]
 fn validate_each_item_invalid_assignment_nested_object_destructure() {
     let diags = analyze_with_diags(
         r#"<script>let items = $state([1, 2, 3]); let value = { nested: { current: 1 } };</script>

--- a/crates/svelte_analyze/src/validate/mod.rs
+++ b/crates/svelte_analyze/src/validate/mod.rs
@@ -1,24 +1,27 @@
 mod runes;
 mod stores;
 
-use oxc_ast::ast::Program;
+use oxc_ast::ast::{Program, Statement};
+use svelte_ast::Component;
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
+use svelte_span::Span;
 
 use crate::types::script::RuneKind;
 use crate::{types::data::ParserResult, AnalysisData};
 
 pub fn validate(
+    component: &Component,
     data: &AnalysisData,
     parsed: &ParserResult,
     runes: bool,
     diags: &mut Vec<Diagnostic>,
 ) {
-    let Some(program) = &parsed.program else {
-        return;
-    };
-    let offset = parsed.script_content_span.map_or(0, |s| s.start);
+    if let Some(program) = &parsed.program {
+        let offset = parsed.script_content_span.map_or(0, |s| s.start);
+        validate_program(data, program, offset, runes, diags);
+    }
 
-    validate_program(data, program, offset, runes, diags);
+    validate_snippet_exports(component, parsed, diags);
     validate_custom_element_props(data, diags);
 }
 
@@ -31,6 +34,56 @@ pub fn validate_program(
 ) {
     runes::validate(data, program, offset, runes, diags);
     stores::validate(data, program, offset, diags);
+}
+
+/// Error when `<script module>` exports a name that is a template snippet.
+///
+/// Snippets are template-level constructs; exporting them from a module block is invalid
+/// because they are not accessible as module-scope bindings.
+fn validate_snippet_exports(
+    component: &Component,
+    parsed: &ParserResult,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let Some(module_program) = &parsed.module_program else {
+        return;
+    };
+
+    // Collect all snippet names defined in the component template.
+    let snippet_names: Vec<&str> = (0..component.store.len())
+        .filter_map(|i| {
+            component
+                .store
+                .get(svelte_ast::NodeId(i))
+                .as_snippet_block()
+                .map(|s| s.name(&component.source))
+        })
+        .collect();
+
+    if snippet_names.is_empty() {
+        return;
+    }
+
+    for stmt in &module_program.body {
+        let Statement::ExportNamedDeclaration(export) = stmt else {
+            continue;
+        };
+        // Only `export { ... }` (re-exports with `source` are skipped).
+        if export.declaration.is_some() || export.source.is_some() {
+            continue;
+        }
+        for specifier in &export.specifiers {
+            let oxc_ast::ast::ModuleExportName::IdentifierReference(ident) = &specifier.local
+            else {
+                continue;
+            };
+            let name = ident.name.as_str();
+            if snippet_names.iter().any(|&s| s == name) {
+                let span = Span::new(specifier.span.start, specifier.span.end);
+                diags.push(Diagnostic::error(DiagnosticKind::SnippetInvalidExport, span));
+            }
+        }
+    }
 }
 
 /// Warn when `$props()` uses identifier pattern or rest element in a custom element

--- a/crates/svelte_analyze/src/validate/mod.rs
+++ b/crates/svelte_analyze/src/validate/mod.rs
@@ -1,7 +1,7 @@
 mod runes;
 mod stores;
 
-use oxc_ast::ast::{Program, Statement};
+use oxc_ast::ast::{BindingPattern, Declaration, ImportDeclarationSpecifier, Program, Statement};
 use svelte_ast::Component;
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
@@ -78,11 +78,113 @@ fn validate_snippet_exports(
                 continue;
             };
             let name = ident.name.as_str();
-            if snippet_names.iter().any(|&s| s == name) {
+            // Only fire if the name is NOT declared in module scope (matches reference compiler).
+            // If bound in module scope, it's a valid export of a module-local binding.
+            if snippet_names.iter().any(|&s| s == name)
+                && !is_module_bound(module_program, name)
+            {
                 let span = Span::new(specifier.span.start, specifier.span.end);
                 diags.push(Diagnostic::error(DiagnosticKind::SnippetInvalidExport, span));
             }
         }
+    }
+}
+
+/// Returns `true` if `name` is declared at the top level of the module program.
+///
+/// Mirrors `analysis.module.scope.get(name)` from the reference compiler: covers variable
+/// declarations, function/class declarations, and imports (including re-exported declarations).
+fn is_module_bound<'a>(program: &Program<'a>, name: &str) -> bool {
+    for stmt in &program.body {
+        match stmt {
+            Statement::VariableDeclaration(decl) => {
+                if decl
+                    .declarations
+                    .iter()
+                    .any(|d| binding_contains(&d.id, name))
+                {
+                    return true;
+                }
+            }
+            Statement::FunctionDeclaration(func) => {
+                if func.id.as_ref().is_some_and(|id| id.name == name) {
+                    return true;
+                }
+            }
+            Statement::ClassDeclaration(cls) => {
+                if cls.id.as_ref().is_some_and(|id| id.name == name) {
+                    return true;
+                }
+            }
+            Statement::ImportDeclaration(import) => {
+                if let Some(specifiers) = &import.specifiers {
+                    for spec in specifiers {
+                        let local = match spec {
+                            ImportDeclarationSpecifier::ImportSpecifier(s) => {
+                                s.local.name.as_str()
+                            }
+                            ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
+                                s.local.name.as_str()
+                            }
+                            ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
+                                s.local.name.as_str()
+                            }
+                        };
+                        if local == name {
+                            return true;
+                        }
+                    }
+                }
+            }
+            Statement::ExportNamedDeclaration(export) => {
+                if let Some(decl) = &export.declaration {
+                    match decl {
+                        Declaration::VariableDeclaration(d) => {
+                            if d.declarations.iter().any(|v| binding_contains(&v.id, name)) {
+                                return true;
+                            }
+                        }
+                        Declaration::FunctionDeclaration(f) => {
+                            if f.id.as_ref().is_some_and(|id| id.name == name) {
+                                return true;
+                            }
+                        }
+                        Declaration::ClassDeclaration(c) => {
+                            if c.id.as_ref().is_some_and(|id| id.name == name) {
+                                return true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn binding_contains(pattern: &BindingPattern<'_>, name: &str) -> bool {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => id.name == name,
+        BindingPattern::ObjectPattern(obj) => {
+            obj.properties.iter().any(|p| binding_contains(&p.value, name))
+                || obj
+                    .rest
+                    .as_ref()
+                    .is_some_and(|r| binding_contains(&r.argument, name))
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            arr.elements
+                .iter()
+                .flatten()
+                .any(|e| binding_contains(e, name))
+                || arr
+                    .rest
+                    .as_ref()
+                    .is_some_and(|r| binding_contains(&r.argument, name))
+        }
+        BindingPattern::AssignmentPattern(assign) => binding_contains(&assign.left, name),
     }
 }
 

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -162,7 +162,10 @@ pub struct NodeId(pub u32);
 pub struct Component {
     pub fragment: Fragment,
     pub store: AstStore,
-    pub script: Option<Script>,
+    /// Instance-level `<script>` block (runs once per component instance).
+    pub instance_script: Option<Script>,
+    /// Module-level `<script module>` block (runs once when the module loads).
+    pub module_script: Option<Script>,
     pub css: Option<RawBlock>,
     pub options: Option<SvelteOptions>,
     /// Full source text of the .svelte file.
@@ -174,13 +177,15 @@ impl Component {
         source: String,
         fragment: Fragment,
         store: AstStore,
-        script: Option<Script>,
+        instance_script: Option<Script>,
+        module_script: Option<Script>,
         css: Option<RawBlock>,
     ) -> Self {
         Self {
             fragment,
             store,
-            script,
+            instance_script,
+            module_script,
             css,
             options: None,
             source,

--- a/crates/svelte_codegen_client/src/script/pipeline.rs
+++ b/crates/svelte_codegen_client/src/script/pipeline.rs
@@ -24,7 +24,7 @@ pub struct ScriptOutput<'a> {
 }
 
 pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
-    if ctx.query.component.script.is_none() {
+    if ctx.query.component.instance_script.is_none() {
         return ScriptOutput {
             imports: vec![],
             body: vec![],
@@ -40,7 +40,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
     let script_content_start = ctx
         .query
         .component
-        .script
+        .instance_script
         .as_ref()
         .unwrap()
         .content_span
@@ -84,7 +84,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
 
     let component_scoping = ctx.query.scoping();
     let props = ctx.query.props();
-    let script = ctx.query.component.script.as_ref().unwrap();
+    let script = ctx.query.component.instance_script.as_ref().unwrap();
     let is_ts = script.language == ScriptLanguage::TypeScript;
     let script_text = ctx.query.component.source_text(script.content_span);
     transform_script_text(

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -197,7 +197,8 @@ impl<'a> Parser<'a> {
 
         let mut children_stack: Vec<Vec<NodeId>> = vec![vec![]];
         let mut entry_stack: Vec<StackEntry> = vec![];
-        let mut script_data: Option<ScriptData> = None;
+        let mut instance_script_data: Option<ScriptData> = None;
+        let mut module_script_data: Option<ScriptData> = None;
         let mut css_data: Option<CssData> = None;
 
         for token in tokens {
@@ -383,29 +384,41 @@ impl<'a> Parser<'a> {
                     push_child(&mut children_stack, id);
                 }
                 TokenType::ScriptTag(script_tag) => {
-                    if script_data.is_some() {
-                        self.recover(Diagnostic::only_single_top_level_script(token.span));
-                        continue;
-                    }
-
                     let language = if script_tag.is_typescript {
                         ScriptLanguage::TypeScript
                     } else {
                         ScriptLanguage::JavaScript
                     };
 
-                    let context = if script_tag.is_module {
-                        ScriptContext::Module
+                    if script_tag.is_module {
+                        if module_script_data.is_some() {
+                            self.recover(Diagnostic::error(
+                                svelte_diagnostics::DiagnosticKind::ScriptDuplicate,
+                                token.span,
+                            ));
+                            continue;
+                        }
+                        module_script_data = Some(ScriptData {
+                            span: token.span,
+                            content_span: script_tag.content_span,
+                            language,
+                            context: ScriptContext::Module,
+                        });
                     } else {
-                        ScriptContext::Default
-                    };
-
-                    script_data = Some(ScriptData {
-                        span: token.span,
-                        content_span: script_tag.content_span,
-                        language,
-                        context,
-                    });
+                        if instance_script_data.is_some() {
+                            self.recover(Diagnostic::error(
+                                svelte_diagnostics::DiagnosticKind::ScriptDuplicate,
+                                token.span,
+                            ));
+                            continue;
+                        }
+                        instance_script_data = Some(ScriptData {
+                            span: token.span,
+                            content_span: script_tag.content_span,
+                            language,
+                            context: ScriptContext::Default,
+                        });
+                    }
                 }
                 TokenType::StyleTag(style_tag) => {
                     if css_data.is_some() {
@@ -427,7 +440,15 @@ impl<'a> Parser<'a> {
 
         let roots = pop_children(&mut children_stack);
 
-        let script = script_data.map(|sd| Script {
+        let instance_script = instance_script_data.map(|sd| Script {
+            id: self.reserve_id(),
+            span: sd.span,
+            content_span: sd.content_span,
+            context: sd.context,
+            language: sd.language,
+        });
+
+        let module_script = module_script_data.map(|sd| Script {
             id: self.reserve_id(),
             span: sd.span,
             content_span: sd.content_span,
@@ -445,7 +466,8 @@ impl<'a> Parser<'a> {
             self.source.to_string(),
             Fragment::new(roots),
             store,
-            script,
+            instance_script,
+            module_script,
             css,
         );
         // Extract <svelte:options> from fragment (must be top-level)

--- a/crates/svelte_parser/src/tests.rs
+++ b/crates/svelte_parser/src/tests.rs
@@ -24,7 +24,7 @@ fn assert_node(c: &Component, index: usize, expected: &str) {
 }
 
 fn assert_script(c: &Component, expected: &str) {
-    let script = c.script.as_ref().expect("expected script");
+    let script = c.instance_script.as_ref().expect("expected instance script");
     assert_eq!(c.source_text(script.content_span), expected);
 }
 
@@ -99,7 +99,7 @@ fn script_tag() {
 #[test]
 fn script_tag_lang_ts() {
     let c = parse(r#"<script lang="ts">const i: number = 10;</script>"#);
-    let script = c.script.as_ref().expect("expected script");
+    let script = c.instance_script.as_ref().expect("expected instance script");
     assert_eq!(script.language, ScriptLanguage::TypeScript);
 }
 
@@ -147,21 +147,21 @@ fn multiple_roots() {
 #[test]
 fn script_context_default() {
     let c = parse("<script>let x = 1;</script>");
-    let script = c.script.as_ref().expect("expected script");
+    let script = c.instance_script.as_ref().expect("expected instance script");
     assert_eq!(script.context, ScriptContext::Default);
 }
 
 #[test]
 fn script_context_module_attribute() {
     let c = parse("<script module>let x = 1;</script>");
-    let script = c.script.as_ref().expect("expected script");
+    let script = c.module_script.as_ref().expect("expected module script");
     assert_eq!(script.context, ScriptContext::Module);
 }
 
 #[test]
 fn script_context_module_context_attribute() {
     let c = parse(r#"<script context="module">let x = 1;</script>"#);
-    let script = c.script.as_ref().expect("expected script");
+    let script = c.module_script.as_ref().expect("expected module script");
     assert_eq!(script.context, ScriptContext::Module);
 }
 
@@ -504,15 +504,45 @@ fn recovery_close_tag_no_matching_open() {
 }
 
 #[test]
+fn dual_scripts_instance_and_module() {
+    let c = parse("<script module>export let x = 1;</script><script>let y = 2;</script>");
+    assert!(c.module_script.is_some());
+    assert!(c.instance_script.is_some());
+    let ms = c.module_script.as_ref().unwrap();
+    assert_eq!(ms.context, ScriptContext::Module);
+    let is_ = c.instance_script.as_ref().unwrap();
+    assert_eq!(is_.context, ScriptContext::Default);
+}
+
+#[test]
+fn dual_scripts_module_then_instance() {
+    // Order does not matter — module goes to module_script, instance to instance_script.
+    let c = parse("<script>let a = 1;</script><script module>export let b = 2;</script>");
+    assert!(c.instance_script.is_some());
+    assert!(c.module_script.is_some());
+}
+
+#[test]
 fn recovery_duplicate_script_continues() {
     let (c, diags) = parse_with_diagnostics(
         "<script>let a = 1;</script><script>let b = 2;</script><div>ok</div>",
     );
     assert!(!diags.is_empty());
-    // First script is kept, second is skipped, div is parsed
-    assert!(c.script.is_some());
+    // First instance script is kept, second is skipped, div is parsed
+    assert!(c.instance_script.is_some());
     assert_eq!(c.fragment.nodes.len(), 1);
     assert!(c.store.get(c.fragment.nodes[0]).is_element());
+}
+
+#[test]
+fn recovery_duplicate_module_script_continues() {
+    let (c, diags) = parse_with_diagnostics(
+        "<script module>let a = 1;</script><script module>let b = 2;</script><div>ok</div>",
+    );
+    assert!(!diags.is_empty());
+    assert!(c.module_script.is_some());
+    assert!(c.instance_script.is_none());
+    assert_eq!(c.fragment.nodes.len(), 1);
 }
 
 #[test]

--- a/crates/svelte_parser/src/types.rs
+++ b/crates/svelte_parser/src/types.rs
@@ -10,7 +10,10 @@ pub struct ExprHandle(pub u32);
 pub struct StmtHandle(pub u32);
 
 pub struct ParserResult<'a> {
+    /// Parsed program for the instance `<script>` block.
     pub program: Option<oxc_ast::ast::Program<'a>>,
+    /// Parsed program for the `<script module>` block.
+    pub module_program: Option<oxc_ast::ast::Program<'a>>,
     exprs: FxHashMap<ExprHandle, Expression<'a>>,
     stmts: FxHashMap<StmtHandle, Statement<'a>>,
     expr_by_offset: FxHashMap<u32, ExprHandle>,
@@ -18,6 +21,7 @@ pub struct ParserResult<'a> {
     next_expr: u32,
     next_stmt: u32,
     pub script_content_span: Option<Span>,
+    pub module_script_content_span: Option<Span>,
     pub typescript: bool,
 }
 
@@ -25,6 +29,7 @@ impl<'a> ParserResult<'a> {
     pub fn new() -> Self {
         Self {
             program: None,
+            module_program: None,
             exprs: FxHashMap::default(),
             stmts: FxHashMap::default(),
             expr_by_offset: FxHashMap::default(),
@@ -32,6 +37,7 @@ impl<'a> ParserResult<'a> {
             next_expr: 0,
             next_stmt: 0,
             script_content_span: None,
+            module_script_content_span: None,
             typescript: false,
         }
     }

--- a/crates/svelte_parser/src/walk_js.rs
+++ b/crates/svelte_parser/src/walk_js.rs
@@ -19,13 +19,15 @@ pub(crate) fn parse_js<'a>(
     result: &mut ParserResult<'a>,
     diags: &mut Vec<Diagnostic>,
 ) {
-    let typescript = component
+    // Template expressions use TS parsing if either script is TypeScript.
+    let template_typescript = component
         .instance_script
         .as_ref()
         .or(component.module_script.as_ref())
         .is_some_and(|s| matches!(s.language, ScriptLanguage::TypeScript));
 
     if let Some(script) = &component.instance_script {
+        let typescript = matches!(script.language, ScriptLanguage::TypeScript);
         let source = component.source_text(script.content_span);
         let arena_source: &'a str = alloc.alloc_str(source);
         match parse_script_with_alloc(alloc, arena_source, script.content_span.start, typescript) {
@@ -39,6 +41,7 @@ pub(crate) fn parse_js<'a>(
     }
 
     if let Some(script) = &component.module_script {
+        let typescript = matches!(script.language, ScriptLanguage::TypeScript);
         let source = component.source_text(script.content_span);
         let arena_source: &'a str = alloc.alloc_str(source);
         match parse_script_with_alloc(alloc, arena_source, script.content_span.start, typescript) {
@@ -55,7 +58,7 @@ pub(crate) fn parse_js<'a>(
         &component.fragment,
         &component.store,
         component,
-        typescript,
+        template_typescript,
         result,
         diags,
     );
@@ -67,7 +70,7 @@ pub(crate) fn parse_js<'a>(
         .as_ref()
         .and_then(|o| o.custom_element.as_ref())
     {
-        parse_span(alloc, component, *span, typescript, result, diags);
+        parse_span(alloc, component, *span, template_typescript, result, diags);
     }
 }
 

--- a/crates/svelte_parser/src/walk_js.rs
+++ b/crates/svelte_parser/src/walk_js.rs
@@ -20,11 +20,12 @@ pub(crate) fn parse_js<'a>(
     diags: &mut Vec<Diagnostic>,
 ) {
     let typescript = component
-        .script
+        .instance_script
         .as_ref()
+        .or(component.module_script.as_ref())
         .is_some_and(|s| matches!(s.language, ScriptLanguage::TypeScript));
 
-    if let Some(script) = &component.script {
+    if let Some(script) = &component.instance_script {
         let source = component.source_text(script.content_span);
         let arena_source: &'a str = alloc.alloc_str(source);
         match parse_script_with_alloc(alloc, arena_source, script.content_span.start, typescript) {
@@ -35,6 +36,18 @@ pub(crate) fn parse_js<'a>(
             Err(errs) => diags.extend(errs),
         }
         result.typescript = typescript;
+    }
+
+    if let Some(script) = &component.module_script {
+        let source = component.source_text(script.content_span);
+        let arena_source: &'a str = alloc.alloc_str(source);
+        match parse_script_with_alloc(alloc, arena_source, script.content_span.start, typescript) {
+            Ok(program) => {
+                result.module_program = Some(program);
+                result.module_script_content_span = Some(script.content_span);
+            }
+            Err(errs) => diags.extend(errs),
+        }
     }
 
     walk_fragment(

--- a/specs/snippet-block.md
+++ b/specs/snippet-block.md
@@ -1,10 +1,9 @@
 # SnippetBlock
 
 ## Current state
-- **Working**: 18/19 use cases — codegen now covers nested/computed destructuring and analyze validates snippet param assignment, invalid rest params, prop shadowing, and children conflicts
-- **Blocked**: `snippet_invalid_export` — reference-invalid cases require both `<script module>` and instance `<script>`, but the parser still accepts only one top-level script
-- **Next**: parser/analyze support for dual top-level scripts, then implement `snippet_invalid_export`
-- Last updated: 2026-04-03
+- **Complete**: 19/19 use cases — all implemented and covered
+- `snippet_invalid_export` landed: dual top-level script parsing (`instance_script` + `module_script`) added to AST/parser; validation fires when `<script module>` exports a template snippet name
+- Last updated: 2026-04-04
 
 ## Source
 ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
@@ -31,7 +30,7 @@ ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
 18. [x] `snippet_invalid_rest_parameter` validation (tests: analyzer unit tests)
 19. [x] `snippet_shadowing_prop` validation (tests: analyzer unit tests)
 20. [x] `snippet_conflict` validation (tests: analyzer unit tests)
-21. [ ] `snippet_invalid_export` validation
+21. [x] `snippet_invalid_export` validation (tests: analyzer unit tests)
 
 ## Reference
 
@@ -46,9 +45,12 @@ ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
 - `crates/svelte_codegen_client/src/template/snippet.rs` — parsed-param-driven destructuring codegen, including nested object/array patterns and computed keys
 - `crates/svelte_analyze/src/passes/template_side_tables.rs` — `SnippetParamMarker` marks snippet-param symbols for downstream validation
 - `crates/svelte_analyze/src/passes/template_validation.rs` — snippet param assignment/rest/shadowing/conflict validation
+- `crates/svelte_analyze/src/validate/mod.rs` — `validate_snippet_exports` fires `snippet_invalid_export` when module script exports a snippet name
 - `crates/svelte_analyze/src/tests.rs` — analyzer-level coverage for snippet diagnostics; `tasks/compiler_tests/test_v3.rs` remains snapshot-only
 - `crates/svelte_analyze/src/scope.rs` — `is_snippet_param` / `is_snippet_name` symbol classification
-- `crates/svelte_parser/src/lib.rs` — current blocker: only one top-level `<script>` is accepted
+- `crates/svelte_parser/src/lib.rs` — dual `<script>` + `<script module>` now accepted; each stored in `Component.instance_script` / `Component.module_script`
+- `crates/svelte_ast/src/lib.rs` — `Component.instance_script` + `Component.module_script` (replaces single `script` field)
+- `crates/svelte_parser/src/types.rs` — `ParserResult.module_program` + `module_script_content_span`
 
 ## Tasks
 
@@ -56,7 +58,7 @@ ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
 - [x] Mark snippet parameter symbols explicitly in scoping so validation can reject writes by `SymbolId`, not by name
 - [x] Validate snippet parameter assignment in template JS, including nested assignment targets
 - [x] Validate snippet rest parameters, component-prop shadowing, and `children` snippet conflicts
-- [ ] Add `snippet_invalid_export` once parser/analyze can represent both module and instance scripts in the same component
+- [x] Add `snippet_invalid_export` — parser now supports dual scripts; validation fires from `validate_snippet_exports`
 
 ### Codegen
 - [x] Walk parsed `FormalParameters` directly from `parsed.stmts`


### PR DESCRIPTION
## Summary
This PR implements support for both instance-level `<script>` and module-level `<script module>` blocks in Svelte components, and adds validation to prevent exporting template snippet names from the module script.

## Key Changes

### Parser & AST Updates
- **Dual script support**: Modified `svelte_parser` to track both `instance_script` and `module_script` separately instead of a single `script` field
  - `Component` struct now has `instance_script: Option<Script>` and `module_script: Option<Script>`
  - Parser correctly routes `<script>` to instance and `<script module>` to module based on context
  - Both scripts can coexist in a single component
- **Duplicate script detection**: Added separate duplicate checks for instance and module scripts with appropriate error recovery

### JavaScript Parsing
- Updated `walk_js.rs` to parse both instance and module scripts into separate `Program` objects
- Template expressions use TypeScript mode if *either* script is TypeScript (preserves existing behavior)
- Module script parsing stored in `ParserResult.module_program` with corresponding `module_script_content_span`

### Snippet Export Validation
- Implemented `validate_snippet_exports()` in `svelte_analyze` that:
  - Collects all snippet names defined in the component template
  - Checks `<script module>` for `export { ... }` statements
  - Fires `snippet_invalid_export` diagnostic when a snippet name is exported without a module-scope binding
  - Correctly handles destructuring patterns and nested bindings via `is_module_bound()` helper
  - Mirrors reference compiler behavior: only fires when exported name has no module-scope declaration
- Added comprehensive test coverage including false-positive prevention

### Integration
- Updated `validate()` function signature to accept `component` parameter for snippet validation
- Updated all call sites in `svelte_analyze` and test utilities

## Notable Implementation Details
- The `is_module_bound()` function recursively checks binding patterns (identifiers, objects, arrays, assignments) to accurately determine if a name is declared at module scope
- Validation correctly distinguishes between:
  - Exporting a snippet name with no module binding (error)
  - Exporting a snippet name that shadows a module binding (allowed)
  - Exporting a non-snippet name (allowed)

https://claude.ai/code/session_014tT8V1jokrvweDaLNNVDWX