### PR TITLE
Add A11y diagnostics for distracting elements and attributes

### DIFF
--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -162,6 +162,48 @@ impl TemplateVisitor for TemplateValidationVisitor {
                 el.span,
             ));
         }
+
+        // a11y_distracting_elements: <marquee> and <blink> are harmful to accessibility.
+        if matches!(el.name.as_str(), "marquee" | "blink") {
+            ctx.warnings_mut().push(Diagnostic::warning(
+                DiagnosticKind::A11yDistractingElements { name: el.name.clone() },
+                el.span,
+            ));
+        }
+
+        // Attribute-level A11y checks that only need the attribute name or a static value.
+        for attr in &el.attributes {
+            let attr_name = match attr {
+                Attribute::StringAttribute(a) => a.name.as_str(),
+                Attribute::BooleanAttribute(a) => a.name.as_str(),
+                Attribute::ExpressionAttribute(a) => a.name.as_str(),
+                Attribute::ConcatenationAttribute(a) => a.name.as_str(),
+                _ => continue,
+            };
+            match attr_name {
+                // a11y_accesskey: using accesskey harms keyboard-only navigation.
+                "accesskey" => {
+                    ctx.warnings_mut().push(Diagnostic::warning(
+                        DiagnosticKind::A11yAccesskey,
+                        attr_value_span(attr),
+                    ));
+                }
+                // a11y_positive_tabindex: tabindex > 0 disrupts natural tab order.
+                "tabindex" => {
+                    if let Some(text) = static_text_attr_value(attr, ctx.source) {
+                        if let Ok(n) = text.trim().parse::<i64>() {
+                            if n > 0 {
+                                ctx.warnings_mut().push(Diagnostic::warning(
+                                    DiagnosticKind::A11yPositiveTabindex,
+                                    attr_value_span(attr),
+                                ));
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 
     fn leave_element(&mut self, _el: &Element, ctx: &mut VisitContext<'_>) {

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2944,6 +2944,52 @@ fn slot_attribute_invalid_placement_root() {
 }
 
 // ---------------------------------------------------------------------------
+// A11y diagnostics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a11y_distracting_elements_marquee() {
+    let diags = analyze_with_diags(r#"<marquee>scroll</marquee>"#);
+    assert_has_warning(&diags, "a11y_distracting_elements");
+}
+
+#[test]
+fn a11y_distracting_elements_blink() {
+    let diags = analyze_with_diags(r#"<blink>flash</blink>"#);
+    assert_has_warning(&diags, "a11y_distracting_elements");
+}
+
+#[test]
+fn a11y_accesskey_warns() {
+    let diags = analyze_with_diags(r#"<div accesskey="a">content</div>"#);
+    assert_has_warning(&diags, "a11y_accesskey");
+}
+
+#[test]
+fn a11y_positive_tabindex_warns() {
+    let diags = analyze_with_diags(r#"<div tabindex="2">content</div>"#);
+    assert_has_warning(&diags, "a11y_positive_tabindex");
+}
+
+#[test]
+fn a11y_tabindex_zero_no_warning() {
+    let diags = analyze_with_diags(r#"<div tabindex="0">content</div>"#);
+    assert_no_warning(&diags, "a11y_positive_tabindex");
+}
+
+#[test]
+fn a11y_tabindex_negative_no_warning() {
+    let diags = analyze_with_diags(r#"<div tabindex="-1">content</div>"#);
+    assert_no_warning(&diags, "a11y_positive_tabindex");
+}
+
+#[test]
+fn a11y_tabindex_dynamic_no_warning() {
+    let diags = analyze_with_diags(r#"<script>let n = $state(0);</script><div tabindex={n}>content</div>"#);
+    assert_no_warning(&diags, "a11y_positive_tabindex");
+}
+
+// ---------------------------------------------------------------------------
 // AwaitBlock diagnostics
 // ---------------------------------------------------------------------------
 

--- a/specs/element.md
+++ b/specs/element.md
@@ -1,11 +1,11 @@
 # Element
 
 ## Current state
-- **Working**: 12/16 use cases
-- **Partial**: template validation — `slot_attribute_invalid_placement` added; `node_invalid_placement` and `component_name_lowercase` skipped (require HTML content model table and symbol ref-count access respectively)
-- **Missing**: 4 — namespace edge cases, legacy slots, A11y, CSS-scoped metadata
-- **Next**: legacy slots or A11y
-- Last updated: 2026-04-03
+- **Working**: 13/16 use cases
+- **Partial**: template validation — `slot_attribute_invalid_placement` added; `node_invalid_placement` and `component_name_lowercase` skipped (require HTML content model table and symbol ref-count access respectively). A11y: first 3 checks implemented (`a11y_distracting_elements`, `a11y_accesskey`, `a11y_positive_tabindex`); remaining checks (missing attributes, autofocus, ARIA roles, event handler A11y) deferred to next A11y slice.
+- **Missing**: 3 — namespace edge cases, legacy slots, CSS-scoped metadata
+- **Next**: legacy slots or remaining A11y checks
+- Last updated: 2026-04-04
 
 ## Source
 
@@ -68,7 +68,10 @@
   Current coverage proves common cases only
 
 - `[ ]` Legacy `<slot>` semantics and slot elements
-- `[ ]` A11y warnings for regular elements
+- `[~]` A11y warnings for regular elements
+  Implemented: `a11y_distracting_elements` (`<marquee>`/`<blink>`), `a11y_accesskey` (accesskey attribute), `a11y_positive_tabindex` (tabindex > 0).
+  Tests: `a11y_distracting_elements_marquee`, `a11y_distracting_elements_blink`, `a11y_accesskey_warns`, `a11y_positive_tabindex_warns`, `a11y_tabindex_zero_no_warning`, `a11y_tabindex_negative_no_warning`, `a11y_tabindex_dynamic_no_warning`.
+  Remaining: `a11y_missing_attribute` (img alt, anchor label), `a11y_autofocus` (context-sensitive), ARIA role checks, event handler A11y checks.
 - `[ ]` CSS-scoped element metadata and pruning
 
 ## Reference


### PR DESCRIPTION
## Summary
Implement three accessibility (A11y) diagnostic checks for Svelte template validation: detection of distracting HTML elements (`<marquee>` and `<blink>`), the `accesskey` attribute, and positive `tabindex` values.

## Key Changes

- **New diagnostic kinds**: Added `A11yDistractingElements`, `A11yAccesskey`, and `A11yPositiveTabindex` to the diagnostic system
- **Element-level checks**: Detect `<marquee>` and `<blink>` elements and emit warnings, as these are harmful to accessibility
- **Attribute-level checks**: 
  - Warn on `accesskey` attribute usage, which disrupts keyboard-only navigation
  - Warn on `tabindex` with positive integer values (> 0), which disrupts natural tab order
  - Skip warnings for `tabindex="0"`, negative values, and dynamic expressions
- **Comprehensive test coverage**: Added 7 test cases covering both positive cases (warnings emitted) and negative cases (no false positives for zero/negative/dynamic tabindex values)
- **Documentation**: Updated specs/element.md to reflect A11y implementation progress and deferred checks

## Implementation Details

The A11y checks are implemented in `template_validation.rs` within the `visit_element` method:
- Element name matching for distracting elements
- Attribute iteration with static value extraction for `tabindex` validation
- Integer parsing with bounds checking to distinguish positive values from zero and negative values
- Dynamic expressions are safely ignored (no warning emitted)

All checks emit warnings (not errors) as per accessibility best practices, allowing developers to override when necessary while encouraging accessible patterns.

https://claude.ai/code/session_01XiLVrV65NPpJL3Z8rEgHrc