### PR TITLE
Support :global() inside :not()/:is()/:where()/:has() pseudo-classes

### DIFF
--- a/crates/svelte_transform_css/src/lib.rs
+++ b/crates/svelte_transform_css/src/lib.rs
@@ -127,12 +127,28 @@ impl VisitMut for ScopeSelectors<'_> {
                         has_non_global_scopable = true;
                     }
                     new_selectors.push(sel);
+                    // Recurse into pseudo-class args (e.g. :not(), :is(), :where(), :has())
+                    // so that :global() inside them is unwrapped and inner selectors are scoped.
+                    if let Some(last) = new_selectors.last_mut() {
+                        self.visit_simple_selector_mut(last);
+                    }
                 }
             }
         }
 
         if has_non_global_scopable && !scope_inserted {
-            new_selectors.push(self.scope_class());
+            // Insert scope class before trailing pseudo-class/pseudo-element selectors,
+            // matching the reference compiler which walks backwards to find insertion point.
+            let mut insert_pos = new_selectors.len();
+            while insert_pos > 0 {
+                match &new_selectors[insert_pos - 1] {
+                    SimpleSelector::PseudoClass(_) | SimpleSelector::PseudoElement(_) => {
+                        insert_pos -= 1;
+                    }
+                    _ => break,
+                }
+            }
+            new_selectors.insert(insert_pos, self.scope_class());
         }
 
         node.selectors = new_selectors.into();
@@ -154,6 +170,20 @@ impl VisitMut for ScopeSelectors<'_> {
             return;
         }
         svelte_css::visit::walk_at_rule_mut(self, node);
+    }
+
+    fn visit_simple_selector_mut(&mut self, node: &mut SimpleSelector) {
+        // Recurse into :is(), :where(), :has(), :not() arguments so that
+        // :global() inside them is unwrapped and non-global selectors are scoped.
+        // Mirrors reference compiler PseudoClassSelector visitor.
+        if let SimpleSelector::PseudoClass(pc) = node {
+            match pc.name.as_str() {
+                "is" | "where" | "has" | "not" => {
+                    svelte_css::visit::walk_simple_selector_args_mut(self, node);
+                }
+                _ => {}
+            }
+        }
     }
 
     fn visit_declaration_mut(&mut self, node: &mut Declaration) {
@@ -453,6 +483,62 @@ mod tests {
         assert!(
             result.contains(", other"),
             "non-matching name should be preserved, got: {result}"
+        );
+    }
+
+    #[test]
+    fn global_inside_not() {
+        let source = "p:not(:global(.active)) { color: red; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
+        assert!(
+            result.contains("p.svelte-abc123:not(.active)"),
+            ":global() inside :not() should be unwrapped, got: {result}"
+        );
+        assert!(
+            !result.contains(":global"),
+            ":global should be removed, got: {result}"
+        );
+    }
+
+    #[test]
+    fn global_inside_is() {
+        let source = ":is(:global(.foo), .bar) { color: red; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
+        assert!(
+            result.contains(".foo"),
+            ":global(.foo) should be unwrapped to .foo, got: {result}"
+        );
+        assert!(
+            result.contains(".bar.svelte-abc123"),
+            ".bar should be scoped, got: {result}"
+        );
+        assert!(
+            !result.contains(":global"),
+            ":global should be removed, got: {result}"
+        );
+    }
+
+    #[test]
+    fn global_inside_where() {
+        let source = "p:where(:global(.x)) { color: red; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
+        assert!(
+            result.contains("p.svelte-abc123:where(.x)"),
+            ":global() inside :where() should be unwrapped, got: {result}"
+        );
+    }
+
+    #[test]
+    fn scoped_inside_not() {
+        let source = "p:not(.active) { color: red; }";
+        let (ss, _) = svelte_css::parse(source);
+        let result = transform_css("svelte-abc123", &[], ss, source);
+        assert!(
+            result.contains("p.svelte-abc123:not(.active.svelte-abc123)"),
+            "selectors inside :not() should be scoped, got: {result}"
         );
     }
 

--- a/specs/css-pipeline.md
+++ b/specs/css-pipeline.md
@@ -6,10 +6,12 @@
 - **Working**: `:global(.foo)` functional form — AST-level stripping of pseudo-class wrapper, mixed selectors (`p :global(.bar)`) scope outer LocalName correctly. Test: `css_global_basic`.
 - **Working**: `:global { ... }` block form — lone `:global` blocks hoisted at transform time (inner rules promoted unscoped to parent level). Works at top level, inside `@media`/`@supports`, and nested inside style rules. Analyze pass skips type selector collection for global blocks. Test: `css_global_block`.
 - **Partial**: nested `<style>` elements likely compile as plain DOM elements, but no focused compiler case proves "unscoped, inserted as-is" parity.
-- **Missing**: `:global .foo { ... }` compound form (non-lone), `:global()` inside `:not()`/`:is()`/`:where()`, `:global()` validation diagnostics, `@keyframes` scoping, unused-selector warnings, CSS custom properties.
+- **Missing**: `:global .foo { ... }` compound form (non-lone), `:global()` validation diagnostics, unused-selector warnings, CSS custom properties.
 - **Done**: Scoped `@keyframes` + `-global-` escape — keyframe names prefixed with hash, `-global-` prefix stripped, `animation`/`animation-name` values rewritten.
-- **Next**: Port `:global .foo { ... }` compound form or `:global()` inside `:not()`/`:is()`/`:where()`.
+- **Done**: `:global()` inside `:not()`/`:is()`/`:where()`/`:has()` — visitor recurses into pseudo-class args, unwraps `:global()` and scopes non-global selectors. Also fixed scope class insertion position to go before trailing pseudo-classes (matching reference compiler). Test: `css_global_in_pseudo`.
+- **Next**: Port `:global .foo { ... }` compound form or `:global()` validation diagnostics.
 - **Known debt**: `has_global_component` is duplicated between `svelte_analyze` and `svelte_transform_css` — to be resolved when `:global()` work makes the function non-trivial.
+- **Current slice**: completed `:global()` inside pseudo-classes
 - Last updated: 2026-04-06
 
 ## Source
@@ -40,7 +42,7 @@ ROADMAP.md — CSS
 - [x] `css: "injected"` output — `const $$css = { hash, code }` hoisted module-level const + `$.append_styles($$anchor, $$css)` as first statement in component body (tests: `css_injected`, `css_injected_via_compile_options`)
 - [x] `:global(.foo)` functional form — strip wrapper, scope outer LocalName (test: `css_global_basic`)
 - [x] `:global { ... }` block form transform (test: `css_global_block`)
-- [ ] `:global()` inside `:not()`, `:is()`, `:where()` — currently unvisited (visitor declares SELECTORS only, not PSEUDO_CLASSES; nested selectors inside functional pseudo-classes silently pass through)
+- [x] `:global()` inside `:not()`, `:is()`, `:where()`, `:has()` — visitor recurses into pseudo-class args (test: `css_global_in_pseudo`)
 - [ ] `:global()` validation diagnostics
 - [x] Scoped `@keyframes` plus `-global-*` escape (test: `css_keyframes_scoped`)
 - [ ] CSS comments preserved in output — lightningcss drops comments during AST parsing; reference compiler preserves them via MagicString text manipulation
@@ -87,3 +89,4 @@ ROADMAP.md — CSS
 - [x] `css_injected_via_compile_options`
 - [x] `css_global_block`
 - [x] `css_keyframes_scoped`
+- [x] `css_global_in_pseudo`

--- a/tasks/compiler_tests/cases2/css_global_in_pseudo/case-rust.css
+++ b/tasks/compiler_tests/cases2/css_global_in_pseudo/case-rust.css
@@ -1,0 +1,11 @@
+p.svelte-1rk0dqc:not(.active) {
+  color: red;
+}
+
+:is(.foo, .bar.svelte-1rk0dqc) {
+  font-weight: bold;
+}
+
+div.svelte-1rk0dqc:where(.x) {
+  margin: 0;
+}

--- a/tasks/compiler_tests/cases2/css_global_in_pseudo/case-rust.js
+++ b/tasks/compiler_tests/cases2/css_global_in_pseudo/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p class="svelte-1rk0dqc">content</p> <p class="bar svelte-1rk0dqc">bar</p> <div class="svelte-1rk0dqc">box</div>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(4);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/css_global_in_pseudo/case-svelte.css
+++ b/tasks/compiler_tests/cases2/css_global_in_pseudo/case-svelte.css
@@ -1,0 +1,10 @@
+
+	p.svelte-1rk0dqc:not(.active) {
+		color: red;
+	}
+	:is(.foo, .bar.svelte-1rk0dqc) {
+		font-weight: bold;
+	}
+	div.svelte-1rk0dqc:where(.x) {
+		margin: 0;
+	}

--- a/tasks/compiler_tests/cases2/css_global_in_pseudo/case-svelte.js
+++ b/tasks/compiler_tests/cases2/css_global_in_pseudo/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p class="svelte-1rk0dqc">content</p> <p class="bar svelte-1rk0dqc">bar</p> <div class="svelte-1rk0dqc">box</div>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(4);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/css_global_in_pseudo/case.svelte
+++ b/tasks/compiler_tests/cases2/css_global_in_pseudo/case.svelte
@@ -1,0 +1,14 @@
+<style>
+	p:not(:global(.active)) {
+		color: red;
+	}
+	:is(:global(.foo), .bar) {
+		font-weight: bold;
+	}
+	div:where(:global(.x)) {
+		margin: 0;
+	}
+</style>
+<p>content</p>
+<p class="bar">bar</p>
+<div>box</div>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -169,6 +169,11 @@ fn css_global_block() {
 }
 
 #[rstest]
+fn css_global_in_pseudo() {
+    assert_compiler("css_global_in_pseudo");
+}
+
+#[rstest]
 fn css_keyframes_scoped() {
     assert_compiler("css_keyframes_scoped");
 }


### PR DESCRIPTION
The CSS transform now recurses into pseudo-class arguments for :is, :where,
:has, and :not, unwrapping :global() and scoping non-global selectors inside
them. Also fixes scope class insertion to go before trailing pseudo-classes,
matching the reference compiler's placement.

https://claude.ai/code/session_01RHYqsaSV1eFJERvpeahK9d