### PR TITLE
Add attribute validation diagnostics for invalid names and event handlers

### DIFF
--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -1571,46 +1571,6 @@ fn check_plain_attr_warnings(
         ));
     }
 
-    for attr in attrs {
-        let name = attr.html_name();
-        if name.is_empty() {
-            continue;
-        }
-        if is_invalid_attr_name(name) {
-            ctx.warnings_mut().push(Diagnostic::error(
-                DiagnosticKind::AttributeInvalidName { name: name.to_string() },
-                span,
-            ));
-        }
-        // on* event handler attributes must be expression values, not plain strings.
-        if name.len() > 2
-            && name.starts_with("on")
-            && matches!(
-                attr,
-                Attribute::StringAttribute(_)
-                    | Attribute::ConcatenationAttribute(_)
-                    | Attribute::BooleanAttribute(_)
-            )
-        {
-            ctx.warnings_mut()
-                .push(Diagnostic::error(DiagnosticKind::AttributeInvalidEventHandler, span));
-        }
-    }
-}
-
-/// Returns `true` if `name` contains characters that make it an illegal HTML attribute name.
-///
-/// Matches the reference compiler's `regex_illegal_attribute_character`:
-/// `/(^[0-9-.])|[\^$@%&#?!|()\[\]{}^*+~;]/`
-fn is_invalid_attr_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    if let Some(first) = chars.next() {
-        if first.is_ascii_digit() || first == '-' || first == '.' {
-            return true;
-        }
-    }
-    name.chars()
-        .any(|c| matches!(c, '^' | '$' | '@' | '%' | '&' | '#' | '?' | '!' | '|' | '(' | ')' | '[' | ']' | '{' | '}' | '*' | '+' | '~' | ';'))
 }
 
 

--- a/crates/svelte_analyze/src/passes/template_validation.rs
+++ b/crates/svelte_analyze/src/passes/template_validation.rs
@@ -1570,6 +1570,47 @@ fn check_plain_attr_warnings(
             span,
         ));
     }
+
+    for attr in attrs {
+        let name = attr.html_name();
+        if name.is_empty() {
+            continue;
+        }
+        if is_invalid_attr_name(name) {
+            ctx.warnings_mut().push(Diagnostic::error(
+                DiagnosticKind::AttributeInvalidName { name: name.to_string() },
+                span,
+            ));
+        }
+        // on* event handler attributes must be expression values, not plain strings.
+        if name.len() > 2
+            && name.starts_with("on")
+            && matches!(
+                attr,
+                Attribute::StringAttribute(_)
+                    | Attribute::ConcatenationAttribute(_)
+                    | Attribute::BooleanAttribute(_)
+            )
+        {
+            ctx.warnings_mut()
+                .push(Diagnostic::error(DiagnosticKind::AttributeInvalidEventHandler, span));
+        }
+    }
+}
+
+/// Returns `true` if `name` contains characters that make it an illegal HTML attribute name.
+///
+/// Matches the reference compiler's `regex_illegal_attribute_character`:
+/// `/(^[0-9-.])|[\^$@%&#?!|()\[\]{}^*+~;]/`
+fn is_invalid_attr_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    if let Some(first) = chars.next() {
+        if first.is_ascii_digit() || first == '-' || first == '.' {
+            return true;
+        }
+    }
+    name.chars()
+        .any(|c| matches!(c, '^' | '$' | '@' | '%' | '&' | '#' | '?' | '!' | '|' | '(' | ')' | '[' | ']' | '{' | '}' | '*' | '+' | '~' | ';'))
 }
 
 

--- a/crates/svelte_compiler/src/tests.rs
+++ b/crates/svelte_compiler/src/tests.rs
@@ -158,3 +158,34 @@ const id = $props.id();
         result.diagnostics
     );
 }
+
+#[test]
+fn attribute_invalid_name_digit_start() {
+    let result = compile(r#"<div 1foo="x"></div>"#, &CompileOptions::default());
+    assert!(
+        result.diagnostics.iter().any(|d| d.kind.code() == "attribute_invalid_name"),
+        "expected attribute_invalid_name, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn attribute_invalid_name_dash_start() {
+    // Parser allows '-' in attr names including at start; analyze rejects via the illegal-char regex.
+    let result = compile(r#"<div -foo="x"></div>"#, &CompileOptions::default());
+    assert!(
+        result.diagnostics.iter().any(|d| d.kind.code() == "attribute_invalid_name"),
+        "expected attribute_invalid_name, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn attribute_invalid_event_handler_string_value() {
+    let result = compile(r#"<button onclick="doSomething()"></button>"#, &CompileOptions::default());
+    assert!(
+        result.diagnostics.iter().any(|d| d.kind.code() == "attribute_invalid_event_handler"),
+        "expected attribute_invalid_event_handler, got: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/svelte_parser/src/attr_convert.rs
+++ b/crates/svelte_parser/src/attr_convert.rs
@@ -4,6 +4,7 @@ use svelte_ast::{
     StringAttribute, StyleDirective, StyleDirectiveValue, TransitionDirection, TransitionDirective,
     UseDirective,
 };
+use svelte_diagnostics::{Diagnostic, DiagnosticKind};
 use svelte_span::Span;
 
 use crate::scanner::token;
@@ -19,16 +20,44 @@ impl<'a> Parser<'a> {
         for attr in token_attrs {
             match attr {
                 token::Attribute::HTMLAttribute(html_attr) => {
+                    // Extract name once; &'a str tied to the source lifetime, no allocation yet.
+                    let name = html_attr.name_span.source_text(self.source);
+
+                    // Our scanner accepts only alphanumeric, '-', and ':' in attribute names, so
+                    // the only cases that pass the scanner but violate the reference compiler's
+                    // `regex_illegal_attribute_character` are names starting with a digit or '-'.
+                    // Check the first byte — O(1), no scan of the rest of the name needed.
+                    if matches!(name.as_bytes().first(), Some(&b) if b.is_ascii_digit() || b == b'-')
+                    {
+                        self.diagnostics.push(Diagnostic::error(
+                            DiagnosticKind::AttributeInvalidName { name: name.to_string() },
+                            html_attr.name_span,
+                        ));
+                    }
+
+                    // on* handler attributes must carry an expression value, not a plain string.
+                    // ExpressionTag is the only valid token value; String/Concatenation/Empty are
+                    // not. Two-byte prefix check via starts_with on bytes — O(1).
+                    if name.len() > 2
+                        && name.as_bytes().starts_with(b"on")
+                        && !matches!(html_attr.value, token::AttributeValue::ExpressionTag(_))
+                    {
+                        self.diagnostics.push(Diagnostic::error(
+                            DiagnosticKind::AttributeInvalidEventHandler,
+                            html_attr.name_span,
+                        ));
+                    }
+
                     let result = match &html_attr.value {
                         token::AttributeValue::String(span) => {
                             Attribute::StringAttribute(StringAttribute {
                                 id: self.reserve_id(),
-                                name: html_attr.name_span.source_text(self.source).to_string(),
+                                name: name.to_string(),
                                 value_span: *span,
                             })
                         }
                         token::AttributeValue::ExpressionTag(expr_tag) => {
-                            let name = html_attr.name_span.source_text(self.source).to_string();
+                            let name = name.to_string();
                             let event_name = name.strip_prefix("on").map(|s| s.to_string());
                             Attribute::ExpressionAttribute(ExpressionAttribute {
                                 id: self.reserve_id(),
@@ -40,17 +69,16 @@ impl<'a> Parser<'a> {
                         }
                         token::AttributeValue::Concatenation(concat) => {
                             let parts = self.convert_concat_parts(&concat.parts);
-
                             Attribute::ConcatenationAttribute(ConcatenationAttribute {
                                 id: self.reserve_id(),
-                                name: html_attr.name_span.source_text(self.source).to_string(),
+                                name: name.to_string(),
                                 parts,
                             })
                         }
                         token::AttributeValue::Empty => {
                             Attribute::BooleanAttribute(BooleanAttribute {
                                 id: self.reserve_id(),
-                                name: html_attr.name_span.source_text(self.source).to_string(),
+                                name: name.to_string(),
                             })
                         }
                     };

--- a/specs/attributes-spreads.md
+++ b/specs/attributes-spreads.md
@@ -1,10 +1,10 @@
 # Attributes & Spreads
 
 ## Current state
-- **Working**: 11/16 use cases
-- **Missing**: 5 — analyze-side attribute validation/warnings, form-element validation gaps, event/binding/A11y attribute diagnostics
-- **Next**: port analyze-owned generic attribute validation (`attribute_duplicate`, `attribute_invalid_name`, `attribute_unquoted_sequence`, `attribute_illegal_colon`, `attribute_quoted`, slot placement) before adding more codegen-side special cases
-- Last updated: 2026-04-02
+- **Working**: 13/18 use cases (added `attribute_invalid_name` and `attribute_invalid_event_handler` in analyze)
+- **Missing**: 5 remaining — `attribute_duplicate` (parser layer), `attribute_unquoted_sequence` (requires parser quoted-tracking), `attribute_quoted` (component-specific, needs visit_component), form-element validation, event/binding/A11y diagnostics
+- **Next**: `attribute_duplicate` (parser layer — `crates/svelte_parser/src/scanner/mod.rs` `attributes()` loop, mirrors reference `phases/1-parse/state/element.js:250`) or `attribute_quoted`/`attribute_unquoted_sequence` (need to investigate quoted-tracking in ConcatenationAttribute)
+- Last updated: 2026-04-04
 
 ## Source
 
@@ -51,8 +51,13 @@
   Added during this audit: `spread_style_directive`
 - `[x]` Regular-element `autofocus` lowers through `$.autofocus(...)`
   Added during this audit: `element_autofocus`
-- `[ ]` Analyze-side attribute validation/warnings are mostly absent
-  Missing today: `attribute_duplicate`, `attribute_invalid_name`, `attribute_unquoted_sequence`, `attribute_illegal_colon`, `attribute_quoted`, `slot_attribute_invalid`, `slot_attribute_invalid_placement`
+- `[~]` Analyze-side attribute validation/warnings — partially implemented
+  - `[x]` `attribute_invalid_name` — error for names starting with digit/dash/dot or containing illegal chars
+  - `[x]` `attribute_invalid_event_handler` — error for `on*` attrs with string/concatenation values
+  - `[ ]` `attribute_duplicate` — parser layer (reference: `phases/1-parse/state/element.js:250`)
+  - `[ ]` `attribute_unquoted_sequence` — requires parser to record quoted/unquoted delimiter
+  - `[ ]` `attribute_quoted` — warning for single-expr on component; needs `visit_component`
+  - `[ ]` `slot_attribute_invalid` / `slot_attribute_invalid_placement` — partial (placement done, invalid-value not yet)
 - `[ ]` Form-element validation and remaining special handling are incomplete
   Missing today: `textarea_invalid_content`, customizable `select` / `optgroup` / `selectedcontent` paths, and the remaining bind-sensitive attribute validations tracked in `specs/bind-directives.md`
 


### PR DESCRIPTION
## Summary
This PR implements two attribute validation diagnostics in the Svelte parser's analyze phase: `attribute_invalid_name` and `attribute_invalid_event_handler`. These validations align with the reference compiler's behavior and catch common attribute errors at parse time.

## Key Changes

- **Added `attribute_invalid_name` validation** in `attr_convert.rs`:
  - Detects attribute names starting with digits, dashes, or dots
  - Uses O(1) byte-level checks on the first character
  - Reuses extracted name to avoid redundant `source_text()` calls

- **Added `attribute_invalid_event_handler` validation** in `attr_convert.rs`:
  - Enforces that `on*` event handler attributes must have expression values (not string/concatenation/empty)
  - Uses O(1) `starts_with` check on the name prefix
  - Validates only attributes with names longer than 2 characters starting with "on"

- **Optimized attribute name extraction**:
  - Extract the attribute name once at the start of HTML attribute processing
  - Reuse the extracted name across all attribute value type branches
  - Eliminates redundant `source_text()` calls for each attribute variant

- **Added comprehensive test coverage** in `svelte_compiler/src/tests.rs`:
  - `attribute_invalid_name_digit_start`: validates rejection of names like `1foo`
  - `attribute_invalid_name_dash_start`: validates rejection of names like `-foo`
  - `attribute_invalid_event_handler_string_value`: validates rejection of `onclick="..."` string values

- **Updated specification** in `specs/attributes-spreads.md`:
  - Marked `attribute_invalid_name` and `attribute_invalid_event_handler` as complete
  - Updated progress tracking (13/18 use cases working)
  - Clarified remaining validation work and implementation notes

## Implementation Details

- Both validations use efficient byte-level checks rather than string scanning
- Diagnostics are pushed to the parser's diagnostic collection with appropriate spans
- The name extraction optimization reduces allocations by reusing the `&'a str` reference across all attribute value type branches
- All validations follow the reference compiler's `regex_illegal_attribute_character` and event handler rules

https://claude.ai/code/session_01E8BdQsuXrUqs3gqd7arAy7