### PR TITLE
Optimize attribute lookups with O(1) indexed access

### DIFF
--- a/crates/svelte_analyze/src/passes/bind_semantics.rs
+++ b/crates/svelte_analyze/src/passes/bind_semantics.rs
@@ -1,7 +1,6 @@
 use svelte_ast::{
     Attribute, BindDirective, ClassDirective, Element, StyleDirective, StyleDirectiveValue,
 };
-
 use crate::scope::SymbolId;
 use crate::types::data::AnalysisData;
 use crate::walker::{ParentKind, TemplateVisitor, VisitContext};
@@ -109,21 +108,16 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
     }
 
     fn leave_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
+        let idx = ctx.data.element_flags.attr_indices.get(el.id);
         // Detect bind:group → mark element and find value attribute
-        let bind_group = el.attributes.iter().find_map(|a| {
-            if let Attribute::BindDirective(bd) = a {
-                if bd.name == "group" {
-                    return Some(bd);
-                }
-            }
-            None
-        });
+        let bind_group = idx
+            .and_then(|i| i.first(&el.attributes, "group"))
+            .and_then(|a| if let Attribute::BindDirective(bd) = a { Some(bd) } else { None });
         if let Some(bg) = bind_group {
             ctx.data.bind_semantics.has_bind_group.insert(el.id);
-            if let Some(val_attr) = el
-                .attributes
-                .iter()
-                .find(|a| matches!(a, Attribute::ExpressionAttribute(ea) if ea.name == "value"))
+            if let Some(val_attr) = idx
+                .and_then(|i| i.first(&el.attributes, "value"))
+                .filter(|a| matches!(a, Attribute::ExpressionAttribute(_)))
             {
                 ctx.data
                     .bind_semantics
@@ -175,22 +169,28 @@ impl<'s> TemplateVisitor for BindSemanticsVisitor<'s> {
         }
 
         // Detect contenteditable + bind:innerHTML|innerText|textContent
-        let has_contenteditable = el.attributes.iter().any(|a| match a {
-            Attribute::BooleanAttribute(ba) => ba.name == "contenteditable",
-            Attribute::StringAttribute(sa) if sa.name == "contenteditable" => {
-                let val =
-                    self.source[sa.value_span.start as usize..sa.value_span.end as usize].trim();
-                val == "true"
-            }
-            _ => false,
-        });
+        let has_contenteditable = idx
+            .and_then(|i| i.first(&el.attributes, "contenteditable"))
+            .is_some_and(|a| match a {
+                Attribute::BooleanAttribute(_) => true,
+                Attribute::StringAttribute(sa) => {
+                    let val = self.source
+                        [sa.value_span.start as usize..sa.value_span.end as usize]
+                        .trim();
+                    val == "true"
+                }
+                _ => false,
+            });
         if !has_contenteditable {
             return;
         }
 
-        let has_content_bind = el.attributes.iter().any(|a| {
-            matches!(a, Attribute::BindDirective(bd) if matches!(bd.name.as_str(), "innerHTML" | "innerText" | "textContent"))
-        });
+        let has_content_bind = ["innerHTML", "innerText", "textContent"]
+            .iter()
+            .any(|name| {
+                idx.and_then(|i| i.first(&el.attributes, name))
+                    .is_some_and(|a| matches!(a, Attribute::BindDirective(_)))
+            });
         if has_content_bind {
             ctx.data.element_flags.bound_contenteditable.insert(el.id);
         }

--- a/crates/svelte_analyze/src/passes/element_flags.rs
+++ b/crates/svelte_analyze/src/passes/element_flags.rs
@@ -7,8 +7,7 @@ use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
 
 use crate::types::data::{
-    AttrIndex, ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind,
-    EventHandlerMode,
+    ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, EventHandlerMode,
 };
 use crate::walker::{TemplateVisitor, VisitContext};
 
@@ -28,11 +27,6 @@ impl<'src> ElementFlagsVisitor<'src> {
 
 impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
     fn visit_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
-        ctx.data
-            .element_flags
-            .attr_indices
-            .insert(el.id, AttrIndex::build(&el.attributes));
-
         // Warn for non-void, non-SVG, non-MathML elements written as self-closing.
         if el.self_closing && !is_void(&el.name) && !is_svg(&el.name) && !is_mathml(&el.name) {
             ctx.warnings_mut().push(Diagnostic::warning(
@@ -43,10 +37,10 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
             ));
         }
 
-        let has_value_attr = el.attributes.iter().any(|a| {
-            matches!(a, Attribute::StringAttribute(sa) if sa.name == "value")
-                || matches!(a, Attribute::ExpressionAttribute(ea) if ea.name == "value")
-        });
+        let has_value_attr = {
+            let idx = ctx.data.element_flags.attr_index(el.id);
+            idx.is_some_and(|i| i.has("value"))
+        };
 
         // <textarea>: detect expression children
         if el.name == "textarea" && !el.fragment.nodes.is_empty() {
@@ -169,11 +163,6 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
     }
 
     fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut VisitContext<'_>) {
-        ctx.data
-            .element_flags
-            .attr_indices
-            .insert(cn.id, AttrIndex::build(&cn.attributes));
-
         let data = &mut *ctx.data;
         // Dotted component names are dynamic (e.g., registry.Widget → $.component(...))
         if cn.name.contains('.') {

--- a/crates/svelte_analyze/src/passes/element_flags.rs
+++ b/crates/svelte_analyze/src/passes/element_flags.rs
@@ -7,7 +7,8 @@ use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
 
 use crate::types::data::{
-    ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, EventHandlerMode,
+    AttrIndex, ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind,
+    EventHandlerMode,
 };
 use crate::walker::{TemplateVisitor, VisitContext};
 
@@ -27,6 +28,11 @@ impl<'src> ElementFlagsVisitor<'src> {
 
 impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
     fn visit_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
+
         // Warn for non-void, non-SVG, non-MathML elements written as self-closing.
         if el.self_closing && !is_void(&el.name) && !is_svg(&el.name) && !is_mathml(&el.name) {
             ctx.warnings_mut().push(Diagnostic::warning(
@@ -163,6 +169,11 @@ impl<'src> TemplateVisitor for ElementFlagsVisitor<'src> {
     }
 
     fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(cn.id, AttrIndex::build(&cn.attributes));
+
         let data = &mut *ctx.data;
         // Dotted component names are dynamic (e.g., registry.Widget → $.component(...))
         if cn.name.contains('.') {

--- a/crates/svelte_analyze/src/passes/template_side_tables.rs
+++ b/crates/svelte_analyze/src/passes/template_side_tables.rs
@@ -16,10 +16,10 @@ use oxc_ast::ast::{
     VariableDeclarator,
 };
 use oxc_ast_visit::Visit;
-use svelte_ast::{Attribute, ConstTag, EachBlock, Node, SnippetBlock};
+use svelte_ast::{Attribute, ComponentNode, ConstTag, EachBlock, Element, Node, SnippetBlock};
 
 use crate::scope::ComponentScoping;
-use crate::types::data::{FragmentKey, StmtHandle};
+use crate::types::data::{AttrIndex, FragmentKey, StmtHandle};
 use crate::utils::binding_pattern::collect_binding_names;
 use crate::walker::{TemplateVisitor, VisitContext};
 
@@ -237,6 +237,34 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
                     ctx.data.const_tags.names.insert(tag.id, name_strings);
                 }
             }
+        }
+    }
+
+    fn visit_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
+        if el
+            .attributes
+            .iter()
+            .any(|a| matches!(a, Attribute::SpreadAttribute(_)))
+        {
+            ctx.data.element_flags.has_spread.insert(el.id);
+        }
+    }
+
+    fn visit_component_node(&mut self, cn: &ComponentNode, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(cn.id, AttrIndex::build(&cn.attributes));
+        if cn
+            .attributes
+            .iter()
+            .any(|a| matches!(a, Attribute::SpreadAttribute(_)))
+        {
+            ctx.data.element_flags.has_spread.insert(cn.id);
         }
     }
 }

--- a/crates/svelte_analyze/src/passes/template_side_tables.rs
+++ b/crates/svelte_analyze/src/passes/template_side_tables.rs
@@ -16,7 +16,10 @@ use oxc_ast::ast::{
     VariableDeclarator,
 };
 use oxc_ast_visit::Visit;
-use svelte_ast::{Attribute, ComponentNode, ConstTag, EachBlock, Element, Node, SnippetBlock};
+use svelte_ast::{
+    Attribute, ComponentNode, ConstTag, EachBlock, Element, Node, SnippetBlock, SvelteBody,
+    SvelteDocument, SvelteElement, SvelteBoundary, SvelteWindow,
+};
 
 use crate::scope::ComponentScoping;
 use crate::types::data::{AttrIndex, FragmentKey, StmtHandle};
@@ -266,6 +269,41 @@ impl TemplateVisitor for TemplateSideTablesVisitor<'_> {
         {
             ctx.data.element_flags.has_spread.insert(cn.id);
         }
+    }
+
+    fn visit_svelte_element(&mut self, el: &SvelteElement, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
+    }
+
+    fn visit_svelte_window(&mut self, el: &SvelteWindow, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
+    }
+
+    fn visit_svelte_document(&mut self, el: &SvelteDocument, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
+    }
+
+    fn visit_svelte_body(&mut self, el: &SvelteBody, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
+    }
+
+    fn visit_svelte_boundary(&mut self, el: &SvelteBoundary, ctx: &mut VisitContext<'_>) {
+        ctx.data
+            .element_flags
+            .attr_indices
+            .insert(el.id, AttrIndex::build(&el.attributes));
     }
 }
 

--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -13,8 +13,7 @@ use oxc_span::GetSpan;
 use svelte_ast::{
     is_svg, AnimateDirective, Attribute, AwaitBlock, BindDirective, ComponentNode, ConcatPart,
     ConstTag, DebugTag, EachBlock, Element, ExpressionAttribute, ExpressionTag, Fragment, IfBlock,
-    KeyBlock, Node, NodeId, OnDirectiveLegacy, SnippetBlock, SvelteBody, SvelteDocument,
-    SvelteElement, SvelteWindow, Text,
+    KeyBlock, Node, NodeId, OnDirectiveLegacy, SnippetBlock, SvelteElement, Text,
 };
 use svelte_diagnostics::codes::fuzzymatch;
 use svelte_diagnostics::{Diagnostic, DiagnosticKind};
@@ -39,6 +38,7 @@ const EVENT_MODIFIERS: &[&str] = &[
 ];
 
 struct BindParentInfo {
+    id: svelte_ast::NodeId,
     name: String,
     attrs: Vec<Attribute>,
 }
@@ -588,24 +588,29 @@ fn current_bind_parent(ctx: &VisitContext<'_>) -> Option<BindParentInfo> {
     let parent = ctx.parent()?;
     match ctx.store.get(parent.id) {
         Node::Element(el) => Some(BindParentInfo {
+            id: el.id,
             name: el.name.clone(),
             attrs: el.attributes.clone(),
         }),
         Node::SvelteElement(el) => Some(BindParentInfo {
+            id: el.id,
             name: "svelte:element".to_string(),
             attrs: el.attributes.clone(),
         }),
-        Node::SvelteWindow(SvelteWindow { attributes, .. }) => Some(BindParentInfo {
+        Node::SvelteWindow(el) => Some(BindParentInfo {
+            id: el.id,
             name: "svelte:window".to_string(),
-            attrs: attributes.clone(),
+            attrs: el.attributes.clone(),
         }),
-        Node::SvelteDocument(SvelteDocument { attributes, .. }) => Some(BindParentInfo {
+        Node::SvelteDocument(el) => Some(BindParentInfo {
+            id: el.id,
             name: "svelte:document".to_string(),
-            attrs: attributes.clone(),
+            attrs: el.attributes.clone(),
         }),
-        Node::SvelteBody(SvelteBody { attributes, .. }) => Some(BindParentInfo {
+        Node::SvelteBody(el) => Some(BindParentInfo {
+            id: el.id,
             name: "svelte:body".to_string(),
-            attrs: attributes.clone(),
+            attrs: el.attributes.clone(),
         }),
         _ => None,
     }
@@ -716,15 +721,20 @@ fn validate_bind_parent_specifics(
     ctx: &mut VisitContext<'_>,
 ) {
     if parent.name == "input" && dir.name != "this" {
-        validate_input_bindings(dir, &parent.attrs, ctx);
+        validate_input_bindings(dir, parent, ctx);
     }
 
     if parent.name == "select" && dir.name != "this" {
-        if let Some(multiple) = find_named_attr(&parent.attrs, "multiple") {
-            if !attr_is_text(multiple) && !matches!(multiple, Attribute::BooleanAttribute(_)) {
+        let multiple = ctx
+            .data
+            .element_flags
+            .attr_index(parent.id)
+            .and_then(|i| i.first(&parent.attrs, "multiple"));
+        if let Some(a) = multiple {
+            if !attr_is_text(a) && !matches!(a, Attribute::BooleanAttribute(_)) {
                 ctx.warnings_mut().push(Diagnostic::error(
                     DiagnosticKind::AttributeInvalidMultiple,
-                    attr_value_span(multiple),
+                    attr_value_span(a),
                 ));
                 return;
             }
@@ -745,7 +755,12 @@ fn validate_bind_parent_specifics(
     }
 
     if matches!(dir.name.as_str(), "innerHTML" | "innerText" | "textContent") {
-        match find_named_attr(&parent.attrs, "contenteditable") {
+        let contenteditable = ctx
+            .data
+            .element_flags
+            .attr_index(parent.id)
+            .and_then(|i| i.first(&parent.attrs, "contenteditable"));
+        match contenteditable {
             None => emit_bind_error(
                 ctx,
                 dir.expression_span,
@@ -764,8 +779,17 @@ fn validate_bind_parent_specifics(
     }
 }
 
-fn validate_input_bindings(dir: &BindDirective, attrs: &[Attribute], ctx: &mut VisitContext<'_>) {
-    let Some(type_attr) = find_named_attr(attrs, "type") else {
+fn validate_input_bindings(
+    dir: &BindDirective,
+    parent: &BindParentInfo,
+    ctx: &mut VisitContext<'_>,
+) {
+    let Some(type_attr) = ctx
+        .data
+        .element_flags
+        .attr_index(parent.id)
+        .and_then(|i| i.first(&parent.attrs, "type"))
+    else {
         return;
     };
 
@@ -947,28 +971,6 @@ fn bind_targets_each_context(sym_id: crate::scope::SymbolId, ctx: &VisitContext<
         .any(|parent| ctx.data.each_body_scope(parent.id, ctx.scope) == sym_scope)
 }
 
-fn find_named_attr<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a Attribute> {
-    attrs.iter().find(|attr| named_attr_matches(attr, name))
-}
-
-fn named_attr_matches(attr: &Attribute, name: &str) -> bool {
-    match attr {
-        Attribute::StringAttribute(attr) => attr.name == name,
-        Attribute::ExpressionAttribute(attr) => attr.name == name,
-        Attribute::BooleanAttribute(attr) => attr.name == name,
-        Attribute::ConcatenationAttribute(attr) => attr.name == name,
-        Attribute::BindDirective(attr) => attr.name == name,
-        Attribute::Shorthand(_)
-        | Attribute::SpreadAttribute(_)
-        | Attribute::ClassDirective(_)
-        | Attribute::StyleDirective(_)
-        | Attribute::UseDirective(_)
-        | Attribute::OnDirectiveLegacy(_)
-        | Attribute::TransitionDirective(_)
-        | Attribute::AnimateDirective(_)
-        | Attribute::AttachTag(_) => false,
-    }
-}
 
 fn attr_is_text(attr: &Attribute) -> bool {
     matches!(attr, Attribute::StringAttribute(_))
@@ -1520,17 +1522,6 @@ fn el_has_attr(idx: Option<&crate::types::data::AttrIndex>, name: &str) -> bool 
     idx.is_some_and(|i| i.has(name))
 }
 
-/// Returns the static string value of a `StringAttribute` named `name`, if present.
-fn el_static_attr_value<'a>(el: &Element, name: &str, source: &'a str) -> Option<&'a str> {
-    el.attributes.iter().find_map(|a| {
-        if let Attribute::StringAttribute(sa) = a {
-            if sa.name == name {
-                return Some(sa.value_span.source_text(source));
-            }
-        }
-        None
-    })
-}
 
 fn warn_missing_attr(el: &Element, required: &[&str]) -> Diagnostic {
     let first = required[0];
@@ -1592,7 +1583,16 @@ fn check_a11y_missing_attribute(
             if el_has_attr(idx, "id") || el_has_attr(idx, "name") {
                 return None;
             }
-            if el_static_attr_value(el, "aria-disabled", source) == Some("true") {
+            if idx
+                .and_then(|i| i.first(&el.attributes, "aria-disabled"))
+                .is_some_and(|a| {
+                    if let Attribute::StringAttribute(sa) = a {
+                        sa.value_span.source_text(source) == "true"
+                    } else {
+                        false
+                    }
+                })
+            {
                 return None;
             }
             Some(warn_missing_attr(el, &["href"]))

--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -25,6 +25,7 @@ use crate::scope::ComponentScoping;
 use crate::types::data::ExpressionKind;
 use crate::walker::{ParentKind, ParentRef, TemplateVisitor, VisitContext};
 
+
 const EVENT_MODIFIERS: &[&str] = &[
     "preventDefault",
     "stopPropagation",
@@ -154,17 +155,39 @@ impl TemplateVisitor for TemplateValidationVisitor {
             self.dialog_depth += 1;
         }
 
+        // Copy source before borrowing ctx.data so the &str is available after
+        // the idx borrow is released (needed by check_a11y_missing_attribute).
+        let source = ctx.source;
+
+        // Pre-compute all attribute-based flags and refs inside a block so that
+        // the ctx.data borrow through `idx` is released before ctx.warnings_mut().
+        // &Attribute results borrow `el`, not `ctx`, so they outlive the block.
+        let (
+            has_slot,
+            has_spread,
+            accesskey_attr,
+            tabindex_attr,
+            has_autofocus,
+            missing_attr_diag,
+        ) = {
+            let idx = ctx.data.element_flags.attr_index(el.id);
+            (
+                idx.is_some_and(|i| i.has("slot")),
+                ctx.data.element_flags.has_spread(el.id),
+                idx.and_then(|i| i.first(&el.attributes, "accesskey")),
+                idx.and_then(|i| i.first(&el.attributes, "tabindex")),
+                idx.is_some_and(|i| i.has("autofocus")),
+                if !ctx.data.element_flags.has_spread(el.id) {
+                    check_a11y_missing_attribute(el, idx, source)
+                } else {
+                    None
+                },
+            )
+        };
+
         // slot_attribute_invalid_placement: a slot="..." attribute on a regular element
         // is only valid when the element is a direct child of a component.
-        let has_slot_attr = el
-            .attributes
-            .iter()
-            .any(|a| matches!(a, Attribute::StringAttribute(sa) if sa.name == "slot"));
-        if has_slot_attr
-            && !ctx
-                .parent()
-                .is_some_and(|p| p.kind == ParentKind::ComponentNode)
-        {
+        if has_slot && !ctx.parent().is_some_and(|p| p.kind == ParentKind::ComponentNode) {
             ctx.warnings_mut().push(Diagnostic::error(
                 DiagnosticKind::SlotAttributeInvalidPlacement,
                 el.span,
@@ -179,59 +202,35 @@ impl TemplateVisitor for TemplateValidationVisitor {
             ));
         }
 
-        // Attribute-level A11y checks. Also detect spread for missing-attribute suppression.
-        let mut has_spread = false;
-        for attr in &el.attributes {
-            if matches!(attr, Attribute::SpreadAttribute(_)) {
-                has_spread = true;
-                continue;
-            }
-            let attr_name = match attr {
-                Attribute::StringAttribute(a) => a.name.as_str(),
-                Attribute::BooleanAttribute(a) => a.name.as_str(),
-                Attribute::ExpressionAttribute(a) => a.name.as_str(),
-                Attribute::ConcatenationAttribute(a) => a.name.as_str(),
-                _ => continue,
-            };
-            match attr_name {
-                // a11y_accesskey: using accesskey harms keyboard-only navigation.
-                "accesskey" => {
-                    ctx.warnings_mut().push(Diagnostic::warning(
-                        DiagnosticKind::A11yAccesskey,
-                        attr_value_span(attr),
-                    ));
-                }
-                // a11y_positive_tabindex: tabindex > 0 disrupts natural tab order.
-                "tabindex" => {
-                    if let Some(text) = static_text_attr_value(attr, ctx.source) {
-                        if let Ok(n) = text.trim().parse::<i64>() {
-                            if n > 0 {
-                                ctx.warnings_mut().push(Diagnostic::warning(
-                                    DiagnosticKind::A11yPositiveTabindex,
-                                    attr_value_span(attr),
-                                ));
-                            }
-                        }
-                    }
-                }
-                // a11y_autofocus: autofocus is only legitimate on <dialog> and its descendants.
-                "autofocus" => {
-                    if el.name != "dialog" && self.dialog_depth == 0 {
+        // Attribute-level A11y checks.
+        if let Some(attr) = accesskey_attr {
+            ctx.warnings_mut().push(Diagnostic::warning(
+                DiagnosticKind::A11yAccesskey,
+                attr_value_span(attr),
+            ));
+        }
+        if let Some(attr) = tabindex_attr {
+            if let Some(text) = static_text_attr_value(attr, source) {
+                if let Ok(n) = text.trim().parse::<i64>() {
+                    if n > 0 {
                         ctx.warnings_mut().push(Diagnostic::warning(
-                            DiagnosticKind::A11yAutofocus,
-                            el.span,
+                            DiagnosticKind::A11yPositiveTabindex,
+                            attr_value_span(attr),
                         ));
                     }
                 }
-                _ => {}
             }
+        }
+        if has_autofocus && el.name != "dialog" && self.dialog_depth == 0 {
+            ctx.warnings_mut().push(Diagnostic::warning(DiagnosticKind::A11yAutofocus, el.span));
         }
 
         // a11y_missing_attribute: certain elements require specific attributes.
-        // Suppressed when a spread attribute is present (it may supply the missing attr).
-        if !has_spread {
-            check_a11y_missing_attribute(el, ctx);
+        if let Some(diag) = missing_attr_diag {
+            ctx.warnings_mut().push(diag);
         }
+
+        let _ = has_spread; // used only in pre-computation above
     }
 
     fn leave_element(&mut self, el: &Element, ctx: &mut VisitContext<'_>) {
@@ -1517,14 +1516,8 @@ fn contains_invalid_snippet_param_assignment(
 
 /// Returns `true` if `el` has a named attribute (string, boolean, expression, or concatenation)
 /// with the given `name`. Spread and directive attributes are not matched.
-fn el_has_attr(el: &Element, name: &str) -> bool {
-    el.attributes.iter().any(|a| match a {
-        Attribute::StringAttribute(a) => a.name == name,
-        Attribute::BooleanAttribute(a) => a.name == name,
-        Attribute::ExpressionAttribute(a) => a.name == name,
-        Attribute::ConcatenationAttribute(a) => a.name == name,
-        _ => false,
-    })
+fn el_has_attr(idx: Option<&crate::types::data::AttrIndex>, name: &str) -> bool {
+    idx.is_some_and(|i| i.has(name))
 }
 
 /// Returns the static string value of a `StringAttribute` named `name`, if present.
@@ -1539,8 +1532,7 @@ fn el_static_attr_value<'a>(el: &Element, name: &str, source: &'a str) -> Option
     })
 }
 
-/// Emit `a11y_missing_attribute` for `el` when none of `required` attrs are present.
-fn warn_missing_attr(el: &Element, required: &[&str], ctx: &mut VisitContext<'_>) {
+fn warn_missing_attr(el: &Element, required: &[&str]) -> Diagnostic {
     let first = required[0];
     // "href" and vowel-starting names take "an"; everything else takes "a".
     let article = if first == "href" || first.starts_with(['a', 'e', 'i', 'o', 'u']) {
@@ -1554,64 +1546,57 @@ fn warn_missing_attr(el: &Element, required: &[&str], ctx: &mut VisitContext<'_>
         let (last, rest) = required.split_last().unwrap();
         format!("{} or {last}", rest.join(", "))
     };
-    ctx.warnings_mut().push(Diagnostic::warning(
+    Diagnostic::warning(
         DiagnosticKind::A11yMissingAttribute {
             name: el.name.clone(),
             article: article.to_string(),
             sequence,
         },
         el.span,
-    ));
+    )
 }
 
 /// Check `a11y_missing_attribute` for elements that require specific attributes.
 /// Only called when no spread attribute is present on `el`.
-fn check_a11y_missing_attribute(el: &Element, ctx: &mut VisitContext<'_>) {
+/// Returns a diagnostic to emit, or `None` if the element is valid.
+fn check_a11y_missing_attribute(
+    el: &Element,
+    idx: Option<&crate::types::data::AttrIndex>,
+    source: &str,
+) -> Option<Diagnostic> {
     match el.name.as_str() {
         // img needs alt
-        "img" => {
-            if !el_has_attr(el, "alt") {
-                warn_missing_attr(el, &["alt"], ctx);
-            }
-        }
+        "img" => (!el_has_attr(idx, "alt")).then(|| warn_missing_attr(el, &["alt"])),
         // area needs alt, aria-label, or aria-labelledby
         "area" => {
-            if !el_has_attr(el, "alt")
-                && !el_has_attr(el, "aria-label")
-                && !el_has_attr(el, "aria-labelledby")
-            {
-                warn_missing_attr(el, &["alt", "aria-label", "aria-labelledby"], ctx);
-            }
+            (!el_has_attr(idx, "alt")
+                && !el_has_attr(idx, "aria-label")
+                && !el_has_attr(idx, "aria-labelledby"))
+            .then(|| warn_missing_attr(el, &["alt", "aria-label", "aria-labelledby"]))
         }
         // iframe needs title
-        "iframe" => {
-            if !el_has_attr(el, "title") {
-                warn_missing_attr(el, &["title"], ctx);
-            }
-        }
+        "iframe" => (!el_has_attr(idx, "title")).then(|| warn_missing_attr(el, &["title"])),
         // object needs title, aria-label, or aria-labelledby
         "object" => {
-            if !el_has_attr(el, "title")
-                && !el_has_attr(el, "aria-label")
-                && !el_has_attr(el, "aria-labelledby")
-            {
-                warn_missing_attr(el, &["title", "aria-label", "aria-labelledby"], ctx);
-            }
+            (!el_has_attr(idx, "title")
+                && !el_has_attr(idx, "aria-label")
+                && !el_has_attr(idx, "aria-labelledby"))
+            .then(|| warn_missing_attr(el, &["title", "aria-label", "aria-labelledby"]))
         }
         // <a> without href is only valid as a named anchor (id/name) or disabled link
         "a" => {
-            if el_has_attr(el, "href") || el_has_attr(el, "xlink:href") {
-                return;
+            if el_has_attr(idx, "href") || el_has_attr(idx, "xlink:href") {
+                return None;
             }
             // Named anchors and aria-disabled links don't require href.
-            if el_has_attr(el, "id") || el_has_attr(el, "name") {
-                return;
+            if el_has_attr(idx, "id") || el_has_attr(idx, "name") {
+                return None;
             }
-            if el_static_attr_value(el, "aria-disabled", ctx.source) == Some("true") {
-                return;
+            if el_static_attr_value(el, "aria-disabled", source) == Some("true") {
+                return None;
             }
-            warn_missing_attr(el, &["href"], ctx);
+            Some(warn_missing_attr(el, &["href"]))
         }
-        _ => {}
+        _ => None,
     }
 }

--- a/crates/svelte_analyze/src/types/data/attr_index.rs
+++ b/crates/svelte_analyze/src/types/data/attr_index.rs
@@ -1,0 +1,61 @@
+use compact_str::CompactString;
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+use svelte_ast::Attribute;
+
+/// Per-element attribute index enabling O(1) lookups by name.
+///
+/// Built once during analysis from a `Vec<Attribute>` slice; positions stored
+/// as `u16` indices into that same slice so callers pass the original `attrs`
+/// back for any operation that needs the actual value.
+///
+/// Variants with `Span`-based names (`UseDirective`, `TransitionDirective`,
+/// `AnimateDirective`) and nameless variants are not indexed.
+pub struct AttrIndex {
+    by_name: FxHashMap<CompactString, SmallVec<[u16; 1]>>,
+}
+
+impl AttrIndex {
+    pub fn build(attrs: &[Attribute]) -> Self {
+        let mut by_name: FxHashMap<CompactString, SmallVec<[u16; 1]>> = FxHashMap::default();
+        for (i, attr) in attrs.iter().enumerate() {
+            if let Some(name) = attr.name() {
+                by_name
+                    .entry(CompactString::from(name))
+                    .or_default()
+                    .push(i as u16);
+            }
+        }
+        Self { by_name }
+    }
+
+    /// O(1). Returns `true` if at least one attribute with this name is present.
+    #[inline]
+    pub fn has(&self, name: &str) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    /// O(1). Returns the first attribute with this name.
+    /// Covers the overwhelmingly common case of a single occurrence.
+    #[inline]
+    pub fn first<'a>(&self, attrs: &'a [Attribute], name: &str) -> Option<&'a Attribute> {
+        let pos = *self.by_name.get(name)?.first()?;
+        Some(&attrs[pos as usize])
+    }
+
+    /// O(1) start, O(k) iteration. Returns all attributes with this name.
+    /// Useful for repeated directives such as `class:foo` or legacy `on:click`.
+    pub fn all<'idx, 'attrs>(
+        &'idx self,
+        attrs: &'attrs [Attribute],
+        name: &str,
+    ) -> impl Iterator<Item = &'attrs Attribute> + 'idx
+    where
+        'attrs: 'idx,
+    {
+        self.by_name
+            .get(name)
+            .into_iter()
+            .flat_map(move |positions| positions.iter().map(move |&pos| &attrs[pos as usize]))
+    }
+}

--- a/crates/svelte_analyze/src/types/data/codegen_view.rs
+++ b/crates/svelte_analyze/src/types/data/codegen_view.rs
@@ -158,6 +158,9 @@ impl<'a> CodegenView<'a> {
     pub fn has_dynamic_children(&self, key: &FragmentKey) -> bool {
         self.data.fragments.has_dynamic_children(key)
     }
+    pub fn attr_index(&self, id: NodeId) -> Option<&AttrIndex> {
+        self.data.element_flags.attr_index(id)
+    }
     pub fn has_spread(&self, id: NodeId) -> bool {
         self.data.element_flags.has_spread(id)
     }

--- a/crates/svelte_analyze/src/types/data/elements.rs
+++ b/crates/svelte_analyze/src/types/data/elements.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::attr_index::AttrIndex;
 
 pub struct ClassDirectiveInfo {
     pub id: NodeId,
@@ -108,6 +109,7 @@ pub struct ElementFlags {
     pub(crate) customizable_select: NodeBitSet,
     /// `<selectedcontent>` elements — require a JS var for `$.selectedcontent(el, setter)`.
     pub(crate) is_selectedcontent: NodeBitSet,
+    pub(crate) attr_indices: NodeTable<AttrIndex>,
 }
 
 impl ElementFlags {
@@ -135,6 +137,7 @@ impl ElementFlags {
             is_dynamic_component: NodeBitSet::new(node_count),
             customizable_select: NodeBitSet::new(node_count),
             is_selectedcontent: NodeBitSet::new(node_count),
+            attr_indices: NodeTable::new(node_count),
         }
     }
 
@@ -219,5 +222,8 @@ impl ElementFlags {
     }
     pub fn is_selectedcontent(&self, id: NodeId) -> bool {
         self.is_selectedcontent.contains(&id)
+    }
+    pub fn attr_index(&self, id: NodeId) -> Option<&AttrIndex> {
+        self.attr_indices.get(id)
     }
 }

--- a/crates/svelte_analyze/src/types/data/mod.rs
+++ b/crates/svelte_analyze/src/types/data/mod.rs
@@ -12,6 +12,7 @@ pub use svelte_parser::{ExprHandle, ParserResult, StmtHandle};
 
 mod analysis;
 mod async_data;
+pub(crate) mod attr_index;
 mod codegen_view;
 mod elements;
 mod expr;
@@ -25,6 +26,7 @@ mod template_data;
 pub use analysis::AnalysisData;
 pub use async_data::{AsyncStmtMeta, BlockerData};
 pub use codegen_view::CodegenView;
+pub use attr_index::AttrIndex;
 pub use elements::{
     ClassDirectiveInfo, ComponentBindMode, ComponentPropInfo, ComponentPropKind, ElementFlags,
     EventHandlerMode,

--- a/crates/svelte_ast/src/lib.rs
+++ b/crates/svelte_ast/src/lib.rs
@@ -701,6 +701,30 @@ impl_attr_enum! {
     AttachTag(AttachTag),
 }
 
+impl Attribute {
+    /// Returns the attribute name if it is stored as a `String` field.
+    /// Variants with `Span`-based names (`UseDirective`, `TransitionDirective`,
+    /// `AnimateDirective`) and nameless variants return `None`.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Attribute::StringAttribute(a) => Some(&a.name),
+            Attribute::ExpressionAttribute(a) => Some(&a.name),
+            Attribute::BooleanAttribute(a) => Some(&a.name),
+            Attribute::ConcatenationAttribute(a) => Some(&a.name),
+            Attribute::ClassDirective(a) => Some(&a.name),
+            Attribute::StyleDirective(a) => Some(&a.name),
+            Attribute::BindDirective(a) => Some(&a.name),
+            Attribute::OnDirectiveLegacy(a) => Some(&a.name),
+            Attribute::UseDirective(_)
+            | Attribute::TransitionDirective(_)
+            | Attribute::AnimateDirective(_)
+            | Attribute::Shorthand(_)
+            | Attribute::SpreadAttribute(_)
+            | Attribute::AttachTag(_) => None,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct StringAttribute {
     pub id: NodeId,

--- a/crates/svelte_codegen_client/src/template/svelte_element.rs
+++ b/crates/svelte_codegen_client/src/template/svelte_element.rs
@@ -44,14 +44,17 @@ pub(crate) fn gen_svelte_element<'a>(
     let has_attrs = !el_clone.attributes.is_empty();
 
     // Detect SVG namespace from static xmlns attribute
-    let is_svg_ns = el.attributes.iter().any(|attr| {
-        if let svelte_ast::Attribute::StringAttribute(sa) = attr {
-            sa.name == "xmlns"
-                && ctx.query.component.source_text(sa.value_span) == "http://www.w3.org/2000/svg"
-        } else {
-            false
-        }
-    });
+    let is_svg_ns = ctx
+        .query
+        .attr_index(el.id)
+        .and_then(|i| i.first(&el.attributes, "xmlns"))
+        .is_some_and(|attr| {
+            if let svelte_ast::Attribute::StringAttribute(sa) = attr {
+                ctx.query.component.source_text(sa.value_span) == "http://www.w3.org/2000/svg"
+            } else {
+                false
+            }
+        });
 
     // Generate $$element ident for the inner callback
     let el_name = ctx.gen_ident("$$element");


### PR DESCRIPTION
## Summary
This PR introduces an `AttrIndex` data structure to enable O(1) attribute lookups by name, replacing linear searches through attribute vectors. This optimization improves performance across template validation, bind semantics, and code generation passes.

## Key Changes

- **New `AttrIndex` structure** (`attr_index.rs`): A hash-based index built once per element during analysis, storing attribute positions as `u16` indices. Provides `has()`, `first()`, and `all()` methods for efficient lookups.

- **Template validation refactoring**: 
  - Pre-computes attribute flags (slot, spread, accesskey, tabindex, autofocus) in a single block to manage borrow lifetimes
  - Replaces linear attribute searches with indexed lookups
  - Refactors `check_a11y_missing_attribute()` to return `Option<Diagnostic>` instead of pushing directly, enabling pre-computation
  - Removes `find_named_attr()` and `named_attr_matches()` helper functions in favor of indexed access
  - Updates `BindParentInfo` to include `id` field for attribute lookups

- **Bind semantics optimization**: Uses `AttrIndex` for detecting bind:group, value attributes, and contenteditable bindings

- **Element flags optimization**: Replaces attribute iteration with indexed `has()` check for value attribute detection

- **Code generation**: Updates `svelte_element.rs` to use indexed xmlns attribute lookup

- **AST enhancement**: Adds `Attribute::name()` method to extract string-based attribute names, supporting the indexing infrastructure

- **Side tables visitor**: Builds `AttrIndex` for all element-like nodes (Element, ComponentNode, SvelteElement, SvelteWindow, SvelteDocument, SvelteBody, SvelteBoundary) during the template side tables pass

## Implementation Details

- Attributes with `Span`-based names (UseDirective, TransitionDirective, AnimateDirective) and nameless variants are not indexed
- The index stores multiple positions per name using `SmallVec<[u16; 1]>` to handle repeated directives (e.g., `class:foo`)
- Callers pass the original `attrs` slice back to the index for any operation needing actual attribute values
- Borrow management improvements in template validation allow pre-computation of multiple attribute checks before calling `ctx.warnings_mut()`

https://claude.ai/code/session_01NRw9h4UASwTgH8zTkTivmS