### PR TITLE
Migrate CSS handling from lightningcss to svelte_css

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,20 +31,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base64-simd"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
-dependencies = [
- "simd-abstraction",
-]
-
-[[package]]
-name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
- "outref 0.5.2",
+ "outref",
  "vsimd",
 ]
 
@@ -91,18 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "bpaf"
 version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,34 +68,6 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -237,35 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-str"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
-dependencies = [
- "const-str-proc-macro",
-]
-
-[[package]]
-name = "const-str-proc-macro"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,66 +221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "cssparser"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-color"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
-dependencies = [
- "cssparser",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "data-url"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
-dependencies = [
- "matches",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,21 +231,6 @@ name = "dragonbox_ecma"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
-
-[[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
 
 [[package]]
 name = "either"
@@ -428,12 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,7 +264,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -493,17 +310,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -534,21 +340,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -563,18 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
+ "hashbrown",
 ]
 
 [[package]]
@@ -621,65 +401,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "lightningcss"
-version = "1.0.0-alpha.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6314c2f0590ac93c86099b98bb7ba8abcf759bfd89604ffca906472bb54937"
-dependencies = [
- "ahash 0.8.12",
- "bitflags",
- "const-str",
- "cssparser",
- "cssparser-color",
- "dashmap",
- "data-encoding",
- "getrandom 0.3.4",
- "indexmap",
- "itertools 0.10.5",
- "lazy_static",
- "lightningcss-derive",
- "parcel_selectors",
- "parcel_sourcemap",
- "pastey",
- "pathdiff",
- "rayon",
- "serde",
- "serde-content",
- "smallvec",
-]
-
-[[package]]
-name = "lightningcss-derive"
-version = "1.0.0-alpha.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -735,12 +460,6 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "outref"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
-
-[[package]]
-name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
@@ -774,7 +493,7 @@ checksum = "d4faecb54d0971f948fbc1918df69b26007e6f279a204793669542e1e8b75eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -784,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b44277218c002c09167474648a478d3d29a29095ef8950ec9f1fac016c62d7"
 dependencies = [
  "allocator-api2",
- "hashbrown 0.16.1",
+ "hashbrown",
  "oxc_data_structures",
  "oxc_estree",
  "rustc-hash",
@@ -814,10 +533,10 @@ version = "0.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e65a38ae589e284dd45a85008024f04aa680e9ddf1321c163cf7f187c805e91"
 dependencies = [
- "phf 0.13.1",
+ "phf",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -947,7 +666,7 @@ dependencies = [
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
- "phf 0.13.1",
+ "phf",
  "rustc-hash",
  "unicode-id-start",
 ]
@@ -958,7 +677,7 @@ version = "0.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "208725f572872b1d53d3d734f959eada9f3b93ca9f64381a625d4e55ec6dea19"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
@@ -980,7 +699,7 @@ version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f89482522f3cd820817d48ee4ade5b10822060d6e5e4d419f05f6d8bd29d70"
 dependencies = [
- "base64-simd 0.8.0",
+ "base64-simd",
  "json-escape-simd",
  "rustc-hash",
  "serde",
@@ -1009,7 +728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e65cbfb06ecbae07e0da931815b6b03ade886d016302c400bda7dc0a2f600d3"
 dependencies = [
  "compact_str",
- "hashbrown 0.16.1",
+ "hashbrown",
  "oxc_allocator",
  "oxc_estree",
  "serde",
@@ -1030,7 +749,7 @@ dependencies = [
  "oxc_estree",
  "oxc_index 4.1.0",
  "oxc_span",
- "phf 0.13.1",
+ "phf",
  "serde",
  "unicode-id-start",
 ]
@@ -1055,61 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parcel_selectors"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
-dependencies = [
- "bitflags",
- "cssparser",
- "log",
- "phf 0.11.3",
- "phf_codegen",
- "precomputed-hash",
- "rustc-hash",
- "smallvec",
-]
-
-[[package]]
-name = "parcel_sourcemap"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485b74d7218068b2b7c0e3ff12fbc61ae11d57cb5d8224f525bd304c6be05bbb"
-dependencies = [
- "base64-simd 0.7.0",
- "data-url",
- "rkyv",
- "serde",
- "serde_json",
- "vlq",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,43 +781,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand",
 ]
 
 [[package]]
@@ -1163,20 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "phf_shared",
 ]
 
 [[package]]
@@ -1185,20 +806,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "syn",
 ]
 
 [[package]]
@@ -1215,12 +827,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
@@ -1251,26 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,27 +870,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -1324,15 +889,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1371,44 +927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rstest"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,7 +952,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.96",
+ "syn",
  "unicode-ident",
 ]
 
@@ -1475,18 +993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,15 +1018,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-content"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1551,7 +1048,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -1565,21 +1062,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "simd-abstraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
-dependencies = [
- "outref 0.1.0",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -1619,7 +1101,6 @@ name = "svelte_analyze"
 version = "0.1.0"
 dependencies = [
  "compact_str",
- "lightningcss",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
@@ -1631,6 +1112,7 @@ dependencies = [
  "smallvec",
  "svelte_ast",
  "svelte_component_semantics",
+ "svelte_css",
  "svelte_diagnostics",
  "svelte_parser",
  "svelte_span",
@@ -1720,7 +1202,6 @@ name = "svelte_parser"
 version = "0.1.0"
 dependencies = [
  "compact_str",
- "lightningcss",
  "oxc_allocator",
  "oxc_ast",
  "oxc_estree",
@@ -1731,6 +1212,7 @@ dependencies = [
  "pretty_assertions",
  "rustc-hash",
  "svelte_ast",
+ "svelte_css",
  "svelte_diagnostics",
  "svelte_span",
 ]
@@ -1762,18 +1244,9 @@ dependencies = [
 name = "svelte_transform_css"
 version = "0.1.0"
 dependencies = [
- "lightningcss",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "compact_str",
+ "svelte_css",
+ "svelte_span",
 ]
 
 [[package]]
@@ -1786,12 +1259,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
@@ -1821,23 +1288,8 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
@@ -1900,28 +1352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "uuid"
-version = "1.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vlq"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
-
-[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,12 +1366,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1974,7 +1398,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1996,7 +1420,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2014,8 +1438,7 @@ dependencies = [
 name = "wasm_compiler"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.3.4",
- "lightningcss",
+ "getrandom",
  "oxc_allocator",
  "oxc_codegen",
  "oxc_parser",
@@ -2023,6 +1446,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "svelte_compiler",
+ "svelte_css",
  "svelte_diagnostics",
  "wasm-bindgen",
 ]
@@ -2035,12 +1459,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -2131,36 +1549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]

--- a/crates/svelte_analyze/Cargo.toml
+++ b/crates/svelte_analyze/Cargo.toml
@@ -21,7 +21,7 @@ oxc_span = { workspace = true }
 compact_str = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }
-lightningcss = { version = "1.0.0-alpha.71", features = ["visitor"] }
+svelte_css = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -1,7 +1,7 @@
-use lightningcss::rules::CssRule;
-use lightningcss::selector::{Component, PseudoClass, Selector};
-use lightningcss::stylesheet::StyleSheet;
 use rustc_hash::FxHashSet;
+use svelte_css::{
+    ComplexSelector, PseudoClassSelector, RelativeSelector, SimpleSelector, StyleSheet, Visit,
+};
 
 use svelte_ast::{AstStore, Component as SvelteComponent, Fragment, Node};
 
@@ -14,7 +14,7 @@ use crate::types::node_table::NodeBitSet;
 /// Does NOT transform or serialize CSS — call `svelte_transform_css::transform_css` for that.
 pub fn analyze_css_pass(
     component: &SvelteComponent,
-    stylesheet: &StyleSheet<'_, '_>,
+    stylesheet: &StyleSheet,
     inject_styles: bool,
     data: &mut AnalysisData,
 ) {
@@ -43,38 +43,47 @@ pub fn analyze_css_pass(
 // Collect selected tag names (read-only, no visitor mutation)
 // ---------------------------------------------------------------------------
 
-fn collect_type_selectors(stylesheet: &StyleSheet<'_, '_>) -> FxHashSet<String> {
-    let mut tags = FxHashSet::default();
-    for rule in stylesheet.rules.0.iter() {
-        if let CssRule::Style(style_rule) = rule {
-            for selector in style_rule.selectors.0.iter() {
-                if has_global_component(selector) {
-                    continue;
-                }
-                for component in selector.iter_raw_match_order() {
-                    if let Component::LocalName(name) = component {
-                        tags.insert(name.name.to_string());
-                    }
-                }
+fn collect_type_selectors(stylesheet: &StyleSheet) -> FxHashSet<String> {
+    let mut collector = TypeSelectorCollector {
+        tags: FxHashSet::default(),
+    };
+    collector.visit_stylesheet(stylesheet);
+    collector.tags
+}
+
+struct TypeSelectorCollector {
+    tags: FxHashSet<String>,
+}
+
+impl Visit for TypeSelectorCollector {
+    fn visit_complex_selector(&mut self, node: &ComplexSelector) {
+        if has_global_selector(node) {
+            return;
+        }
+        svelte_css::visit::walk_complex_selector(self, node);
+    }
+
+    fn visit_relative_selector(&mut self, node: &RelativeSelector) {
+        for sel in &node.selectors {
+            if let SimpleSelector::Type { name, .. } = sel {
+                self.tags.insert(name.to_string());
             }
         }
     }
-    tags
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn has_global_component(selector: &Selector<'_>) -> bool {
-    selector.iter_raw_match_order().any(|c| match c {
-        Component::NonTSPseudoClass(PseudoClass::Global { .. }) => true,
-        Component::NonTSPseudoClass(PseudoClass::Custom { name }) => name.as_ref() == "global",
-        Component::NonTSPseudoClass(PseudoClass::CustomFunction { name, .. }) => {
-            name.as_ref() == "global"
-        }
-        _ => false,
+fn has_global_selector(complex: &ComplexSelector) -> bool {
+    complex.children.iter().any(|rel| {
+        rel.selectors.iter().any(|s| is_global_pseudo(s))
     })
+}
+
+fn is_global_pseudo(sel: &SimpleSelector) -> bool {
+    matches!(sel, SimpleSelector::PseudoClass(PseudoClassSelector { name, .. }) if name.as_str() == "global")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -1,7 +1,5 @@
 use rustc_hash::FxHashSet;
-use svelte_css::{
-    ComplexSelector, PseudoClassSelector, RelativeSelector, SimpleSelector, StyleSheet, Visit,
-};
+use svelte_css::{ComplexSelector, RelativeSelector, SimpleSelector, StyleSheet, Visit};
 
 use svelte_ast::{AstStore, Component as SvelteComponent, Fragment, Node};
 
@@ -78,12 +76,10 @@ impl Visit for TypeSelectorCollector {
 
 fn has_global_selector(complex: &ComplexSelector) -> bool {
     complex.children.iter().any(|rel| {
-        rel.selectors.iter().any(|s| is_global_pseudo(s))
+        rel.selectors
+            .iter()
+            .any(|s| matches!(s, SimpleSelector::Global { .. }))
     })
-}
-
-fn is_global_pseudo(sel: &SimpleSelector) -> bool {
-    matches!(sel, SimpleSelector::PseudoClass(PseudoClassSelector { name, .. }) if name.as_str() == "global")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_compiler/src/lib.rs
+++ b/crates/svelte_compiler/src/lib.rs
@@ -48,9 +48,9 @@ pub fn compile(source: &str, options: &CompileOptions) -> CompileResult {
             let inject_styles = options.css == CssMode::Injected
                 || component.options.as_ref().and_then(|o| o.css) == Some(svelte_ast::CssMode::Injected);
             svelte_analyze::analyze_css_pass(&component, &ss, inject_styles, &mut analysis);
-            let css_source = component.css.as_ref()
-                .map(|b| component.source_text(b.content_span))
-                .unwrap_or("");
+            let css_block = component.css.as_ref()
+                .unwrap_or_else(|| panic!("css block must exist when css_parsed is Some"));
+            let css_source = component.source_text(css_block.content_span);
             let raw_css = svelte_transform_css::transform_css(&analysis.css.hash, ss, css_source);
             css_text = if inject_styles {
                 Some(svelte_transform_css::compact_css_for_injection(&raw_css))

--- a/crates/svelte_compiler/src/lib.rs
+++ b/crates/svelte_compiler/src/lib.rs
@@ -20,7 +20,7 @@ pub fn compile(source: &str, options: &CompileOptions) -> CompileResult {
 
     let js_alloc = oxc_allocator::Allocator::default();
     let (component, js_result, mut diagnostics) = svelte_parser::parse_with_js(&js_alloc, source);
-    let css_stylesheet = svelte_parser::parse_css_block(&js_alloc, &component);
+    let css_parsed = svelte_parser::parse_css_block(&component);
 
     // Whether the parser already found errors — captured before the closure so it
     // can be used inside without borrowing `diagnostics` mutably at the same time.
@@ -38,21 +38,24 @@ pub fn compile(source: &str, options: &CompileOptions) -> CompileResult {
     // `parsed` (invariant over its lifetime) stays inside the closure.
     // Analysis always runs; codegen is gated on the absence of error diagnostics.
     let codegen_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let (mut analysis, mut parsed, analyze_diags) =
+        let (mut analysis, mut parsed, mut analyze_diags) =
             svelte_analyze::analyze_with_options(&component, js_result, &analyze_opts);
 
         let mut css_text: Option<String> = None;
-        if let Some(ss) = css_stylesheet {
+        if let Some((ss, css_diags)) = css_parsed {
+            analyze_diags.extend(css_diags);
             // css:"injected" can come from compile options OR from <svelte:options css="injected">
             let inject_styles = options.css == CssMode::Injected
                 || component.options.as_ref().and_then(|o| o.css) == Some(svelte_ast::CssMode::Injected);
             svelte_analyze::analyze_css_pass(&component, &ss, inject_styles, &mut analysis);
-            let hash_str: &str = js_alloc.alloc_str(&analysis.css.hash);
-            let raw_css = svelte_transform_css::transform_css(hash_str, ss);
+            let css_source = component.css.as_ref()
+                .map(|b| component.source_text(b.content_span))
+                .unwrap_or("");
+            let raw_css = svelte_transform_css::transform_css(&analysis.css.hash, ss, css_source);
             css_text = if inject_styles {
-                raw_css.map(|s| svelte_transform_css::compact_css_for_injection(&s))
+                Some(svelte_transform_css::compact_css_for_injection(&raw_css))
             } else {
-                raw_css
+                Some(raw_css)
             };
         }
         // External CSS is returned in CompileResult.css; injected CSS goes into the JS output.

--- a/crates/svelte_css/src/ast.rs
+++ b/crates/svelte_css/src/ast.rs
@@ -140,6 +140,13 @@ pub enum SimpleSelector {
     PseudoElement(PseudoElementSelector),
     /// `[attr]`, `[attr=value]`, etc.
     Attribute(AttributeSelector),
+    /// `:global(...)` or `:global` — Svelte-specific scoping escape.
+    /// Separated from `PseudoClass` because it controls scoping semantics,
+    /// not CSS matching. Exhaustive match forces every consumer to handle it.
+    Global {
+        span: Span,
+        args: Option<Box<SelectorList>>,
+    },
     /// `&` nesting selector
     Nesting(Span),
     /// An+B notation inside `:nth-child()` etc.
@@ -279,6 +286,7 @@ impl GetSpan for SimpleSelector {
             Self::Type { span, .. }
             | Self::Id { span, .. }
             | Self::Class { span, .. }
+            | Self::Global { span, .. }
             | Self::Nesting(span)
             | Self::Nth(span)
             | Self::Percentage(span) => *span,

--- a/crates/svelte_css/src/parser.rs
+++ b/crates/svelte_css/src/parser.rs
@@ -1004,12 +1004,19 @@ impl<'src> Parser<'src> {
                     None
                 };
 
-                rel.selectors
-                    .push(SimpleSelector::PseudoClass(PseudoClassSelector {
+                if name.as_str() == "global" {
+                    rel.selectors.push(SimpleSelector::Global {
                         span: self.span_from(start),
-                        name,
                         args,
-                    }));
+                    });
+                } else {
+                    rel.selectors
+                        .push(SimpleSelector::PseudoClass(PseudoClassSelector {
+                            span: self.span_from(start),
+                            name,
+                            args,
+                        }));
+                }
             } else if self.eat(b'[') {
                 match self.parse_attribute_selector_inner(start) {
                     Some(attr) => rel.selectors.push(SimpleSelector::Attribute(attr)),

--- a/crates/svelte_css/src/printer.rs
+++ b/crates/svelte_css/src/printer.rs
@@ -205,6 +205,14 @@ impl Printer {
                 self.output.push('.');
                 self.output.push_str(name);
             }
+            SimpleSelector::Global { args, .. } => {
+                self.output.push_str(":global");
+                if let Some(args) = args {
+                    self.output.push('(');
+                    self.print_selector_list(args.as_ref(), source);
+                    self.output.push(')');
+                }
+            }
             SimpleSelector::Nesting(span)
             | SimpleSelector::Nth(span)
             | SimpleSelector::Percentage(span) => {

--- a/crates/svelte_css/src/printer.rs
+++ b/crates/svelte_css/src/printer.rs
@@ -194,10 +194,18 @@ impl Printer {
 
     fn print_simple_selector(&mut self, sel: &SimpleSelector, source: &str) {
         match sel {
-            SimpleSelector::Type { span, .. }
-            | SimpleSelector::Id { span, .. }
-            | SimpleSelector::Class { span, .. }
-            | SimpleSelector::Nesting(span)
+            SimpleSelector::Type { name, .. } => {
+                self.output.push_str(name);
+            }
+            SimpleSelector::Id { name, .. } => {
+                self.output.push('#');
+                self.output.push_str(name);
+            }
+            SimpleSelector::Class { name, .. } => {
+                self.output.push('.');
+                self.output.push_str(name);
+            }
+            SimpleSelector::Nesting(span)
             | SimpleSelector::Nth(span)
             | SimpleSelector::Percentage(span) => {
                 self.push_span(*span, source);

--- a/crates/svelte_css/src/test.rs
+++ b/crates/svelte_css/src/test.rs
@@ -220,6 +220,81 @@ fn global_block() {
     assert!(matches!(&rule.block.children[0], BlockChild::Rule(Rule::Style(_))));
 }
 
+#[test]
+fn global_in_compound_selector() {
+    // p:global(.active) — type selector followed by :global()
+    let src = "p:global(.active) { font-weight: bold; }";
+    let ss = p(src);
+    let StyleSheetChild::Rule(Rule::Style(rule)) = &ss.children[0] else {
+        panic!("expected style rule");
+    };
+    let rel = &rule.prelude.children[0].children[0];
+    assert_eq!(rel.selectors.len(), 2);
+    assert!(matches!(&rel.selectors[0], SimpleSelector::Type { name, .. } if name == "p"));
+    assert!(matches!(&rel.selectors[1], SimpleSelector::Global { args: Some(_), .. }));
+
+    // Verify the inner selector list contains .active
+    let SimpleSelector::Global { args: Some(args), .. } = &rel.selectors[1] else {
+        panic!("expected Global with args");
+    };
+    let inner_rel = &args.children[0].children[0];
+    assert!(matches!(&inner_rel.selectors[0], SimpleSelector::Class { name, .. } if name == "active"));
+}
+
+#[test]
+fn global_with_complex_inner_selector() {
+    // :global(h2.featured) — multiple simple selectors inside :global()
+    let src = ":global(h2.featured) { font-style: italic; }";
+    let ss = p(src);
+    let StyleSheetChild::Rule(Rule::Style(rule)) = &ss.children[0] else {
+        panic!("expected style rule");
+    };
+    let rel = &rule.prelude.children[0].children[0];
+    assert_eq!(rel.selectors.len(), 1);
+    let SimpleSelector::Global { args: Some(args), .. } = &rel.selectors[0] else {
+        panic!("expected Global with args");
+    };
+    let inner_rel = &args.children[0].children[0];
+    assert_eq!(inner_rel.selectors.len(), 2);
+    assert!(matches!(&inner_rel.selectors[0], SimpleSelector::Type { name, .. } if name == "h2"));
+    assert!(matches!(&inner_rel.selectors[1], SimpleSelector::Class { name, .. } if name == "featured"));
+}
+
+#[test]
+fn global_multiple_in_descendant() {
+    // :global(.wrapper) :global(.item) — two :global() with descendant combinator
+    let src = ":global(.wrapper) :global(.item) { display: flex; }";
+    let ss = p(src);
+    let StyleSheetChild::Rule(Rule::Style(rule)) = &ss.children[0] else {
+        panic!("expected style rule");
+    };
+    let complex = &rule.prelude.children[0];
+    assert_eq!(complex.children.len(), 2);
+
+    let rel0 = &complex.children[0];
+    assert!(matches!(&rel0.selectors[0], SimpleSelector::Global { args: Some(_), .. }));
+
+    let rel1 = &complex.children[1];
+    assert!(matches!(&rel1.selectors[0], SimpleSelector::Global { args: Some(_), .. }));
+}
+
+#[test]
+fn non_global_pseudo_class_stays_pseudo_class() {
+    // :hover should remain PseudoClass, not Global
+    let src = "a:hover { color: blue; }";
+    let ss = p(src);
+    let StyleSheetChild::Rule(Rule::Style(rule)) = &ss.children[0] else {
+        panic!("expected style rule");
+    };
+    let rel = &rule.prelude.children[0].children[0];
+    assert_eq!(rel.selectors.len(), 2);
+    assert!(matches!(&rel.selectors[0], SimpleSelector::Type { name, .. } if name == "a"));
+    assert!(
+        matches!(&rel.selectors[1], SimpleSelector::PseudoClass(pc) if pc.name == "hover"),
+        "expected PseudoClass(:hover), not Global"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Attribute selectors
 // ---------------------------------------------------------------------------
@@ -528,6 +603,36 @@ fn printer_global_function() {
     let ss = p(src);
     let output = Printer::print(&ss, src);
     assert_eq!(output, ":global(.foo) {\n  color: red;\n}\n");
+}
+
+#[test]
+fn printer_global_block() {
+    let src = ":global { p { color: red; } }";
+    let ss = p(src);
+    let output = Printer::print(&ss, src);
+    assert_eq!(output, ":global {\n  p {\n    color: red;\n  }\n}\n");
+}
+
+#[test]
+fn printer_global_in_compound() {
+    let src = "p:global(.active) { font-weight: bold; }";
+    let ss = p(src);
+    let output = Printer::print(&ss, src);
+    assert_eq!(
+        output,
+        "p:global(.active) {\n  font-weight: bold;\n}\n"
+    );
+}
+
+#[test]
+fn printer_multiple_globals_descendant() {
+    let src = ":global(.wrapper) :global(.item) { display: flex; }";
+    let ss = p(src);
+    let output = Printer::print(&ss, src);
+    assert_eq!(
+        output,
+        ":global(.wrapper) :global(.item) {\n  display: flex;\n}\n"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_css/src/test.rs
+++ b/crates/svelte_css/src/test.rs
@@ -197,11 +197,10 @@ fn global_function() {
         panic!("expected style rule");
     };
     let rel = &rule.prelude.children[0].children[0];
-    let SimpleSelector::PseudoClass(pc) = &rel.selectors[0] else {
-        panic!("expected pseudo-class");
-    };
-    assert_eq!(pc.name.as_str(), "global");
-    assert!(pc.args.is_some());
+    assert!(
+        matches!(&rel.selectors[0], SimpleSelector::Global { args: Some(_), .. }),
+        "expected Global with args"
+    );
 }
 
 #[test]
@@ -212,11 +211,10 @@ fn global_block() {
         panic!("expected style rule");
     };
     let rel = &rule.prelude.children[0].children[0];
-    let SimpleSelector::PseudoClass(pc) = &rel.selectors[0] else {
-        panic!("expected pseudo-class");
-    };
-    assert_eq!(pc.name.as_str(), "global");
-    assert!(pc.args.is_none());
+    assert!(
+        matches!(&rel.selectors[0], SimpleSelector::Global { args: None, .. }),
+        "expected Global without args"
+    );
 
     assert_eq!(rule.block.children.len(), 1);
     assert!(matches!(&rule.block.children[0], BlockChild::Rule(Rule::Style(_))));

--- a/crates/svelte_css/src/visit.rs
+++ b/crates/svelte_css/src/visit.rs
@@ -190,10 +190,13 @@ pub fn walk_block_mut<V: VisitMut + ?Sized>(v: &mut V, node: &mut Block) {
 /// Call this from your `visit_simple_selector` if you need to recurse into
 /// `:not(...)`, `:is(...)`, `:global(...)` etc.
 pub fn walk_simple_selector_args<V: Visit + ?Sized>(v: &mut V, node: &SimpleSelector) {
-    if let SimpleSelector::PseudoClass(pc) = node
-        && let Some(args) = &pc.args
-    {
-        v.visit_selector_list(args.as_ref());
+    let args = match node {
+        SimpleSelector::PseudoClass(pc) => pc.args.as_deref(),
+        SimpleSelector::Global { args, .. } => args.as_deref(),
+        _ => None,
+    };
+    if let Some(args) = args {
+        v.visit_selector_list(args);
     }
 }
 
@@ -202,9 +205,12 @@ pub fn walk_simple_selector_args_mut<V: VisitMut + ?Sized>(
     v: &mut V,
     node: &mut SimpleSelector,
 ) {
-    if let SimpleSelector::PseudoClass(pc) = node
-        && let Some(args) = &mut pc.args
-    {
-        v.visit_selector_list_mut(args.as_mut());
+    let args = match node {
+        SimpleSelector::PseudoClass(pc) => pc.args.as_deref_mut(),
+        SimpleSelector::Global { args, .. } => args.as_deref_mut(),
+        _ => None,
+    };
+    if let Some(args) = args {
+        v.visit_selector_list_mut(args);
     }
 }

--- a/crates/svelte_parser/Cargo.toml
+++ b/crates/svelte_parser/Cargo.toml
@@ -18,7 +18,7 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 compact_str = { workspace = true }
 rustc-hash = { workspace = true }
-lightningcss = { version = "1.0.0-alpha.71", features = ["visitor"] }
+svelte_css = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/svelte_parser/src/lib.rs
+++ b/crates/svelte_parser/src/lib.rs
@@ -1,5 +1,3 @@
-use lightningcss::stylesheet::{ParserOptions, StyleSheet};
-pub use lightningcss::stylesheet::StyleSheet as CssStyleSheet;
 use scanner::{token::TokenType, Scanner};
 use svelte_span::Span;
 
@@ -63,27 +61,16 @@ pub fn parse_with_js<'a>(
 
 /// Parse the CSS from a component's top-level `<style>` block.
 ///
-/// The CSS source text is copied into `alloc` so the returned `StyleSheet`
-/// has the same lifetime `'a` as all other `ParserResult` data.
-/// Returns `None` when the component has no `<style>` block or the CSS is
-/// syntactically invalid.
-pub fn parse_css_block<'a>(
-    alloc: &'a oxc_allocator::Allocator,
+/// Returns `None` when the component has no `<style>` block.
+/// CSS parse diagnostics are returned separately and should be merged
+/// into the main diagnostic list by the caller.
+pub fn parse_css_block(
     component: &svelte_ast::Component,
-) -> Option<CssStyleSheet<'a, 'a>> {
+) -> Option<(svelte_css::StyleSheet, Vec<svelte_diagnostics::Diagnostic>)> {
     let css_block = component.css.as_ref()?;
     let css_text = component.source_text(css_block.content_span);
-    let css_src: &'a str = alloc.alloc_str(css_text);
-    StyleSheet::parse(
-        css_src,
-        ParserOptions {
-            // Enables PseudoClass::Global { selector } for :global(...) so the transform
-            // pass can expand it at the AST level instead of working with raw tokens.
-            css_modules: Some(lightningcss::css_modules::Config::default()),
-            ..ParserOptions::default()
-        },
-    )
-    .ok()
+    let (stylesheet, diags) = svelte_css::parse(css_text);
+    Some((stylesheet, diags))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_transform_css/Cargo.toml
+++ b/crates/svelte_transform_css/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-lightningcss = { version = "1.0.0-alpha.71", features = ["visitor"] }
+svelte_css = { workspace = true }
+svelte_span = { workspace = true }
+compact_str = { workspace = true }

--- a/crates/svelte_transform_css/src/lib.rs
+++ b/crates/svelte_transform_css/src/lib.rs
@@ -1,112 +1,126 @@
-use lightningcss::error::PrinterError;
-use lightningcss::printer::{Printer, PrinterOptions};
-use lightningcss::selector::{Component, PseudoClass, Selector};
-use lightningcss::stylesheet::StyleSheet;
-use lightningcss::traits::ToCss;
-use lightningcss::values::ident::Ident;
-use lightningcss::{visit_types, visitor::{Visit, Visitor, VisitTypes}};
+use compact_str::CompactString;
+use svelte_css::{
+    ComplexSelector, PseudoClassSelector, RelativeSelector, SimpleSelector, StyleSheet, VisitMut,
+};
+use svelte_span::Span;
 
 /// Transform the stylesheet AST: scope selectors and serialize to CSS text.
 ///
-/// `hash_str` must be allocated into the same arena as the stylesheet so that
-/// `Ident<'a>` components satisfy the lifetime bound.
-///
-/// Returns `None` when the printer fails.
-pub fn transform_css<'a>(
-    hash_str: &'a str,
-    mut stylesheet: StyleSheet<'a, 'a>,
-) -> Option<String> {
-    let mut scoper = ScopeSelectors { hash_class: hash_str };
-    if stylesheet.visit(&mut scoper).is_err() {
-        return None;
-    }
-
-    // Serialize directly through Printer with no CSS module context so that
-    // class names are not renamed (stylesheet.to_css() would enable renaming
-    // because the stylesheet was parsed with css_modules enabled).
-    let mut dest = String::new();
-    let mut printer = Printer::new(&mut dest, PrinterOptions::default());
-    stylesheet.rules.to_css(&mut printer).ok()?;
-    printer.newline().ok()?;
-    Some(dest)
+/// `hash_class` is the scoping class name (e.g. `"svelte-1a7i8ec"`).
+/// `source` is the original CSS source text (needed by the printer which
+/// resolves `Span`s back to source slices).
+pub fn transform_css(
+    hash_class: &str,
+    mut stylesheet: StyleSheet,
+    source: &str,
+) -> String {
+    let mut scoper = ScopeSelectors {
+        hash_class: CompactString::new(hash_class),
+    };
+    scoper.visit_stylesheet_mut(&mut stylesheet);
+    svelte_css::Printer::print(&stylesheet, source)
 }
 
-struct ScopeSelectors<'h> {
-    /// The scoping class name, e.g. `"svelte-1a7i8ec"` (without the dot).
-    /// Allocated into the stylesheet arena so `Ident<'h>` satisfies `'h: 'i`.
-    hash_class: &'h str,
+struct ScopeSelectors {
+    hash_class: CompactString,
 }
 
-impl<'i, 'h: 'i> Visitor<'i> for ScopeSelectors<'h> {
-    type Error = PrinterError;
-
-    fn visit_types(&self) -> VisitTypes {
-        visit_types!(SELECTORS)
-    }
-
-    fn visit_selector(&mut self, selector: &mut Selector<'i>) -> Result<(), Self::Error> {
-        // iter_raw_match_order() returns components in right-to-left (match) order at the
-        // compound level: rightmost compound first, leftmost last. Within a single compound,
-        // components are in parse (left-to-right) order. Selector::from() expects left-to-right
-        // input. We split on combinators, then process compounds from highest index (leftmost in
-        // CSS) down to 0 (rightmost), which produces the correct left-to-right sequence for
-        // Selector::from(). Components within each compound are already in parse order and need
-        // no reversal.
-        let components: Vec<Component<'i>> =
-            selector.iter_raw_match_order().cloned().collect();
-
-        let has_local_name = components.iter().any(|c| matches!(c, Component::LocalName(_)));
-        let has_global = components.iter().any(|c| {
-            matches!(c, Component::NonTSPseudoClass(PseudoClass::Global { .. }))
-        });
-
-        if !has_local_name && !has_global {
-            return Ok(());
+impl VisitMut for ScopeSelectors {
+    fn visit_complex_selector_mut(&mut self, node: &mut ComplexSelector) {
+        // Check if this entire complex selector is wrapped in :global()
+        if is_entirely_global(node) {
+            unwrap_global(node);
+            return;
         }
 
-        // Split components into compound selectors (separated by combinators).
-        // The resulting compounds are in right-to-left order (match order).
-        let compounds: Vec<&[Component<'i>]> = components
-            .as_slice()
-            .split(|c| c.is_combinator())
-            .collect();
+        svelte_css::visit::walk_complex_selector_mut(self, node);
+    }
 
-        // Combinators in right-to-left order: combinators[k] is between compounds[k] and compounds[k+1].
-        let combinators: Vec<Component<'i>> = components
-            .iter()
-            .filter(|c| c.is_combinator())
-            .cloned()
-            .collect();
+    fn visit_relative_selector_mut(&mut self, node: &mut RelativeSelector) {
+        let mut new_selectors = Vec::with_capacity(node.selectors.len() + 1);
+        let mut has_non_global_scopable = false;
+        let mut scope_inserted = false;
 
-        let mut result: Vec<Component<'i>> = Vec::with_capacity(components.len() + 1);
-
-        // Iterate compounds from last index (leftmost in CSS) to 0 (rightmost in CSS).
-        // Between compound[i] and compound[i-1] the combinator is combinators[i-1].
-        for i in (0..compounds.len()).rev() {
-            for component in compounds[i] {
-                match component {
-                    Component::NonTSPseudoClass(PseudoClass::Global { selector }) => {
-                        // Expand the inner selector's components inline, without a scope class —
-                        // content of :global() is intentionally unscoped.
-                        // iter_raw_match_order() returns components within a compound in parse
-                        // (left-to-right) order, so no reversal is needed here.
-                        result.extend(selector.iter_raw_match_order().cloned());
+        for sel in node.selectors.drain(..) {
+            match sel {
+                SimpleSelector::PseudoClass(PseudoClassSelector {
+                    name,
+                    args: Some(args),
+                    span: _,
+                }) if name.as_str() == "global" => {
+                    // Insert scope class before global content if we have a scopable selector
+                    // but haven't inserted the scope class yet.
+                    if has_non_global_scopable && !scope_inserted {
+                        new_selectors.push(SimpleSelector::Class {
+                            span: Span::new(0, 0),
+                            name: self.hash_class.clone(),
+                        });
+                        scope_inserted = true;
                     }
-                    Component::LocalName(_) => {
-                        result.push(component.clone());
-                        result.push(Component::Class(Ident::from(self.hash_class)));
+                    // Expand :global(...) — inline the inner selectors unscoped
+                    for complex in args.children {
+                        for rel in complex.children {
+                            new_selectors.extend(rel.selectors);
+                        }
                     }
-                    _ => result.push(component.clone()),
+                }
+                _ => {
+                    if is_scopable(&sel) {
+                        has_non_global_scopable = true;
+                    }
+                    new_selectors.push(sel);
                 }
             }
-            if i > 0 {
-                result.push(combinators[i - 1].clone());
-            }
         }
 
-        *selector = Selector::from(result);
-        Ok(())
+        // Append scope class at end if we have scopable selectors but didn't insert yet
+        if has_non_global_scopable && !scope_inserted {
+            new_selectors.push(SimpleSelector::Class {
+                span: Span::new(0, 0),
+                name: self.hash_class.clone(),
+            });
+        }
+
+        node.selectors = new_selectors.into();
     }
+}
+
+/// Returns true if the entire complex selector is a single `:global(...)` call.
+fn is_entirely_global(complex: &ComplexSelector) -> bool {
+    complex.children.len() == 1
+        && complex.children[0].selectors.len() == 1
+        && matches!(
+            &complex.children[0].selectors[0],
+            SimpleSelector::PseudoClass(PseudoClassSelector { name, args: Some(_), .. })
+            if name.as_str() == "global"
+        )
+}
+
+/// Unwrap a `:global(...)` complex selector — replace with its inner selectors.
+fn unwrap_global(complex: &mut ComplexSelector) {
+    let sel = complex.children[0].selectors.remove(0);
+    if let SimpleSelector::PseudoClass(PseudoClassSelector { args: Some(args), .. }) = sel {
+        // Replace the complex selector's children with the inner selector list's children
+        let mut new_children = svelte_css::RelativeSelectorVec::new();
+        for inner_complex in args.children {
+            new_children.extend(inner_complex.children);
+        }
+        complex.children = new_children;
+    }
+}
+
+/// Check if a simple selector is something that can be scoped
+/// (type, class, id, attribute, pseudo-element, nesting).
+fn is_scopable(sel: &SimpleSelector) -> bool {
+    matches!(
+        sel,
+        SimpleSelector::Type { .. }
+            | SimpleSelector::Class { .. }
+            | SimpleSelector::Id { .. }
+            | SimpleSelector::Attribute(_)
+            | SimpleSelector::PseudoElement(_)
+            | SimpleSelector::Nesting(_)
+    )
 }
 
 /// Compact formatted CSS into a single-line string matching the reference compiler's
@@ -147,4 +161,17 @@ pub fn compact_css_for_injection(css: &str) -> String {
         out.pop();
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_type_selector() {
+        let source = "p { color: red; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", ss, source);
+        assert!(result.contains("p.svelte-abc123"), "got: {result}");
+    }
 }

--- a/crates/svelte_transform_css/src/lib.rs
+++ b/crates/svelte_transform_css/src/lib.rs
@@ -1,7 +1,5 @@
 use compact_str::CompactString;
-use svelte_css::{
-    ComplexSelector, PseudoClassSelector, RelativeSelector, SimpleSelector, StyleSheet, VisitMut,
-};
+use svelte_css::{ComplexSelector, RelativeSelector, SimpleSelector, StyleSheet, VisitMut};
 use svelte_span::Span;
 
 /// Transform the stylesheet AST: scope selectors and serialize to CSS text.
@@ -27,7 +25,6 @@ struct ScopeSelectors {
 
 impl VisitMut for ScopeSelectors {
     fn visit_complex_selector_mut(&mut self, node: &mut ComplexSelector) {
-        // Check if this entire complex selector is wrapped in :global()
         if is_entirely_global(node) {
             unwrap_global(node);
             return;
@@ -43,18 +40,13 @@ impl VisitMut for ScopeSelectors {
 
         for sel in node.selectors.drain(..) {
             match sel {
-                SimpleSelector::PseudoClass(PseudoClassSelector {
-                    name,
-                    args: Some(args),
-                    span: _,
-                }) if name.as_str() == "global" => {
+                SimpleSelector::Global {
+                    args: Some(args), ..
+                } => {
                     // Insert scope class before global content if we have a scopable selector
                     // but haven't inserted the scope class yet.
                     if has_non_global_scopable && !scope_inserted {
-                        new_selectors.push(SimpleSelector::Class {
-                            span: Span::new(0, 0),
-                            name: self.hash_class.clone(),
-                        });
+                        new_selectors.push(self.scope_class());
                         scope_inserted = true;
                     }
                     // Expand :global(...) — inline the inner selectors unscoped
@@ -63,6 +55,9 @@ impl VisitMut for ScopeSelectors {
                             new_selectors.extend(rel.selectors);
                         }
                     }
+                }
+                SimpleSelector::Global { args: None, .. } => {
+                    // Bare `:global` without args — drop it (block form handled elsewhere)
                 }
                 _ => {
                     if is_scopable(&sel) {
@@ -73,15 +68,20 @@ impl VisitMut for ScopeSelectors {
             }
         }
 
-        // Append scope class at end if we have scopable selectors but didn't insert yet
         if has_non_global_scopable && !scope_inserted {
-            new_selectors.push(SimpleSelector::Class {
-                span: Span::new(0, 0),
-                name: self.hash_class.clone(),
-            });
+            new_selectors.push(self.scope_class());
         }
 
         node.selectors = new_selectors.into();
+    }
+}
+
+impl ScopeSelectors {
+    fn scope_class(&self) -> SimpleSelector {
+        SimpleSelector::Class {
+            span: Span::new(0, 0),
+            name: self.hash_class.clone(),
+        }
     }
 }
 
@@ -91,16 +91,17 @@ fn is_entirely_global(complex: &ComplexSelector) -> bool {
         && complex.children[0].selectors.len() == 1
         && matches!(
             &complex.children[0].selectors[0],
-            SimpleSelector::PseudoClass(PseudoClassSelector { name, args: Some(_), .. })
-            if name.as_str() == "global"
+            SimpleSelector::Global { args: Some(_), .. }
         )
 }
 
 /// Unwrap a `:global(...)` complex selector — replace with its inner selectors.
 fn unwrap_global(complex: &mut ComplexSelector) {
     let sel = complex.children[0].selectors.remove(0);
-    if let SimpleSelector::PseudoClass(PseudoClassSelector { args: Some(args), .. }) = sel {
-        // Replace the complex selector's children with the inner selector list's children
+    if let SimpleSelector::Global {
+        args: Some(args), ..
+    } = sel
+    {
         let mut new_children = svelte_css::RelativeSelectorVec::new();
         for inner_complex in args.children {
             new_children.extend(inner_complex.children);
@@ -173,5 +174,22 @@ mod tests {
         let (ss, _) = svelte_css::parse(source);
         let result = transform_css("svelte-abc123", ss, source);
         assert!(result.contains("p.svelte-abc123"), "got: {result}");
+    }
+
+    #[test]
+    fn global_not_scoped() {
+        let source = ":global(.foo) { color: red; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", ss, source);
+        assert!(!result.contains("svelte-abc123"), "global should not be scoped, got: {result}");
+        assert!(result.contains(".foo"), "got: {result}");
+    }
+
+    #[test]
+    fn mixed_global_and_local() {
+        let source = "p:global(.active) { font-weight: bold; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", ss, source);
+        assert!(result.contains("p.svelte-abc123.active"), "got: {result}");
     }
 }

--- a/crates/wasm_compiler/Cargo.toml
+++ b/crates/wasm_compiler/Cargo.toml
@@ -12,7 +12,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dependencies]
 svelte_compiler = { workspace = true }
-lightningcss = { version = "1.0.0-alpha.71", features = ["visitor"] }
+svelte_css = { workspace = true }
 svelte_diagnostics = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_codegen = { workspace = true }

--- a/crates/wasm_compiler/src/lib.rs
+++ b/crates/wasm_compiler/src/lib.rs
@@ -110,11 +110,7 @@ impl WasmCompiler {
 
     #[wasm_bindgen()]
     pub fn format_css(&self, source: &str) -> String {
-        use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
-        StyleSheet::parse(source, ParserOptions::default())
-            .ok()
-            .and_then(|ss| ss.to_css(PrinterOptions::default()).ok())
-            .map(|r| r.code)
-            .unwrap_or_else(|| source.to_string())
+        let (stylesheet, _diags) = svelte_css::parse(source);
+        svelte_css::Printer::print(&stylesheet, source)
     }
 }


### PR DESCRIPTION
This PR replaces the lightningcss dependency with the internal svelte_css crate across the compiler, enabling better control over CSS scoping semantics and selector handling.

## Summary
Migrates all CSS parsing, transformation, and analysis from lightningcss to svelte_css, which provides a custom AST and visitor pattern tailored to Svelte's scoping requirements.

## Key Changes

- **svelte_transform_css**: Rewrote selector scoping logic to work with svelte_css AST
  - Replaced lightningcss `Visitor` with svelte_css `VisitMut` trait
  - Simplified scoping algorithm to handle `SimpleSelector::Global` as a first-class construct
  - Added helper functions `is_entirely_global()`, `unwrap_global()`, and `is_scopable()`
  - Added comprehensive unit tests for scoping behavior

- **svelte_css AST**: Added `SimpleSelector::Global` variant
  - Separated `:global()` from generic `PseudoClass` to enforce exhaustive handling
  - Includes optional `args` field for `:global(...)` function form
  - Updated parser to recognize and create `Global` selectors

- **svelte_css printer**: Enhanced to handle `Global` selectors
  - Prints `:global` with or without arguments
  - Properly reconstructs `:global(...)` function syntax

- **svelte_css visitor**: Updated walk functions to handle `Global` selector arguments
  - `walk_simple_selector_args()` and `walk_simple_selector_args_mut()` now handle both `PseudoClass` and `Global` args

- **svelte_analyze**: Migrated CSS analysis to svelte_css
  - Replaced lightningcss selector iteration with svelte_css visitor pattern
  - Simplified type selector collection using `Visit` trait
  - Updated `has_global_component()` to check for `SimpleSelector::Global`

- **svelte_parser**: Simplified CSS block parsing
  - Removed allocator lifetime management (svelte_css handles its own allocation)
  - Returns diagnostics alongside stylesheet for better error reporting
  - Removed css_modules configuration (no longer needed)

- **Dependencies**: Updated all crates to use svelte_css instead of lightningcss
  - Removed lightningcss from svelte_transform_css, svelte_analyze, svelte_parser, wasm_compiler
  - Added svelte_css, svelte_span, and compact_str dependencies where needed

## Notable Implementation Details

- The scoping algorithm now explicitly handles `:global()` unwrapping at the AST level
- `SimpleSelector::Global` is a separate enum variant to force exhaustive pattern matching, preventing accidental scoping of global selectors
- CSS diagnostics are now properly propagated from the parser through the compilation pipeline
- The printer uses source spans to reconstruct original formatting where possible

https://claude.ai/code/session_01NJjYNBUB2YhRouBAUswmcs