### PR TITLE
Add CSS validation for :global() usage and emit diagnostics

### DIFF
--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -5,6 +5,7 @@ use svelte_css::{
     SimpleSelector, StyleRule, StyleSheet, Visit,
 };
 use svelte_diagnostics::Diagnostic;
+use svelte_diagnostics::DiagnosticKind;
 use svelte_span::GetSpan;
 
 use svelte_ast::{AstStore, Component as SvelteComponent, Fragment, Node};
@@ -207,8 +208,6 @@ fn is_unscoped_pseudo_class(sel: &SimpleSelector) -> bool {
 // ---------------------------------------------------------------------------
 // CSS validation — `:global()` diagnostics
 // ---------------------------------------------------------------------------
-
-use svelte_diagnostics::DiagnosticKind;
 
 /// Per-rule context tracked on the validator's stack.
 struct RuleContext {
@@ -414,42 +413,40 @@ impl<'a> CssValidator<'a> {
             }
         }
 
-        // Validate `:global(...)` args in each relative selector
+        // Validate `:global(...)` / `:global` args in each relative selector
         for rel in &node.children {
             for (i, sel) in rel.selectors.iter().enumerate() {
                 let (args, span) = match sel {
-                    SimpleSelector::Global {
-                        args: Some(args),
-                        span,
-                        ..
-                    } => (args, span),
+                    SimpleSelector::Global { args, span, .. } => (args, span),
                     _ => continue,
                 };
 
-                // `:global(element)` must be at position 0 in compound
-                if let Some(first_type_sel) = args
-                    .children
-                    .first()
-                    .and_then(|c| c.children.first())
-                    .and_then(|r| r.selectors.first())
-                {
-                    if matches!(first_type_sel, SimpleSelector::Type { .. }) && i != 0 {
-                        self.emit(DiagnosticKind::CssGlobalInvalidSelectorList, *span);
+                if let Some(args) = args {
+                    // `:global(element)` must be at position 0 in compound
+                    if let Some(first_type_sel) = args
+                        .children
+                        .first()
+                        .and_then(|c| c.children.first())
+                        .and_then(|r| r.selectors.first())
+                    {
+                        if matches!(first_type_sel, SimpleSelector::Type { .. }) && i != 0 {
+                            self.emit(DiagnosticKind::CssGlobalInvalidSelectorList, *span);
+                        }
+                    }
+
+                    // `:global(...)` must contain exactly one selector in compound context
+                    if args.children.len() > 1
+                        && (node.children.len() > 1 || rel.selectors.len() > 1)
+                    {
+                        self.emit(DiagnosticKind::CssGlobalInvalidSelector, *span);
                     }
                 }
 
-                // `:global(.class)` must not be followed by a type selector
+                // `:global(...)` or bare `:global` must not be followed by a type selector
                 if let Some(next) = rel.selectors.get(i + 1) {
                     if matches!(next, SimpleSelector::Type { .. }) {
                         self.emit(DiagnosticKind::CssTypeSelectorInvalidPlacement, next.span());
                     }
-                }
-
-                // `:global(...)` must contain exactly one selector in compound context
-                if args.children.len() > 1
-                    && (node.children.len() > 1 || rel.selectors.len() > 1)
-                {
-                    self.emit(DiagnosticKind::CssGlobalInvalidSelector, *span);
                 }
             }
         }

--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -404,11 +404,11 @@ impl<'a> CssValidator<'a> {
             } = &global_rel.selectors[0]
             {
                 if idx != 0 && idx != node.children.len() - 1 {
-                    let has_non_global_after = node.children[idx + 1..]
-                        .iter()
-                        .any(|r| !is_global_relative_selector(r));
-                    if has_non_global_after {
-                        self.emit(DiagnosticKind::CssGlobalInvalidPlacement, *span);
+                    // Emit once per non-global child after the global one
+                    for r in &node.children[idx + 1..] {
+                        if !is_global_relative_selector(r) {
+                            self.emit(DiagnosticKind::CssGlobalInvalidPlacement, *span);
+                        }
                     }
                 }
             }
@@ -654,6 +654,17 @@ mod tests {
             ".a :global(.b) .c { color: red; }",
             DiagnosticKind::CssGlobalInvalidPlacement,
         );
+    }
+
+    #[test]
+    fn css_global_invalid_placement_multiple_non_global_after() {
+        // Reference emits once per non-global child after the global
+        let kinds = validate_css(".a :global(.b) .c .d { color: red; }");
+        let count = kinds
+            .iter()
+            .filter(|k| matches!(k, DiagnosticKind::CssGlobalInvalidPlacement))
+            .count();
+        assert_eq!(count, 2, "expected 2 emissions for .c and .d, got {count}");
     }
 
     #[test]

--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -1,8 +1,11 @@
 use compact_str::CompactString;
 use rustc_hash::FxHashSet;
 use svelte_css::{
-    AtRule, ComplexSelector, RelativeSelector, SimpleSelector, StyleRule, StyleSheet, Visit,
+    AtRule, Block, BlockChild, CombinatorKind, ComplexSelector, RelativeSelector, SelectorList,
+    SimpleSelector, StyleRule, StyleSheet, Visit,
 };
+use svelte_diagnostics::Diagnostic;
+use svelte_span::GetSpan;
 
 use svelte_ast::{AstStore, Component as SvelteComponent, Fragment, Node};
 
@@ -11,6 +14,7 @@ use crate::types::data::{AnalysisData, CssAnalysis};
 use crate::types::node_table::NodeBitSet;
 
 /// Classify the CSS block: compute hash, mark scoped template elements, set inject flag.
+/// Also validates CSS and emits diagnostics for invalid `:global()` usage.
 ///
 /// Does NOT transform or serialize CSS — call `svelte_transform_css::transform_css` for that.
 pub fn analyze_css_pass(
@@ -18,6 +22,7 @@ pub fn analyze_css_pass(
     stylesheet: &StyleSheet,
     inject_styles: bool,
     data: &mut AnalysisData,
+    diagnostics: &mut Vec<Diagnostic>,
 ) {
     let Some(css_block) = &component.css else {
         return;
@@ -35,6 +40,10 @@ pub fn analyze_css_pass(
     let node_count = component.node_count();
     let mut scoped = NodeBitSet::new(node_count);
     mark_scoped_elements(&component.fragment, &component.store, &selected_tags, &mut scoped);
+
+    // Phase 3: validate CSS (:global usage, nesting selectors, etc.)
+    let mut validator = CssValidator::new(diagnostics);
+    validator.visit_stylesheet(stylesheet);
 
     data.css = CssAnalysis {
         hash,
@@ -135,6 +144,416 @@ fn has_global_selector(complex: &ComplexSelector) -> bool {
     })
 }
 
+/// True if the `SimpleSelector` is `:global` (block form, no args).
+fn is_global_block_selector(sel: &SimpleSelector) -> bool {
+    matches!(sel, SimpleSelector::Global { args: None, .. })
+}
+
+/// True if a `RelativeSelector` is `:global(...)` or `:global` and all other
+/// selectors in the compound are unscoped pseudo-classes or pseudo-elements.
+/// Matches the reference compiler's `is_global()` from `css/utils.js`.
+fn is_global_relative_selector(rel: &RelativeSelector) -> bool {
+    let Some(first) = rel.selectors.first() else {
+        return false;
+    };
+    match first {
+        SimpleSelector::Global { args, .. } => {
+            if args.is_none() {
+                // `:global` block selector — counts as global
+                return true;
+            }
+            // `:global(...)` — only global if all siblings are unscoped pseudo-classes/pseudo-elements
+            rel.selectors.iter().all(|s| match s {
+                SimpleSelector::PseudoElement(_) => true,
+                SimpleSelector::PseudoClass(_) => is_unscoped_pseudo_class(s),
+                SimpleSelector::Global { .. } => true,
+                _ => false,
+            })
+        }
+        _ => false,
+    }
+}
+
+/// True if the pseudo-class cannot be scoped (matches reference `is_unscoped_pseudo_class`).
+fn is_unscoped_pseudo_class(sel: &SimpleSelector) -> bool {
+    let SimpleSelector::PseudoClass(pc) = sel else {
+        return false;
+    };
+    let name = pc.name.as_str();
+    // These pseudo-classes make the selector scoped
+    if name == "has" || name == "is" || name == "where" {
+        // ...unless all their children are global
+        return pc.args.as_ref().map_or(true, |args| {
+            args.children
+                .iter()
+                .all(|c| c.children.iter().all(|r| is_global_relative_selector(r)))
+        });
+    }
+    if name == "not" {
+        // :not is special: unscoped unless it has multiple selectors in args
+        // (e.g. :not(.x .y) should be scoped, :not(.x) is unscoped)
+        return pc.args.as_ref().map_or(true, |args| {
+            args.children.iter().all(|c| c.children.len() == 1)
+                || args
+                    .children
+                    .iter()
+                    .all(|c| c.children.iter().all(|r| is_global_relative_selector(r)))
+        });
+    }
+    // All other pseudo-classes are unscoped
+    true
+}
+
+// ---------------------------------------------------------------------------
+// CSS validation — `:global()` diagnostics
+// ---------------------------------------------------------------------------
+
+use svelte_diagnostics::DiagnosticKind;
+
+/// Per-rule context tracked on the validator's stack.
+struct RuleContext {
+    /// Whether this rule has been classified as a `:global` block.
+    is_global_block: bool,
+    /// Whether this rule has a parent rule (i.e. is nested).
+    has_parent_rule: bool,
+    /// Whether the parent rule is a lone top-level `:global` block
+    /// (needed for `&` validation inside `:global { &.foo { ... } }`).
+    parent_is_lone_global_block: bool,
+    /// True if this rule's prelude is exactly `:global(&)`.
+    is_lone_global_with_nesting_arg: bool,
+}
+
+struct CssValidator<'a> {
+    diagnostics: &'a mut Vec<Diagnostic>,
+    /// Stack of parent style rules (innermost last).
+    rule_stack: Vec<RuleContext>,
+    /// Whether we're currently inside a pseudo-class selector's args.
+    in_pseudo_class: bool,
+}
+
+impl<'a> CssValidator<'a> {
+    fn new(diagnostics: &'a mut Vec<Diagnostic>) -> Self {
+        Self {
+            diagnostics,
+            rule_stack: Vec::new(),
+            in_pseudo_class: false,
+        }
+    }
+
+    fn current_rule(&self) -> Option<&RuleContext> {
+        self.rule_stack.last()
+    }
+
+    fn emit(&mut self, kind: DiagnosticKind, span: svelte_span::Span) {
+        self.diagnostics.push(Diagnostic::error(kind, span));
+    }
+
+    /// Validate and traverse a style rule.
+    /// Ported from the `Rule` visitor in `css-analyze.js`.
+    fn validate_rule(&mut self, rule: &StyleRule) {
+        let has_parent = !self.rule_stack.is_empty();
+        let mut rule_is_global_block = false;
+        let mut first_complex = true;
+
+        for complex_selector in &rule.prelude.children {
+            let mut is_global_block = false;
+
+            for (selector_idx, child) in complex_selector.children.iter().enumerate() {
+                let global_pos = child
+                    .selectors
+                    .iter()
+                    .position(is_global_block_selector);
+
+                if let Some(idx) = global_pos {
+                    if idx == 0 {
+                        if child.selectors.len() > 1 && selector_idx == 0 && !has_parent {
+                            // `:global.foo { ... }` at top level — modifier not allowed
+                            self.emit(
+                                DiagnosticKind::CssGlobalBlockInvalidModifierStart,
+                                child.selectors[1].span(),
+                            );
+                        } else {
+                            is_global_block = true;
+
+                            // `:global` can only follow descendant combinator
+                            if let Some(ref comb) = child.combinator {
+                                if comb.kind != CombinatorKind::Descendant {
+                                    self.emit(
+                                        DiagnosticKind::CssGlobalBlockInvalidCombinator {
+                                            name: comb.kind.as_str().to_string(),
+                                        },
+                                        child.span,
+                                    );
+                                }
+                            }
+
+                            let is_lone_global = complex_selector.children.len() == 1
+                                && complex_selector.children[0].selectors.len() == 1;
+
+                            if is_lone_global && rule.prelude.children.len() > 1 {
+                                self.emit(
+                                    DiagnosticKind::CssGlobalBlockInvalidList,
+                                    rule.prelude.span,
+                                );
+                            }
+
+                            if is_lone_global
+                                && rule.prelude.children.len() == 1
+                                && has_declaration(&rule.block)
+                            {
+                                let decl_span = rule
+                                    .block
+                                    .children
+                                    .iter()
+                                    .find_map(|c| match c {
+                                        BlockChild::Declaration(d) => Some(d.span),
+                                        _ => None,
+                                    })
+                                    .unwrap();
+                                self.emit(
+                                    DiagnosticKind::CssGlobalBlockInvalidDeclaration,
+                                    decl_span,
+                                );
+                            }
+                        }
+                    } else {
+                        // `:global` not at position 0 — modifying an existing selector
+                        self.emit(
+                            DiagnosticKind::CssGlobalBlockInvalidModifier,
+                            child.selectors[idx].span(),
+                        );
+                    }
+                }
+            }
+
+            if rule_is_global_block && !is_global_block {
+                self.emit(
+                    DiagnosticKind::CssGlobalBlockInvalidList,
+                    rule.prelude.span,
+                );
+            }
+
+            if first_complex {
+                rule_is_global_block = is_global_block;
+            }
+            first_complex = false;
+        }
+
+        // Compute context for child rules
+        let parent_is_lone_global_block = if has_parent {
+            self.current_rule()
+                .map_or(false, |r| r.is_global_block && !r.has_parent_rule)
+        } else {
+            false
+        };
+
+        let is_lone_global_with_nesting_arg = rule.prelude.children.len() == 1
+            && rule.prelude.children[0].children.len() == 1
+            && rule.prelude.children[0].children[0].selectors.len() == 1
+            && matches!(
+                &rule.prelude.children[0].children[0].selectors[0],
+                SimpleSelector::Global { args: Some(args), .. }
+                if is_nesting_in_global_args(args)
+            );
+
+        self.rule_stack.push(RuleContext {
+            is_global_block: rule_is_global_block,
+            has_parent_rule: has_parent,
+            parent_is_lone_global_block,
+            is_lone_global_with_nesting_arg,
+        });
+
+        // Visit prelude then block
+        self.visit_selector_list(&rule.prelude);
+        self.visit_block(&rule.block);
+
+        self.rule_stack.pop();
+    }
+
+    /// Validate a complex selector for `:global(...)` placement issues.
+    /// Ported from the `ComplexSelector` visitor in `css-analyze.js`.
+    fn validate_complex_selector(&mut self, node: &ComplexSelector) {
+        // Check `:global` block inside pseudo-class
+        if let Some(global_rel) = node
+            .children
+            .iter()
+            .find(|r| is_global_relative_selector(r))
+        {
+            if self.in_pseudo_class && is_global_block_selector_in_rel(global_rel) {
+                self.emit(
+                    DiagnosticKind::CssGlobalBlockInvalidPlacement,
+                    global_rel.selectors[0].span(),
+                );
+            }
+
+            // `:global(...)` not in middle unless all following are also global
+            let idx = node
+                .children
+                .iter()
+                .position(|r| is_global_relative_selector(r))
+                .unwrap();
+            if let SimpleSelector::Global {
+                args: Some(_),
+                span,
+                ..
+            } = &global_rel.selectors[0]
+            {
+                if idx != 0 && idx != node.children.len() - 1 {
+                    let has_non_global_after = node.children[idx + 1..]
+                        .iter()
+                        .any(|r| !is_global_relative_selector(r));
+                    if has_non_global_after {
+                        self.emit(DiagnosticKind::CssGlobalInvalidPlacement, *span);
+                    }
+                }
+            }
+        }
+
+        // Validate `:global(...)` args in each relative selector
+        for rel in &node.children {
+            for (i, sel) in rel.selectors.iter().enumerate() {
+                let (args, span) = match sel {
+                    SimpleSelector::Global {
+                        args: Some(args),
+                        span,
+                        ..
+                    } => (args, span),
+                    _ => continue,
+                };
+
+                // `:global(element)` must be at position 0 in compound
+                if let Some(first_type_sel) = args
+                    .children
+                    .first()
+                    .and_then(|c| c.children.first())
+                    .and_then(|r| r.selectors.first())
+                {
+                    if matches!(first_type_sel, SimpleSelector::Type { .. }) && i != 0 {
+                        self.emit(DiagnosticKind::CssGlobalInvalidSelectorList, *span);
+                    }
+                }
+
+                // `:global(.class)` must not be followed by a type selector
+                if let Some(next) = rel.selectors.get(i + 1) {
+                    if matches!(next, SimpleSelector::Type { .. }) {
+                        self.emit(DiagnosticKind::CssTypeSelectorInvalidPlacement, next.span());
+                    }
+                }
+
+                // `:global(...)` must contain exactly one selector in compound context
+                if args.children.len() > 1
+                    && (node.children.len() > 1 || rel.selectors.len() > 1)
+                {
+                    self.emit(DiagnosticKind::CssGlobalInvalidSelector, *span);
+                }
+            }
+        }
+    }
+
+    /// Validate nesting selector (`&`) placement.
+    /// Ported from the `NestingSelector` visitor in `css-analyze.js`.
+    fn validate_nesting_selector(&mut self, span: svelte_span::Span) {
+        let has_parent = self.current_rule().map_or(false, |r| r.has_parent_rule);
+
+        if !has_parent {
+            // `&` outside nested rule — only valid inside lone `:global(&)`
+            let valid = self
+                .current_rule()
+                .map_or(false, |r| r.is_lone_global_with_nesting_arg);
+            if !valid {
+                self.emit(DiagnosticKind::CssNestingSelectorInvalidPlacement, span);
+            }
+        } else {
+            // `:global { &.foo { ... } }` — `&` inside lone top-level global block is invalid
+            if self
+                .current_rule()
+                .map_or(false, |r| r.parent_is_lone_global_block)
+            {
+                self.emit(DiagnosticKind::CssGlobalBlockInvalidModifierStart, span);
+            }
+        }
+    }
+}
+
+/// True if the args of a `:global(...)` contain a single nesting selector `&`.
+fn is_nesting_in_global_args(args: &SelectorList) -> bool {
+    args.children
+        .first()
+        .and_then(|c| c.children.first())
+        .map_or(false, |r| {
+            r.selectors.len() == 1 && matches!(r.selectors[0], SimpleSelector::Nesting(_))
+        })
+}
+
+/// True if a `RelativeSelector` starts with `:global` (block form, no args).
+fn is_global_block_selector_in_rel(rel: &RelativeSelector) -> bool {
+    rel.selectors
+        .first()
+        .is_some_and(is_global_block_selector)
+}
+
+fn has_declaration(block: &Block) -> bool {
+    block
+        .children
+        .iter()
+        .any(|c| matches!(c, BlockChild::Declaration(_)))
+}
+
+impl Visit for CssValidator<'_> {
+    fn visit_style_rule(&mut self, node: &StyleRule) {
+        self.validate_rule(node);
+    }
+
+    fn visit_complex_selector(&mut self, node: &ComplexSelector) {
+        // Validate relative selectors (leading combinator), walk into them, then validate complex
+        for (i, child) in node.children.iter().enumerate() {
+            if i == 0
+                && child.combinator.is_some()
+                && !self.in_pseudo_class
+                && !self.current_rule().map_or(false, |r| r.has_parent_rule)
+            {
+                self.emit(
+                    DiagnosticKind::CssSelectorInvalid,
+                    child.combinator.as_ref().unwrap().span,
+                );
+            }
+            self.visit_relative_selector(child);
+        }
+        self.validate_complex_selector(node);
+    }
+
+    fn visit_relative_selector(&mut self, node: &RelativeSelector) {
+        for sel in &node.selectors {
+            self.visit_simple_selector(sel);
+        }
+    }
+
+    fn visit_simple_selector(&mut self, node: &SimpleSelector) {
+        match node {
+            SimpleSelector::Nesting(span) => {
+                self.validate_nesting_selector(*span);
+            }
+            SimpleSelector::PseudoClass(pc) => {
+                if let Some(args) = &pc.args {
+                    let prev = self.in_pseudo_class;
+                    self.in_pseudo_class = true;
+                    self.visit_selector_list(args);
+                    self.in_pseudo_class = prev;
+                }
+            }
+            SimpleSelector::Global {
+                args: Some(args), ..
+            } => {
+                let prev = self.in_pseudo_class;
+                self.in_pseudo_class = true;
+                self.visit_selector_list(args);
+                self.in_pseudo_class = prev;
+            }
+            _ => {}
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Mark scoped elements in the template
 // ---------------------------------------------------------------------------
@@ -184,5 +603,199 @@ fn mark_scoped_elements(
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use svelte_diagnostics::DiagnosticKind;
+
+    /// Parse CSS and run the validator, returning collected diagnostics.
+    fn validate_css(css: &str) -> Vec<DiagnosticKind> {
+        let (stylesheet, _parse_diags) = svelte_css::parse(css);
+        let mut diagnostics = Vec::new();
+        let mut validator = CssValidator::new(&mut diagnostics);
+        validator.visit_stylesheet(&stylesheet);
+        diagnostics.into_iter().map(|d| d.kind).collect()
+    }
+
+    fn assert_diagnostic(css: &str, expected: DiagnosticKind) {
+        let kinds = validate_css(css);
+        assert!(
+            kinds.contains(&expected),
+            "Expected diagnostic {expected:?} for CSS:\n  {css}\nGot: {kinds:?}"
+        );
+    }
+
+    fn assert_no_diagnostics(css: &str) {
+        let kinds = validate_css(css);
+        assert!(kinds.is_empty(), "Expected no diagnostics for CSS:\n  {css}\nGot: {kinds:?}");
+    }
+
+    #[test]
+    fn css_global_block_invalid_placement() {
+        // `:global` (block form, no args) inside a pseudo-class
+        assert_diagnostic(
+            ":is(:global) { color: red; }",
+            DiagnosticKind::CssGlobalBlockInvalidPlacement,
+        );
+    }
+
+    #[test]
+    fn css_global_invalid_placement() {
+        // `:global(...)` in the middle of a selector sequence
+        assert_diagnostic(
+            ".a :global(.b) .c { color: red; }",
+            DiagnosticKind::CssGlobalInvalidPlacement,
+        );
+    }
+
+    #[test]
+    fn css_global_invalid_placement_end_ok() {
+        // `:global(...)` at the end is fine
+        assert_no_diagnostics(".a :global(.b) { color: red; }");
+    }
+
+    #[test]
+    fn css_global_invalid_placement_start_ok() {
+        // `:global(...)` at the start is fine
+        assert_no_diagnostics(":global(.a) .b { color: red; }");
+    }
+
+    #[test]
+    fn css_global_invalid_selector_list() {
+        // `:global(element)` not at position 0 in compound
+        assert_diagnostic(
+            ".a:global(div) { color: red; }",
+            DiagnosticKind::CssGlobalInvalidSelectorList,
+        );
+    }
+
+    #[test]
+    fn css_type_selector_invalid_placement() {
+        // `:global(.class)` followed by type selector
+        assert_diagnostic(
+            ":global(.a)div { color: red; }",
+            DiagnosticKind::CssTypeSelectorInvalidPlacement,
+        );
+    }
+
+    #[test]
+    fn css_global_invalid_selector() {
+        // `:global(...)` with multiple selectors in compound context
+        assert_diagnostic(
+            ".a:global(.b, .c) { color: red; }",
+            DiagnosticKind::CssGlobalInvalidSelector,
+        );
+    }
+
+    #[test]
+    fn css_global_block_invalid_modifier_start() {
+        // `:global` block modified at start of top-level rule
+        assert_diagnostic(
+            ":global.foo { color: red; }",
+            DiagnosticKind::CssGlobalBlockInvalidModifierStart,
+        );
+    }
+
+    #[test]
+    fn css_global_block_invalid_combinator() {
+        // `:global` block follows non-space combinator
+        assert_diagnostic(
+            "div > :global { p { color: red; } }",
+            DiagnosticKind::CssGlobalBlockInvalidCombinator {
+                name: ">".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn css_global_block_invalid_list() {
+        // `:global` in selector list mixed with non-global entries
+        assert_diagnostic(
+            ":global, .foo { color: red; }",
+            DiagnosticKind::CssGlobalBlockInvalidList,
+        );
+    }
+
+    #[test]
+    fn css_global_block_invalid_declaration() {
+        // Lone `:global { ... }` block contains declarations
+        assert_diagnostic(
+            ":global { color: red; }",
+            DiagnosticKind::CssGlobalBlockInvalidDeclaration,
+        );
+    }
+
+    #[test]
+    fn css_global_block_invalid_modifier() {
+        // `:global` block selector not at position 0
+        assert_diagnostic(
+            ".foo:global { color: red; }",
+            DiagnosticKind::CssGlobalBlockInvalidModifier,
+        );
+    }
+
+    #[test]
+    fn css_nesting_selector_invalid_placement() {
+        // `&` used outside nested rule
+        assert_diagnostic(
+            "& { color: red; }",
+            DiagnosticKind::CssNestingSelectorInvalidPlacement,
+        );
+    }
+
+    #[test]
+    fn css_nesting_selector_valid_in_global() {
+        // `&` inside `:global(&)` is valid
+        assert_no_diagnostics(":global(&) { color: red; }");
+    }
+
+    #[test]
+    fn css_selector_invalid() {
+        // Leading combinator on first selector
+        assert_diagnostic(
+            "> .foo { color: red; }",
+            DiagnosticKind::CssSelectorInvalid,
+        );
+    }
+
+    #[test]
+    fn css_global_block_with_nested_rules_ok() {
+        // Lone `:global { ... }` with nested rules (not declarations) is valid
+        assert_no_diagnostics(":global { p { color: red; } }");
+    }
+
+    #[test]
+    fn css_global_block_descendant_ok() {
+        // `:global` following a descendant combinator (space) is valid
+        assert_no_diagnostics("div :global { p { color: red; } }");
+    }
+
+    #[test]
+    fn css_global_nesting_modifier_start_in_global_block() {
+        // `&.foo` inside lone `:global { ... }` is invalid
+        assert_diagnostic(
+            ":global { &.foo { color: red; } }",
+            DiagnosticKind::CssGlobalBlockInvalidModifierStart,
+        );
+    }
+
+    #[test]
+    fn css_global_block_invalid_list_mixed() {
+        // One complex selector is global block, the other isn't
+        assert_diagnostic(
+            ":global .x, .y { color: red; }",
+            DiagnosticKind::CssGlobalBlockInvalidList,
+        );
+    }
+
+    #[test]
+    fn valid_scoped_css_no_diagnostics() {
+        assert_no_diagnostics("p { color: red; }");
+        assert_no_diagnostics(".foo { color: red; }");
+        assert_no_diagnostics(":global(.foo) { color: red; }");
+        assert_no_diagnostics("p :global(.foo) { color: red; }");
     }
 }

--- a/crates/svelte_analyze/src/passes/css_analyze.rs
+++ b/crates/svelte_analyze/src/passes/css_analyze.rs
@@ -212,8 +212,8 @@ use svelte_diagnostics::DiagnosticKind;
 
 /// Per-rule context tracked on the validator's stack.
 struct RuleContext {
-    /// Whether this rule has been classified as a `:global` block.
-    is_global_block: bool,
+    /// Whether this rule is a lone `:global` block (single complex, single relative, single selector).
+    is_lone_global_block: bool,
     /// Whether this rule has a parent rule (i.e. is nested).
     has_parent_rule: bool,
     /// Whether the parent rule is a lone top-level `:global` block
@@ -340,9 +340,14 @@ impl<'a> CssValidator<'a> {
         }
 
         // Compute context for child rules
+        let is_lone_global_block = rule_is_global_block
+            && rule.prelude.children.len() == 1
+            && rule.prelude.children[0].children.len() == 1
+            && rule.prelude.children[0].children[0].selectors.len() == 1;
+
         let parent_is_lone_global_block = if has_parent {
             self.current_rule()
-                .map_or(false, |r| r.is_global_block && !r.has_parent_rule)
+                .map_or(false, |r| r.is_lone_global_block && !r.has_parent_rule)
         } else {
             false
         };
@@ -357,7 +362,7 @@ impl<'a> CssValidator<'a> {
             );
 
         self.rule_stack.push(RuleContext {
-            is_global_block: rule_is_global_block,
+            is_lone_global_block,
             has_parent_rule: has_parent,
             parent_is_lone_global_block,
             is_lone_global_with_nesting_arg,
@@ -789,6 +794,13 @@ mod tests {
             ":global .x, .y { color: red; }",
             DiagnosticKind::CssGlobalBlockInvalidList,
         );
+    }
+
+    #[test]
+    fn css_nesting_in_compound_global_block_ok() {
+        // `&` inside `:global .foo { ... }` (compound, not lone) should NOT
+        // trigger CssGlobalBlockInvalidModifierStart — only lone `:global { &.foo }` does.
+        assert_no_diagnostics(":global .foo { &.bar { color: red; } }");
     }
 
     #[test]

--- a/crates/svelte_compiler/src/lib.rs
+++ b/crates/svelte_compiler/src/lib.rs
@@ -47,7 +47,7 @@ pub fn compile(source: &str, options: &CompileOptions) -> CompileResult {
             // css:"injected" can come from compile options OR from <svelte:options css="injected">
             let inject_styles = options.css == CssMode::Injected
                 || component.options.as_ref().and_then(|o| o.css) == Some(svelte_ast::CssMode::Injected);
-            svelte_analyze::analyze_css_pass(&component, &ss, inject_styles, &mut analysis);
+            svelte_analyze::analyze_css_pass(&component, &ss, inject_styles, &mut analysis, &mut analyze_diags);
             let css_block = component.css.as_ref()
                 .unwrap_or_else(|| panic!("css block must exist when css_parsed is Some"));
             let css_source = component.source_text(css_block.content_span);

--- a/crates/svelte_css/src/ast.rs
+++ b/crates/svelte_css/src/ast.rs
@@ -145,6 +145,18 @@ pub enum CombinatorKind {
     Column,
 }
 
+impl CombinatorKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Descendant => " ",
+            Self::Child => ">",
+            Self::NextSibling => "+",
+            Self::SubsequentSibling => "~",
+            Self::Column => "||",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum SimpleSelector {
     /// Element / type selector (e.g. `div`, `*`, `ns|div`)

--- a/specs/css-pipeline.md
+++ b/specs/css-pipeline.md
@@ -2,16 +2,17 @@
 
 ## Current state
 - **Working**: scoped CSS pipeline complete — hash, selector scoping, element marking, class injection, `CompileResult.css`. Both `css:"external"` (default) and `css:"injected"` modes work. Tests: `css_scoped_basic`, `css_injected`, `css_injected_via_compile_options`.
-- **Architecture**: `svelte_transform_css` crate owns CSS AST → CSS string transform (scoping, serialization, injection compaction). `svelte_analyze::analyze_css_pass` is read-only classifier (hash, scoped elements, inject flag). `svelte_compiler` orchestrates and owns mode-specific post-processing.
+- **Architecture**: `svelte_transform_css` crate owns CSS AST → CSS string transform (scoping, serialization, injection compaction). `svelte_analyze::analyze_css_pass` is read-only classifier (hash, scoped elements, inject flag) and CSS validator (`:global` diagnostics). `svelte_compiler` orchestrates and owns mode-specific post-processing.
 - **Working**: `:global(.foo)` functional form — AST-level stripping of pseudo-class wrapper, mixed selectors (`p :global(.bar)`) scope outer LocalName correctly. Test: `css_global_basic`.
 - **Working**: `:global { ... }` block form — lone `:global` blocks hoisted at transform time (inner rules promoted unscoped to parent level). Works at top level, inside `@media`/`@supports`, and nested inside style rules. Analyze pass skips type selector collection for global blocks. Test: `css_global_block`.
-- **Partial**: nested `<style>` elements likely compile as plain DOM elements, but no focused compiler case proves "unscoped, inserted as-is" parity.
-- **Missing**: `:global .foo { ... }` compound form (non-lone), `:global()` validation diagnostics, unused-selector warnings, CSS custom properties.
+- **Done**: `:global()` validation diagnostics — all 12 CSS validation error diagnostics ported from reference `css-analyze.js`. `CssValidator` visitor in `svelte_analyze::passes::css_analyze` tracks parent rule context via stack. 20 unit tests covering all diagnostic kinds plus valid cases.
 - **Done**: Scoped `@keyframes` + `-global-` escape — keyframe names prefixed with hash, `-global-` prefix stripped, `animation`/`animation-name` values rewritten.
 - **Done**: `:global()` inside `:not()`/`:is()`/`:where()`/`:has()` — visitor recurses into pseudo-class args, unwraps `:global()` and scopes non-global selectors. Also fixed scope class insertion position to go before trailing pseudo-classes (matching reference compiler). Test: `css_global_in_pseudo`.
-- **Next**: Port `:global .foo { ... }` compound form or `:global()` validation diagnostics.
+- **Partial**: nested `<style>` elements likely compile as plain DOM elements, but no focused compiler case proves "unscoped, inserted as-is" parity.
+- **Missing**: `:global .foo { ... }` compound form (non-lone), unused-selector warnings, CSS custom properties.
+- **Next**: Port unused selector warnings (requires css-prune pass) or `:global .foo { ... }` compound form.
 - **Known debt**: `has_global_component` is duplicated between `svelte_analyze` and `svelte_transform_css` — to be resolved when `:global()` work makes the function non-trivial.
-- **Current slice**: completed `:global()` inside pseudo-classes
+- **Current slice**: completed `:global()` validation diagnostics
 - Last updated: 2026-04-06
 
 ## Source
@@ -43,7 +44,7 @@ ROADMAP.md — CSS
 - [x] `:global(.foo)` functional form — strip wrapper, scope outer LocalName (test: `css_global_basic`)
 - [x] `:global { ... }` block form transform (test: `css_global_block`)
 - [x] `:global()` inside `:not()`, `:is()`, `:where()`, `:has()` — visitor recurses into pseudo-class args (test: `css_global_in_pseudo`)
-- [ ] `:global()` validation diagnostics
+- [x] `:global()` validation diagnostics (20 unit tests in `css_analyze::tests`)
 - [x] Scoped `@keyframes` plus `-global-*` escape (test: `css_keyframes_scoped`)
 - [ ] CSS comments preserved in output — lightningcss drops comments during AST parsing; reference compiler preserves them via MagicString text manipulation
 - [ ] Unused selector warning (`css_unused_selector`)


### PR DESCRIPTION
## Summary
This PR adds comprehensive CSS validation to the `analyze_css_pass` function, detecting and reporting invalid `:global()` usage patterns through a new `CssValidator` visitor. The validator emits diagnostics for various CSS issues including invalid `:global` block placement, incorrect combinator usage, invalid selector lists, and nesting selector (`&`) placement violations.

## Key Changes

- **New `CssValidator` struct**: Implements the `Visit` trait to traverse the CSS AST and validate `:global()` usage patterns, ported from the reference compiler's `css-analyze.js`
  - Tracks rule context on a stack to understand nesting depth and parent rule properties
  - Validates `:global` block selectors (no-arg form) vs `:global(...)` function form
  - Detects invalid placements, combinators, and selector list combinations

- **Helper functions for `:global()` classification**:
  - `is_global_block_selector()`: Identifies `:global` block form (no arguments)
  - `is_global_relative_selector()`: Determines if a relative selector is globally scoped
  - `is_unscoped_pseudo_class()`: Checks if pseudo-classes like `:has`, `:is`, `:where`, `:not` can be scoped
  - `is_nesting_in_global_args()`: Validates nesting selector usage in `:global(&)` form

- **Validation methods**:
  - `validate_rule()`: Checks for invalid `:global` block modifiers, combinators, and declarations
  - `validate_complex_selector()`: Validates `:global(...)` placement in selector sequences
  - `validate_nesting_selector()`: Ensures `&` is only used in nested rules or `:global(&)`

- **Diagnostic emission**: The validator now passes a `diagnostics` vector to `analyze_css_pass` and emits errors for:
  - `CssGlobalBlockInvalidPlacement`: `:global` block inside pseudo-class
  - `CssGlobalInvalidPlacement`: `:global(...)` in middle of selector sequence
  - `CssGlobalInvalidSelectorList`: `:global(element)` not at position 0
  - `CssTypeSelectorInvalidPlacement`: Type selector after `:global(.class)`
  - `CssGlobalBlockInvalidModifier*`: Various invalid modifier patterns
  - `CssNestingSelectorInvalidPlacement`: `&` outside nested rules
  - And several others

- **Comprehensive test suite**: 18 test cases covering valid and invalid CSS patterns, including edge cases like `:global` with nested rules, descendant combinators, and mixed selector lists

- **AST enhancement**: Added `CombinatorKind::as_str()` method to convert combinator kinds to their string representations for error messages

- **Documentation update**: Updated `specs/css-pipeline.md` to reflect that `analyze_css_pass` now performs both classification and CSS validation

## Implementation Details

The validator uses a stack-based approach to track nested rule contexts, maintaining information about whether a rule is a `:global` block, has parent rules, and other properties needed for validation. The `in_pseudo_class` flag tracks when traversing inside pseudo-class arguments to detect invalid `:global` block placement.

The implementation closely follows the reference compiler's validation logic while adapting it to work with the Rust AST structures and the diagnostic system.

https://claude.ai/code/session_014xe93FZE7AJx2CQSKY2eof