### PR TITLE
fix: enable getrandom wasm_js backend for wasm32 target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1992,6 +1994,7 @@ dependencies = [
 name = "wasm_compiler"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "lightningcss",
  "oxc_allocator",
  "oxc_codegen",

--- a/crates/wasm_compiler/Cargo.toml
+++ b/crates/wasm_compiler/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 doctest = false
 crate-type = ["cdylib", "rlib"]
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
 [dependencies]
 svelte_compiler = { workspace = true }
 lightningcss = { version = "1.0.0-alpha.71", features = ["visitor"] }


### PR DESCRIPTION
getrandom 0.3.x requires explicit wasm backend configuration for
wasm32-unknown-unknown. Added .cargo/config.toml with the required
rustflag and getrandom wasm_js feature dependency in wasm_compiler.

https://claude.ai/code/session_01Fs3cAqoe2JKCkN6M4pqTmW