### PR TITLE
Add a11y_autofocus and a11y_missing_attribute checks

### DIFF
--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -62,6 +62,8 @@ pub(crate) struct TemplateValidationVisitor {
     current_expr_offset: u32,
     /// Stack of per-element event state, pushed on `visit_element` and popped on `leave_element`.
     element_event_state: Vec<ElementEventState>,
+    /// Nesting depth of `<dialog>` elements; used to suppress `a11y_autofocus` inside dialogs.
+    dialog_depth: u32,
 }
 
 impl TemplateValidationVisitor {
@@ -69,6 +71,7 @@ impl TemplateValidationVisitor {
         Self {
             current_expr_offset: 0,
             element_event_state: Vec::new(),
+            dialog_depth: 0,
         }
     }
 
@@ -146,6 +149,11 @@ impl TemplateVisitor for TemplateValidationVisitor {
     fn visit_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
         self.element_event_state.push(ElementEventState::default());
 
+        // Track dialog nesting for a11y_autofocus suppression.
+        if el.name == "dialog" {
+            self.dialog_depth += 1;
+        }
+
         // slot_attribute_invalid_placement: a slot="..." attribute on a regular element
         // is only valid when the element is a direct child of a component.
         let has_slot_attr = el
@@ -171,8 +179,13 @@ impl TemplateVisitor for TemplateValidationVisitor {
             ));
         }
 
-        // Attribute-level A11y checks that only need the attribute name or a static value.
+        // Attribute-level A11y checks. Also detect spread for missing-attribute suppression.
+        let mut has_spread = false;
         for attr in &el.attributes {
+            if matches!(attr, Attribute::SpreadAttribute(_)) {
+                has_spread = true;
+                continue;
+            }
             let attr_name = match attr {
                 Attribute::StringAttribute(a) => a.name.as_str(),
                 Attribute::BooleanAttribute(a) => a.name.as_str(),
@@ -201,12 +214,30 @@ impl TemplateVisitor for TemplateValidationVisitor {
                         }
                     }
                 }
+                // a11y_autofocus: autofocus is only legitimate on <dialog> and its descendants.
+                "autofocus" => {
+                    if el.name != "dialog" && self.dialog_depth == 0 {
+                        ctx.warnings_mut().push(Diagnostic::warning(
+                            DiagnosticKind::A11yAutofocus,
+                            el.span,
+                        ));
+                    }
+                }
                 _ => {}
             }
         }
+
+        // a11y_missing_attribute: certain elements require specific attributes.
+        // Suppressed when a spread attribute is present (it may supply the missing attr).
+        if !has_spread {
+            check_a11y_missing_attribute(el, ctx);
+        }
     }
 
-    fn leave_element(&mut self, _el: &Element, ctx: &mut VisitContext<'_>) {
+    fn leave_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
+        if el.name == "dialog" {
+            self.dialog_depth -= 1;
+        }
         self.emit_mixed_syntax_if_needed(ctx);
     }
 
@@ -1478,4 +1509,109 @@ fn contains_invalid_snippet_param_assignment(
     };
     visitor.visit_expression(expr);
     visitor.found
+}
+
+// ---------------------------------------------------------------------------
+// A11y: missing required attributes
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `el` has a named attribute (string, boolean, expression, or concatenation)
+/// with the given `name`. Spread and directive attributes are not matched.
+fn el_has_attr(el: &Element, name: &str) -> bool {
+    el.attributes.iter().any(|a| match a {
+        Attribute::StringAttribute(a) => a.name == name,
+        Attribute::BooleanAttribute(a) => a.name == name,
+        Attribute::ExpressionAttribute(a) => a.name == name,
+        Attribute::ConcatenationAttribute(a) => a.name == name,
+        _ => false,
+    })
+}
+
+/// Returns the static string value of a `StringAttribute` named `name`, if present.
+fn el_static_attr_value<'a>(el: &Element, name: &str, source: &'a str) -> Option<&'a str> {
+    el.attributes.iter().find_map(|a| {
+        if let Attribute::StringAttribute(sa) = a {
+            if sa.name == name {
+                return Some(sa.value_span.source_text(source));
+            }
+        }
+        None
+    })
+}
+
+/// Emit `a11y_missing_attribute` for `el` when none of `required` attrs are present.
+fn warn_missing_attr(el: &Element, required: &[&str], ctx: &mut VisitContext<'_>) {
+    let first = required[0];
+    // "href" and vowel-starting names take "an"; everything else takes "a".
+    let article = if first == "href" || first.starts_with(['a', 'e', 'i', 'o', 'u']) {
+        "an"
+    } else {
+        "a"
+    };
+    let sequence = if required.len() == 1 {
+        required[0].to_string()
+    } else {
+        let (last, rest) = required.split_last().unwrap();
+        format!("{} or {last}", rest.join(", "))
+    };
+    ctx.warnings_mut().push(Diagnostic::warning(
+        DiagnosticKind::A11yMissingAttribute {
+            name: el.name.clone(),
+            article: article.to_string(),
+            sequence,
+        },
+        el.span,
+    ));
+}
+
+/// Check `a11y_missing_attribute` for elements that require specific attributes.
+/// Only called when no spread attribute is present on `el`.
+fn check_a11y_missing_attribute(el: &Element, ctx: &mut VisitContext<'_>) {
+    match el.name.as_str() {
+        // img needs alt
+        "img" => {
+            if !el_has_attr(el, "alt") {
+                warn_missing_attr(el, &["alt"], ctx);
+            }
+        }
+        // area needs alt, aria-label, or aria-labelledby
+        "area" => {
+            if !el_has_attr(el, "alt")
+                && !el_has_attr(el, "aria-label")
+                && !el_has_attr(el, "aria-labelledby")
+            {
+                warn_missing_attr(el, &["alt", "aria-label", "aria-labelledby"], ctx);
+            }
+        }
+        // iframe needs title
+        "iframe" => {
+            if !el_has_attr(el, "title") {
+                warn_missing_attr(el, &["title"], ctx);
+            }
+        }
+        // object needs title, aria-label, or aria-labelledby
+        "object" => {
+            if !el_has_attr(el, "title")
+                && !el_has_attr(el, "aria-label")
+                && !el_has_attr(el, "aria-labelledby")
+            {
+                warn_missing_attr(el, &["title", "aria-label", "aria-labelledby"], ctx);
+            }
+        }
+        // <a> without href is only valid as a named anchor (id/name) or disabled link
+        "a" => {
+            if el_has_attr(el, "href") || el_has_attr(el, "xlink:href") {
+                return;
+            }
+            // Named anchors and aria-disabled links don't require href.
+            if el_has_attr(el, "id") || el_has_attr(el, "name") {
+                return;
+            }
+            if el_static_attr_value(el, "aria-disabled", ctx.source) == Some("true") {
+                return;
+            }
+            warn_missing_attr(el, &["href"], ctx);
+        }
+        _ => {}
+    }
 }

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -3053,6 +3053,19 @@ fn a11y_missing_attribute_iframe_with_title_no_warning() {
 }
 
 #[test]
+fn a11y_missing_attribute_object_no_title() {
+    let diags = analyze_with_diags(r#"<object data="file.swf"></object>"#);
+    assert_has_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_object_with_aria_labelledby_no_warning() {
+    let diags =
+        analyze_with_diags(r#"<object data="file.swf" aria-labelledby="desc"></object>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
 fn a11y_missing_attribute_anchor_no_href() {
     // <a> without href, id, name, or aria-disabled=true should warn
     let diags = analyze_with_diags(r#"<a>link text</a>"#);

--- a/crates/svelte_analyze/src/tests.rs
+++ b/crates/svelte_analyze/src/tests.rs
@@ -2989,6 +2989,108 @@ fn a11y_tabindex_dynamic_no_warning() {
     assert_no_warning(&diags, "a11y_positive_tabindex");
 }
 
+#[test]
+fn a11y_autofocus_warns() {
+    let diags = analyze_with_diags(r#"<input autofocus />"#);
+    assert_has_warning(&diags, "a11y_autofocus");
+}
+
+#[test]
+fn a11y_autofocus_on_dialog_no_warning() {
+    // autofocus is legitimate on a <dialog> element itself
+    let diags = analyze_with_diags(r#"<dialog autofocus>content</dialog>"#);
+    assert_no_warning(&diags, "a11y_autofocus");
+}
+
+#[test]
+fn a11y_autofocus_inside_dialog_no_warning() {
+    // autofocus is legitimate on elements nested inside a <dialog>
+    let diags = analyze_with_diags(r#"<dialog><input autofocus /></dialog>"#);
+    assert_no_warning(&diags, "a11y_autofocus");
+}
+
+#[test]
+fn a11y_missing_attribute_img_no_alt() {
+    let diags = analyze_with_diags(r#"<img src="cat.jpg" />"#);
+    assert_has_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_img_with_alt_no_warning() {
+    let diags = analyze_with_diags(r#"<img src="cat.jpg" alt="a cat" />"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_img_spread_no_warning() {
+    // spread may include alt — don't warn
+    let diags = analyze_with_diags(r#"<script>let p = $state({});</script><img {...p} />"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_area_no_alt() {
+    let diags = analyze_with_diags(r#"<map name="m"><area /></map>"#);
+    assert_has_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_area_with_aria_label_no_warning() {
+    let diags = analyze_with_diags(r#"<map name="m"><area aria-label="region" /></map>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_iframe_no_title() {
+    let diags = analyze_with_diags(r#"<iframe src="page.html"></iframe>"#);
+    assert_has_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_iframe_with_title_no_warning() {
+    let diags = analyze_with_diags(r#"<iframe src="page.html" title="page"></iframe>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_anchor_no_href() {
+    // <a> without href, id, name, or aria-disabled=true should warn
+    let diags = analyze_with_diags(r#"<a>link text</a>"#);
+    assert_has_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_anchor_with_href_no_warning() {
+    let diags = analyze_with_diags(r#"<a href="/page">link</a>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_anchor_with_id_no_warning() {
+    // <a id="..."> is a named anchor — href not required
+    let diags = analyze_with_diags(r#"<a id="anchor">anchor</a>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_anchor_with_name_no_warning() {
+    let diags = analyze_with_diags(r#"<a name="anchor">anchor</a>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_anchor_aria_disabled_no_warning() {
+    // aria-disabled="true" suppresses the href requirement
+    let diags = analyze_with_diags(r#"<a aria-disabled="true">disabled link</a>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
+#[test]
+fn a11y_missing_attribute_anchor_spread_no_warning() {
+    let diags = analyze_with_diags(r#"<script>let p = $state({});</script><a {...p}>link</a>"#);
+    assert_no_warning(&diags, "a11y_missing_attribute");
+}
+
 // ---------------------------------------------------------------------------
 // AwaitBlock diagnostics
 // ---------------------------------------------------------------------------

--- a/specs/element.md
+++ b/specs/element.md
@@ -69,13 +69,13 @@
 
 - `[ ]` Legacy `<slot>` semantics and slot elements
 - `[~]` A11y warnings for regular elements
-  Implemented: `a11y_distracting_elements` (`<marquee>`/`<blink>`), `a11y_accesskey`, `a11y_positive_tabindex`, `a11y_autofocus` (suppressed inside `<dialog>`), `a11y_missing_attribute` (img[alt], area[alt|aria-label|aria-labelledby], iframe[title], object[title|aria-label|aria-labelledby], a[href] with id/name/aria-disabled exceptions).
-  Tests: `a11y_distracting_elements_marquee`, `a11y_distracting_elements_blink`, `a11y_accesskey_warns`, `a11y_positive_tabindex_warns`, `a11y_tabindex_zero_no_warning`, `a11y_tabindex_negative_no_warning`, `a11y_tabindex_dynamic_no_warning`, `a11y_autofocus_warns`, `a11y_autofocus_on_dialog_no_warning`, `a11y_autofocus_inside_dialog_no_warning`, `a11y_missing_attribute_img_no_alt`, `a11y_missing_attribute_img_with_alt_no_warning`, `a11y_missing_attribute_img_spread_no_warning`, `a11y_missing_attribute_area_no_alt`, `a11y_missing_attribute_area_with_aria_label_no_warning`, `a11y_missing_attribute_iframe_no_title`, `a11y_missing_attribute_iframe_with_title_no_warning`, `a11y_missing_attribute_anchor_no_href`, `a11y_missing_attribute_anchor_with_href_no_warning`, `a11y_missing_attribute_anchor_with_id_no_warning`, `a11y_missing_attribute_anchor_with_name_no_warning`, `a11y_missing_attribute_anchor_aria_disabled_no_warning`, `a11y_missing_attribute_anchor_spread_no_warning`.
-  Remaining: `html[lang]`, `input[type=image]` alt, `a11y_missing_content`, ARIA role/attribute checks, event handler A11y checks.
-  [ ] `html[lang]` — root element, needs separate treatment
-  [ ] `input[type=image]` — needs static type attribute value inspection
-  [ ] ARIA role checks (`a11y_unknown_role`, `a11y_no_abstract_role`, `a11y_role_has_required_aria_props`, etc.)
-  [ ] Event handler A11y (`a11y_click_events_have_key_events`, `a11y_mouse_events_have_key_events`)
+  Implemented: `a11y_distracting_elements` (`<marquee>`/`<blink>`), `a11y_accesskey`, `a11y_positive_tabindex`, `a11y_autofocus` (suppressed inside `<dialog>`; diagnostic reported at element span — `BooleanAttribute` has no span field so attribute-level span is not yet available), `a11y_missing_attribute` (img[alt], area[alt|aria-label|aria-labelledby], iframe[title], object[title|aria-label|aria-labelledby], a[href] with id/name/aria-disabled exceptions).
+  Tests: `a11y_distracting_elements_marquee`, `a11y_distracting_elements_blink`, `a11y_accesskey_warns`, `a11y_positive_tabindex_warns`, `a11y_tabindex_zero_no_warning`, `a11y_tabindex_negative_no_warning`, `a11y_tabindex_dynamic_no_warning`, `a11y_autofocus_warns`, `a11y_autofocus_on_dialog_no_warning`, `a11y_autofocus_inside_dialog_no_warning`, `a11y_missing_attribute_img_no_alt`, `a11y_missing_attribute_img_with_alt_no_warning`, `a11y_missing_attribute_img_spread_no_warning`, `a11y_missing_attribute_area_no_alt`, `a11y_missing_attribute_area_with_aria_label_no_warning`, `a11y_missing_attribute_iframe_no_title`, `a11y_missing_attribute_iframe_with_title_no_warning`, `a11y_missing_attribute_object_no_title`, `a11y_missing_attribute_object_with_aria_labelledby_no_warning`, `a11y_missing_attribute_anchor_no_href`, `a11y_missing_attribute_anchor_with_href_no_warning`, `a11y_missing_attribute_anchor_with_id_no_warning`, `a11y_missing_attribute_anchor_with_name_no_warning`, `a11y_missing_attribute_anchor_aria_disabled_no_warning`, `a11y_missing_attribute_anchor_spread_no_warning`.
+- `[ ]` A11y: `html[lang]` — root element, needs separate treatment
+- `[ ]` A11y: `input[type=image]` alt — needs static type attribute value inspection
+- `[ ]` A11y: ARIA role checks (`a11y_unknown_role`, `a11y_no_abstract_role`, `a11y_role_has_required_aria_props`, etc.)
+- `[ ]` A11y: event handler pair checks (`a11y_click_events_have_key_events`, `a11y_mouse_events_have_key_events`)
+- `[ ]` A11y: `a11y_missing_content` for headings, buttons, anchors
 - `[ ]` CSS-scoped element metadata and pruning
 
 ## Reference

--- a/specs/element.md
+++ b/specs/element.md
@@ -2,9 +2,9 @@
 
 ## Current state
 - **Working**: 13/16 use cases
-- **Partial**: template validation — `slot_attribute_invalid_placement` added; `node_invalid_placement` and `component_name_lowercase` skipped (require HTML content model table and symbol ref-count access respectively). A11y: first 3 checks implemented (`a11y_distracting_elements`, `a11y_accesskey`, `a11y_positive_tabindex`); remaining checks (missing attributes, autofocus, ARIA roles, event handler A11y) deferred to next A11y slice.
+- **Partial**: template validation — `slot_attribute_invalid_placement` added; `node_invalid_placement` and `component_name_lowercase` skipped (require HTML content model table and symbol ref-count access respectively). A11y: 5 checks implemented (`a11y_distracting_elements`, `a11y_accesskey`, `a11y_positive_tabindex`, `a11y_autofocus`, `a11y_missing_attribute` for img/area/iframe/object/a); remaining (ARIA roles, event handler A11y, html[lang], input type=image) deferred.
 - **Missing**: 3 — namespace edge cases, legacy slots, CSS-scoped metadata
-- **Next**: legacy slots or remaining A11y checks
+- **Next**: ARIA role/attribute checks or remaining A11y (html[lang], missing_content, event handler pair checks)
 - Last updated: 2026-04-04
 
 ## Source
@@ -69,9 +69,13 @@
 
 - `[ ]` Legacy `<slot>` semantics and slot elements
 - `[~]` A11y warnings for regular elements
-  Implemented: `a11y_distracting_elements` (`<marquee>`/`<blink>`), `a11y_accesskey` (accesskey attribute), `a11y_positive_tabindex` (tabindex > 0).
-  Tests: `a11y_distracting_elements_marquee`, `a11y_distracting_elements_blink`, `a11y_accesskey_warns`, `a11y_positive_tabindex_warns`, `a11y_tabindex_zero_no_warning`, `a11y_tabindex_negative_no_warning`, `a11y_tabindex_dynamic_no_warning`.
-  Remaining: `a11y_missing_attribute` (img alt, anchor label), `a11y_autofocus` (context-sensitive), ARIA role checks, event handler A11y checks.
+  Implemented: `a11y_distracting_elements` (`<marquee>`/`<blink>`), `a11y_accesskey`, `a11y_positive_tabindex`, `a11y_autofocus` (suppressed inside `<dialog>`), `a11y_missing_attribute` (img[alt], area[alt|aria-label|aria-labelledby], iframe[title], object[title|aria-label|aria-labelledby], a[href] with id/name/aria-disabled exceptions).
+  Tests: `a11y_distracting_elements_marquee`, `a11y_distracting_elements_blink`, `a11y_accesskey_warns`, `a11y_positive_tabindex_warns`, `a11y_tabindex_zero_no_warning`, `a11y_tabindex_negative_no_warning`, `a11y_tabindex_dynamic_no_warning`, `a11y_autofocus_warns`, `a11y_autofocus_on_dialog_no_warning`, `a11y_autofocus_inside_dialog_no_warning`, `a11y_missing_attribute_img_no_alt`, `a11y_missing_attribute_img_with_alt_no_warning`, `a11y_missing_attribute_img_spread_no_warning`, `a11y_missing_attribute_area_no_alt`, `a11y_missing_attribute_area_with_aria_label_no_warning`, `a11y_missing_attribute_iframe_no_title`, `a11y_missing_attribute_iframe_with_title_no_warning`, `a11y_missing_attribute_anchor_no_href`, `a11y_missing_attribute_anchor_with_href_no_warning`, `a11y_missing_attribute_anchor_with_id_no_warning`, `a11y_missing_attribute_anchor_with_name_no_warning`, `a11y_missing_attribute_anchor_aria_disabled_no_warning`, `a11y_missing_attribute_anchor_spread_no_warning`.
+  Remaining: `html[lang]`, `input[type=image]` alt, `a11y_missing_content`, ARIA role/attribute checks, event handler A11y checks.
+  [ ] `html[lang]` — root element, needs separate treatment
+  [ ] `input[type=image]` — needs static type attribute value inspection
+  [ ] ARIA role checks (`a11y_unknown_role`, `a11y_no_abstract_role`, `a11y_role_has_required_aria_props`, etc.)
+  [ ] Event handler A11y (`a11y_click_events_have_key_events`, `a11y_mouse_events_have_key_events`)
 - `[ ]` CSS-scoped element metadata and pruning
 
 ## Reference


### PR DESCRIPTION
## Summary
Implement two new accessibility validation checks for template elements: `a11y_autofocus` to warn about autofocus usage outside of `<dialog>` elements, and `a11y_missing_attribute` to enforce required attributes on semantic HTML elements.

## Key Changes

- **Dialog nesting tracking**: Added `dialog_depth` field to `TemplateValidationVisitor` to track nesting depth of `<dialog>` elements, enabling context-aware validation of the `autofocus` attribute.

- **Autofocus validation**: Implemented `a11y_autofocus` check that warns when `autofocus` is used on elements other than `<dialog>` or its descendants. The check is suppressed inside `<dialog>` elements since autofocus is legitimate in that context.

- **Missing attribute validation**: Implemented `a11y_missing_attribute` check for five element types:
  - `<img>`: requires `alt` attribute
  - `<area>`: requires one of `alt`, `aria-label`, or `aria-labelledby`
  - `<iframe>`: requires `title` attribute
  - `<object>`: requires one of `title`, `aria-label`, or `aria-labelledby`
  - `<a>`: requires `href` or `xlink:href`, with exceptions for named anchors (`id`/`name`) and disabled links (`aria-disabled="true"`)

- **Spread attribute handling**: Added detection of spread attributes (`{...obj}`) to suppress `a11y_missing_attribute` warnings, since spreads may provide the missing attributes at runtime.

- **Helper functions**: Added utility functions (`el_has_attr`, `el_static_attr_value`, `warn_missing_attr`, `check_a11y_missing_attribute`) to support attribute checking logic.

## Implementation Details

- Spread attributes are detected and tracked during element visitation to conditionally skip missing attribute checks.
- The `leave_element` method now decrements `dialog_depth` when exiting a `<dialog>` element.
- Error messages for missing attributes use grammatically correct articles ("a" vs "an") and format multiple required attributes as readable alternatives.
- Comprehensive test coverage added for all new checks, including edge cases like named anchors and aria-disabled links.

https://claude.ai/code/session_01XSagwQqH18uy7hRhkghmPC