### PR TITLE
Update Element spec: document ConcatenationAttribute and constant folding bugs

### DIFF
--- a/specs/element.md
+++ b/specs/element.md
@@ -1,10 +1,10 @@
 # Element
 
 ## Current state
-- **Working**: 13/16 use cases
+- **Working**: 13/18 use cases
 - **Partial**: template validation — `slot_attribute_invalid_placement` added; `node_invalid_placement` and `component_name_lowercase` skipped (require HTML content model table and symbol ref-count access respectively). A11y: 5 checks implemented (`a11y_distracting_elements`, `a11y_accesskey`, `a11y_positive_tabindex`, `a11y_autofocus`, `a11y_missing_attribute` for img/area/iframe/object/a); remaining (ARIA roles, event handler A11y, html[lang], input type=image) deferred.
-- **Missing**: 3 — namespace edge cases, legacy slots, CSS-scoped metadata
-- **Next**: ARIA role/attribute checks or remaining A11y (html[lang], missing_content, event handler pair checks)
+- **Missing**: 5 — ConcatenationAttribute+class bug, literal constant folding, namespace edge cases, legacy slots, CSS-scoped metadata
+- **Next**: Fix `ConcatenationAttribute` for `class` → `$.set_class` (bounded local bug in element_flags.rs + attributes.rs)
 - Last updated: 2026-04-04
 
 ## Source
@@ -42,6 +42,10 @@
   Existing tests: `single_element`, `nested_elements`, `elements_childs`, `mixed_html_elements`
 - `[x]` Static and simple dynamic attributes compile on regular elements
   Existing tests: `element_attributes`, `spread_attribute`
+- `[ ]` `ConcatenationAttribute` for `class` (e.g. `class="static {expr}"`) compiles via `$.set_class`, not `$.set_attribute`
+  Bug: `class_attr_id` in `element_flags.rs` only registers `ExpressionAttribute`, so the ConcatenationAttribute path falls through to `$.set_attribute`
+- `[ ]` Constant folding for all-literal `ConcatenationAttribute` parts (e.g. `class="1231 {1231}"` → `"1231 1231"`, not a template literal)
+  Reference compiler evaluates constant numeric/string literal dynamic parts at compile time and collapses them into a plain string
 - `[x]` Root namespace options and basic inline SVG/MathML paths compile
   Existing tests: `namespace_svg`, `namespace_mathml`, `svg_inner_template_from_svg`, `html_tag_svg`
 - `[x]` Non-void self-closing tags lower to explicit open/close HTML


### PR DESCRIPTION
## Summary
Updated the Element specification document to reflect current implementation status and document two known bugs that need to be fixed.

## Changes Made
- Updated working use case count from 13/16 to 13/18
- Expanded "Missing" section from 3 to 5 items, adding:
  - `ConcatenationAttribute` + `class` attribute bug
  - Literal constant folding for concatenation attributes
- Added two new unchecked items to the checklist documenting these bugs:
  - `ConcatenationAttribute` for `class` attributes (e.g., `class="static {expr}"`) incorrectly compiles via `$.set_attribute` instead of `$.set_class` due to `class_attr_id` in `element_flags.rs` only registering `ExpressionAttribute` cases
  - Constant folding for all-literal `ConcatenationAttribute` parts (e.g., `class="1231 {1231}"` should fold to `"1231 1231"` as a plain string, not a template literal)
- Updated "Next" priority to focus on fixing the `ConcatenationAttribute` for `class` bug

## Notable Details
These are implementation bugs in the compiler where:
1. The `class_attr_id` registration logic has a bounded local bug that causes concatenation attributes with class to fall through to the generic `$.set_attribute` path instead of the optimized `$.set_class` path
2. The compiler doesn't perform constant folding on dynamic parts of concatenation attributes that are literal values, unlike the reference compiler

https://claude.ai/code/session_01XZxQphzg5qQxZj2pLM3LGu