### PR TITLE
Add @keyframes scoping support for component-local animations

### DIFF
--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -1,5 +1,8 @@
+use compact_str::CompactString;
 use rustc_hash::FxHashSet;
-use svelte_css::{ComplexSelector, RelativeSelector, SimpleSelector, StyleRule, StyleSheet, Visit};
+use svelte_css::{
+    AtRule, ComplexSelector, RelativeSelector, SimpleSelector, StyleRule, StyleSheet, Visit,
+};
 
 use svelte_ast::{AstStore, Component as SvelteComponent, Fragment, Node};
 
@@ -25,6 +28,9 @@ pub fn analyze_css_pass(
     // Phase 1: collect HTML tag names selected by CSS rules (read-only).
     let selected_tags = collect_type_selectors(stylesheet);
 
+    // Phase 1b: collect locally-scoped @keyframes names.
+    let keyframes = collect_keyframe_names(stylesheet, css_text);
+
     // Phase 2: walk template, mark elements whose tag name is in selected_tags.
     let node_count = component.node_count();
     let mut scoped = NodeBitSet::new(node_count);
@@ -34,6 +40,7 @@ pub fn analyze_css_pass(
         hash,
         scoped_elements: scoped,
         inject_styles,
+        keyframes,
     };
 }
 
@@ -74,6 +81,45 @@ impl Visit for TypeSelectorCollector {
                 self.tags.insert(name.to_string());
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Collect @keyframes names (read-only)
+// ---------------------------------------------------------------------------
+
+fn collect_keyframe_names(stylesheet: &StyleSheet, source: &str) -> Vec<CompactString> {
+    let mut collector = KeyframeCollector {
+        names: Vec::new(),
+        source,
+    };
+    collector.visit_stylesheet(stylesheet);
+    collector.names
+}
+
+struct KeyframeCollector<'a> {
+    names: Vec<CompactString>,
+    source: &'a str,
+}
+
+impl Visit for KeyframeCollector<'_> {
+    fn visit_style_rule(&mut self, node: &StyleRule) {
+        // Skip `:global { ... }` blocks — their keyframes are unscoped.
+        if node.is_lone_global_block() {
+            return;
+        }
+        svelte_css::visit::walk_style_rule(self, node);
+    }
+
+    fn visit_at_rule(&mut self, node: &AtRule) {
+        if node.name == "keyframes" {
+            let prelude = node.prelude.source_text(self.source).trim();
+            if !prelude.starts_with("-global-") {
+                self.names.push(CompactString::new(prelude));
+            }
+        }
+        // Still recurse into the block for nested @keyframes (unlikely but correct)
+        svelte_css::visit::walk_at_rule(self, node);
     }
 }
 

--- a/crates/svelte_analyze/src/types/data/css.rs
+++ b/crates/svelte_analyze/src/types/data/css.rs
@@ -1,3 +1,5 @@
+use compact_str::CompactString;
+
 use super::NodeBitSet;
 
 /// CSS-scoping metadata computed by the CSS analysis pass.
@@ -10,6 +12,10 @@ pub struct CssAnalysis {
     /// Whether CSS should be injected at runtime via `$.append_styles()` instead of
     /// returned in `CompileResult.css`. Set when `css:"injected"` is active.
     pub inject_styles: bool,
+    /// Locally-scoped `@keyframes` names (those without `-global-` prefix).
+    /// Used by the CSS transform to prefix these names with the component hash
+    /// and rewrite matching `animation`/`animation-name` values.
+    pub keyframes: Vec<CompactString>,
 }
 
 impl CssAnalysis {
@@ -18,6 +24,7 @@ impl CssAnalysis {
             hash: String::new(),
             scoped_elements: NodeBitSet::new(node_count),
             inject_styles: false,
+            keyframes: Vec::new(),
         }
     }
 }

--- a/crates/svelte_compiler/src/lib.rs
+++ b/crates/svelte_compiler/src/lib.rs
@@ -51,7 +51,7 @@ pub fn compile(source: &str, options: &CompileOptions) -> CompileResult {
             let css_block = component.css.as_ref()
                 .unwrap_or_else(|| panic!("css block must exist when css_parsed is Some"));
             let css_source = component.source_text(css_block.content_span);
-            let raw_css = svelte_transform_css::transform_css(&analysis.css.hash, ss, css_source);
+            let raw_css = svelte_transform_css::transform_css(&analysis.css.hash, &analysis.css.keyframes, ss, css_source);
             css_text = if inject_styles {
                 Some(svelte_transform_css::compact_css_for_injection(&raw_css))
             } else {

--- a/crates/svelte_css/src/ast.rs
+++ b/crates/svelte_css/src/ast.rs
@@ -95,6 +95,8 @@ pub struct AtRule {
     pub span: Span,
     pub name: CompactString,
     pub prelude: Span,
+    /// When set by the transform, the printer uses this instead of `prelude`.
+    pub prelude_override: Option<CompactString>,
     pub block: Option<Block>,
 }
 
@@ -224,6 +226,8 @@ pub struct Declaration {
     pub span: Span,
     pub property: Span,
     pub value: Span,
+    /// When set by the transform, the printer uses this instead of `value`.
+    pub value_override: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/svelte_css/src/parser.rs
+++ b/crates/svelte_css/src/parser.rs
@@ -834,6 +834,7 @@ impl<'src> Parser<'src> {
             span: self.span_from(start),
             name,
             prelude,
+            prelude_override: None,
             block,
         })
     }
@@ -1340,6 +1341,7 @@ impl<'src> Parser<'src> {
             span: Span::new(start as u32, end as u32),
             property,
             value,
+            value_override: None,
         })
     }
 }

--- a/crates/svelte_css/src/printer.rs
+++ b/crates/svelte_css/src/printer.rs
@@ -109,23 +109,41 @@ impl Printer {
         self.output.push('@');
         self.output.push_str(&rule.name);
 
-        let prelude_text = rule.prelude.source_text(source).trim();
+        let prelude_text = match &rule.prelude_override {
+            Some(ov) => ov.as_str(),
+            None => rule.prelude.source_text(source).trim(),
+        };
         if !prelude_text.is_empty() {
             self.output.push(' ');
             self.output.push_str(prelude_text);
         }
 
         if let Some(block) = &rule.block {
-            if self.minify {
+            let is_keyframes = rule.name == "keyframes"
+                || rule
+                    .name
+                    .strip_prefix('-')
+                    .and_then(|s| s.split_once('-'))
+                    .is_some_and(|(_, rest)| rest == "keyframes");
+
+            if is_keyframes {
+                // Preserve original formatting for @keyframes body — the internal
+                // structure (from/to/percentage stops) is never transformed.
+                self.output.push(' ');
+                self.push_span(block.span, source);
+                self.output.push('\n');
+            } else if self.minify {
                 self.output.push('{');
+                self.print_block_children(block, source);
+                self.output.push('}');
             } else {
                 self.output.push_str(" {\n");
+                self.indent += 1;
+                self.print_block_children(block, source);
+                self.indent -= 1;
+                self.write_indent();
+                self.output.push_str("}\n");
             }
-            self.indent += 1;
-            self.print_block_children(block, source);
-            self.indent -= 1;
-            self.write_indent();
-            self.output.push_str("}\n");
         } else {
             self.output.push_str(";\n");
         }
@@ -156,7 +174,10 @@ impl Printer {
         } else {
             self.output.push_str(": ");
         }
-        self.push_span(decl.value, source);
+        match &decl.value_override {
+            Some(ov) => self.output.push_str(ov),
+            None => self.push_span(decl.value, source),
+        }
         self.output.push_str(";\n");
     }
 

--- a/crates/svelte_transform_css/src/lib.rs
+++ b/crates/svelte_transform_css/src/lib.rs
@@ -1,32 +1,38 @@
 use compact_str::CompactString;
 use svelte_css::{
-    Block, BlockChild, ComplexSelector, RelativeSelector, Rule, SimpleSelector, StyleSheet,
-    StyleSheetChild, VisitMut,
+    AtRule, Block, BlockChild, ComplexSelector, Declaration, RelativeSelector, Rule,
+    SimpleSelector, StyleSheet, StyleSheetChild, VisitMut,
 };
 use svelte_span::Span;
 
 /// Transform the stylesheet AST: scope selectors and serialize to CSS text.
 ///
 /// `hash_class` is the scoping class name (e.g. `"svelte-1a7i8ec"`).
+/// `keyframes` is the list of locally-scoped `@keyframes` names (collected by analyze).
 /// `source` is the original CSS source text (needed by the printer which
 /// resolves `Span`s back to source slices).
 pub fn transform_css(
     hash_class: &str,
+    keyframes: &[CompactString],
     mut stylesheet: StyleSheet,
     source: &str,
 ) -> String {
     let mut scoper = ScopeSelectors {
         hash_class: CompactString::new(hash_class),
+        keyframes,
+        source,
     };
     scoper.visit_stylesheet_mut(&mut stylesheet);
     svelte_css::Printer::print(&stylesheet, source)
 }
 
-struct ScopeSelectors {
+struct ScopeSelectors<'a> {
     hash_class: CompactString,
+    keyframes: &'a [CompactString],
+    source: &'a str,
 }
 
-impl VisitMut for ScopeSelectors {
+impl VisitMut for ScopeSelectors<'_> {
     fn visit_stylesheet_mut(&mut self, node: &mut StyleSheet) {
         let children = std::mem::take(&mut node.children);
         let mut new_children = Vec::with_capacity(children.len());
@@ -131,9 +137,86 @@ impl VisitMut for ScopeSelectors {
 
         node.selectors = new_selectors.into();
     }
+
+    fn visit_at_rule_mut(&mut self, node: &mut AtRule) {
+        if node.name == "keyframes" {
+            let prelude = node.prelude.source_text(self.source).trim();
+            if let Some(stripped) = prelude.strip_prefix("-global-") {
+                // `-global-` escape: strip prefix, leave name unscoped
+                node.prelude_override = Some(CompactString::new(stripped));
+            } else if self.keyframes.iter().any(|k| k.as_str() == prelude) {
+                // Local keyframe: prefix with component hash
+                node.prelude_override =
+                    Some(CompactString::new(&format!("{}-{}", self.hash_class, prelude)));
+            }
+            // Do NOT recurse into @keyframes body — keyframe selectors (from/to/%)
+            // are not scoped.
+            return;
+        }
+        svelte_css::visit::walk_at_rule_mut(self, node);
+    }
+
+    fn visit_declaration_mut(&mut self, node: &mut Declaration) {
+        if self.keyframes.is_empty() {
+            return;
+        }
+        let prop = node.property.source_text(self.source).trim();
+        let prop_lower = prop.to_ascii_lowercase();
+        let is_animation = prop_lower == "animation" || prop_lower == "animation-name";
+        if !is_animation {
+            return;
+        }
+        let value = node.value.source_text(self.source);
+        let rewritten = rewrite_animation_value(value, &self.hash_class, self.keyframes);
+        if let Some(rewritten) = rewritten {
+            node.value_override = Some(rewritten);
+        }
+    }
 }
 
-impl ScopeSelectors {
+/// Scan an `animation` or `animation-name` value token by token, replacing
+/// tokens that match a locally-scoped keyframe name with the hash-prefixed form.
+///
+/// Returns `Some(rewritten)` if any replacement was made, `None` otherwise.
+fn rewrite_animation_value(
+    value: &str,
+    hash_class: &str,
+    keyframes: &[CompactString],
+) -> Option<String> {
+    let mut result = String::with_capacity(value.len() + 32);
+    let mut changed = false;
+    let bytes = value.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        let b = bytes[i];
+        // Accumulate non-name characters (whitespace, commas, semicolons)
+        if b.is_ascii_whitespace() || b == b',' {
+            result.push(b as char);
+            i += 1;
+            continue;
+        }
+        // Accumulate a CSS name token
+        let start = i;
+        while i < len && !bytes[i].is_ascii_whitespace() && bytes[i] != b',' && bytes[i] != b';' {
+            i += 1;
+        }
+        let token = &value[start..i];
+        if keyframes.iter().any(|k| k.as_str() == token) {
+            result.push_str(hash_class);
+            result.push('-');
+            result.push_str(token);
+            changed = true;
+        } else {
+            result.push_str(token);
+        }
+    }
+
+    changed.then_some(result)
+}
+
+impl ScopeSelectors<'_> {
     fn scope_class(&self) -> SimpleSelector {
         SimpleSelector::Class {
             span: Span::new(0, 0),
@@ -229,7 +312,7 @@ mod tests {
     fn scope_type_selector() {
         let source = "p { color: red; }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(result.contains("p.svelte-abc123"), "got: {result}");
     }
 
@@ -237,7 +320,7 @@ mod tests {
     fn global_not_scoped() {
         let source = ":global(.foo) { color: red; }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(!result.contains("svelte-abc123"), "global should not be scoped, got: {result}");
         assert!(result.contains(".foo"), "got: {result}");
     }
@@ -246,7 +329,7 @@ mod tests {
     fn mixed_global_and_local() {
         let source = "p:global(.active) { font-weight: bold; }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(result.contains("p.svelte-abc123.active"), "got: {result}");
     }
 
@@ -254,7 +337,7 @@ mod tests {
     fn global_block_not_scoped() {
         let source = ":global { p { color: red; } }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(
             !result.contains("svelte-abc123"),
             "global block inner rules should not be scoped, got: {result}"
@@ -267,7 +350,7 @@ mod tests {
     fn global_block_multiple_inner_rules() {
         let source = ":global { .foo { color: red; } .bar { font-size: 16px; } }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(!result.contains("svelte-abc123"), "got: {result}");
         assert!(result.contains(".foo"), "got: {result}");
         assert!(result.contains(".bar"), "got: {result}");
@@ -278,7 +361,7 @@ mod tests {
     fn global_block_mixed_with_local() {
         let source = ":global { p { color: red; } }\ndiv { font-size: 16px; }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(
             !result.contains("p.svelte-abc123"),
             "p should not be scoped, got: {result}"
@@ -293,7 +376,7 @@ mod tests {
     fn global_block_in_media() {
         let source = "@media (min-width: 768px) { :global { p { color: red; } } }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(!result.contains("svelte-abc123"), "got: {result}");
         assert!(result.contains("p"), "got: {result}");
         assert!(!result.contains(":global"), "got: {result}");
@@ -303,7 +386,7 @@ mod tests {
     fn global_block_nested_in_style_rule() {
         let source = ".foo { :global { .bar { color: red; } } }";
         let (ss, _) = svelte_css::parse(source);
-        let result = transform_css("svelte-abc123", ss, source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
         assert!(
             result.contains(".foo.svelte-abc123"),
             ".foo should be scoped, got: {result}"
@@ -311,6 +394,80 @@ mod tests {
         assert!(
             !result.contains(".bar.svelte-abc123"),
             ".bar should not be scoped, got: {result}"
+        );
+    }
+
+    #[test]
+    fn scope_keyframes_basic() {
+        let source = "@keyframes bounce { from { opacity: 0; } to { opacity: 1; } }";
+        let keyframes = vec![CompactString::new("bounce")];
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &keyframes, ss, source);
+        assert!(
+            result.contains("@keyframes svelte-abc123-bounce"),
+            "keyframe name should be scoped, got: {result}"
+        );
+    }
+
+    #[test]
+    fn keyframes_global_escape() {
+        let source = "@keyframes -global-slide { from { opacity: 0; } to { opacity: 1; } }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
+        assert!(
+            result.contains("@keyframes slide"),
+            "-global- prefix should be stripped, got: {result}"
+        );
+        assert!(
+            !result.contains("-global-"),
+            "-global- should not appear in output, got: {result}"
+        );
+        assert!(
+            !result.contains("svelte-abc123-slide"),
+            "global keyframe should not be scoped, got: {result}"
+        );
+    }
+
+    #[test]
+    fn animation_value_rewritten() {
+        let source = ".foo { animation: bounce 2s ease; }";
+        let keyframes = vec![CompactString::new("bounce")];
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &keyframes, ss, source);
+        assert!(
+            result.contains("svelte-abc123-bounce 2s ease"),
+            "animation value should reference scoped keyframe, got: {result}"
+        );
+    }
+
+    #[test]
+    fn animation_name_rewritten() {
+        let source = ".foo { animation-name: bounce, other; }";
+        let keyframes = vec![CompactString::new("bounce")];
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &keyframes, ss, source);
+        assert!(
+            result.contains("svelte-abc123-bounce"),
+            "matching keyframe should be rewritten, got: {result}"
+        );
+        assert!(
+            result.contains(", other"),
+            "non-matching name should be preserved, got: {result}"
+        );
+    }
+
+    #[test]
+    fn keyframes_in_global_block_untouched() {
+        let source = ":global { @keyframes slide { from { opacity: 0; } to { opacity: 1; } } }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
+        assert!(
+            result.contains("@keyframes slide"),
+            "keyframes in :global block should stay unscoped, got: {result}"
+        );
+        assert!(
+            !result.contains("svelte-abc123-slide"),
+            "should not be scoped, got: {result}"
         );
     }
 }

--- a/specs/css-pipeline.md
+++ b/specs/css-pipeline.md
@@ -7,7 +7,8 @@
 - **Working**: `:global { ... }` block form — lone `:global` blocks hoisted at transform time (inner rules promoted unscoped to parent level). Works at top level, inside `@media`/`@supports`, and nested inside style rules. Analyze pass skips type selector collection for global blocks. Test: `css_global_block`.
 - **Partial**: nested `<style>` elements likely compile as plain DOM elements, but no focused compiler case proves "unscoped, inserted as-is" parity.
 - **Missing**: `:global .foo { ... }` compound form (non-lone), `:global()` inside `:not()`/`:is()`/`:where()`, `:global()` validation diagnostics, `@keyframes` scoping, unused-selector warnings, CSS custom properties.
-- **Next**: Port `:global .foo { ... }` compound form or `@keyframes` scoping.
+- **Done**: Scoped `@keyframes` + `-global-` escape — keyframe names prefixed with hash, `-global-` prefix stripped, `animation`/`animation-name` values rewritten.
+- **Next**: Port `:global .foo { ... }` compound form or `:global()` inside `:not()`/`:is()`/`:where()`.
 - **Known debt**: `has_global_component` is duplicated between `svelte_analyze` and `svelte_transform_css` — to be resolved when `:global()` work makes the function non-trivial.
 - Last updated: 2026-04-06
 
@@ -41,7 +42,7 @@ ROADMAP.md — CSS
 - [x] `:global { ... }` block form transform (test: `css_global_block`)
 - [ ] `:global()` inside `:not()`, `:is()`, `:where()` — currently unvisited (visitor declares SELECTORS only, not PSEUDO_CLASSES; nested selectors inside functional pseudo-classes silently pass through)
 - [ ] `:global()` validation diagnostics
-- [ ] Scoped `@keyframes` plus `-global-*` escape
+- [x] Scoped `@keyframes` plus `-global-*` escape (test: `css_keyframes_scoped`)
 - [ ] CSS comments preserved in output — lightningcss drops comments during AST parsing; reference compiler preserves them via MagicString text manipulation
 - [ ] Unused selector warning (`css_unused_selector`)
 - [ ] CSS custom properties on components — `<svelte-css-wrapper>` / `<g>` wrapper lowering for `--prop=...`
@@ -85,3 +86,4 @@ ROADMAP.md — CSS
 - [x] `css_injected`
 - [x] `css_injected_via_compile_options`
 - [x] `css_global_block`
+- [x] `css_keyframes_scoped`

--- a/tasks/compiler_tests/cases2/css_keyframes_scoped/case-rust.css
+++ b/tasks/compiler_tests/cases2/css_keyframes_scoped/case-rust.css
@@ -1,0 +1,17 @@
+@keyframes svelte-13q9pxc-bounce {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+@keyframes slide {
+		from { transform: translateX(-100%); }
+		to { transform: translateX(0); }
+	}
+
+p.svelte-13q9pxc {
+  animation: svelte-13q9pxc-bounce 2s ease;
+}
+
+div.svelte-13q9pxc {
+  animation-name: svelte-13q9pxc-bounce, slide;
+}

--- a/tasks/compiler_tests/cases2/css_keyframes_scoped/case-rust.js
+++ b/tasks/compiler_tests/cases2/css_keyframes_scoped/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p class="svelte-13q9pxc">animated</p> <div class="svelte-13q9pxc">also animated</div>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(2);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/css_keyframes_scoped/case-svelte.css
+++ b/tasks/compiler_tests/cases2/css_keyframes_scoped/case-svelte.css
@@ -1,0 +1,18 @@
+
+	@keyframes svelte-13q9pxc-bounce {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes slide {
+		from { transform: translateX(-100%); }
+		to { transform: translateX(0); }
+	}
+
+	p.svelte-13q9pxc {
+		animation: svelte-13q9pxc-bounce 2s ease;
+	}
+
+	div.svelte-13q9pxc {
+		animation-name: svelte-13q9pxc-bounce, slide;
+	}

--- a/tasks/compiler_tests/cases2/css_keyframes_scoped/case-svelte.js
+++ b/tasks/compiler_tests/cases2/css_keyframes_scoped/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p class="svelte-13q9pxc">animated</p> <div class="svelte-13q9pxc">also animated</div>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(2);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/css_keyframes_scoped/case.svelte
+++ b/tasks/compiler_tests/cases2/css_keyframes_scoped/case.svelte
@@ -1,0 +1,22 @@
+<style>
+	@keyframes bounce {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes -global-slide {
+		from { transform: translateX(-100%); }
+		to { transform: translateX(0); }
+	}
+
+	p {
+		animation: bounce 2s ease;
+	}
+
+	div {
+		animation-name: bounce, slide;
+	}
+</style>
+
+<p>animated</p>
+<div>also animated</div>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -169,6 +169,11 @@ fn css_global_block() {
 }
 
 #[rstest]
+fn css_keyframes_scoped() {
+    assert_compiler("css_keyframes_scoped");
+}
+
+#[rstest]
 fn head_position_with_body() {
     assert_compiler("head_position_with_body");
 }


### PR DESCRIPTION
## Summary
Implement scoping for CSS `@keyframes` declarations and their corresponding `animation`/`animation-name` property values. Local keyframes are now prefixed with the component hash, while keyframes marked with the `-global-` prefix escape scoping.

## Key Changes

- **CSS Analysis Pass**: Added `collect_keyframe_names()` to identify locally-scoped `@keyframes` (those without `-global-` prefix), skipping keyframes inside `:global { }` blocks. Results stored in `CssAnalysis.keyframes`.

- **CSS Transform**: 
  - Extended `ScopeSelectors` to handle `@keyframes` via `visit_at_rule_mut()`: prefixes local keyframe names with component hash, strips `-global-` prefix for global keyframes
  - Added `visit_declaration_mut()` to rewrite `animation` and `animation-name` property values, replacing matching keyframe names with their hash-prefixed equivalents
  - Implemented `rewrite_animation_value()` to parse animation values token-by-token and selectively rewrite keyframe name references

- **CSS Printer**: 
  - Added `prelude_override` and `value_override` fields to `AtRule` and `Declaration` AST nodes to allow transforms to override serialized output
  - Special handling for `@keyframes` blocks: preserves original source formatting (via `push_span`) instead of reformatting, since internal keyframe selectors (from/to/%) are never transformed

- **Test Coverage**: Added comprehensive test cases covering:
  - Basic keyframe scoping
  - `-global-` escape mechanism
  - Animation value rewriting for both `animation` and `animation-name` properties
  - Keyframes inside `:global` blocks (remain unscoped)
  - New compiler test case `css_keyframes_scoped` with expected output files

## Implementation Details

- Keyframe collection respects `:global { }` block boundaries—keyframes declared inside global blocks are not collected for scoping
- Animation value parsing is whitespace/comma-aware to correctly handle comma-separated animation names
- The `-global-` prefix is stripped entirely from output (e.g., `-global-slide` becomes `slide`, not `svelte-hash-slide`)
- Keyframe body formatting is preserved as-is since the internal structure (percentage stops, from/to keywords) requires no transformation

https://claude.ai/code/session_01U8z4zFs1QHjmLvwpBK7mVS