### PR TITLE
Add N-API crate and @mrwaip/svelte-rs2 JS facade exposing `compile` / `compileModule`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +228,16 @@ name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "diff"
@@ -401,6 +420,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +440,74 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "napi"
+version = "2.16.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "napi-derive",
+ "napi-sys",
+ "once_cell",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+
+[[package]]
+name = "napi-derive"
+version = "2.16.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
+dependencies = [
+ "cfg-if",
+ "convert_case",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
+dependencies = [
+ "convert_case",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "semver",
+ "syn",
+]
+
+[[package]]
+name = "napi-sys"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "napi_compiler"
+version = "0.1.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "svelte_compiler",
+ "svelte_diagnostics",
+]
 
 [[package]]
 name = "nonmax"
@@ -1461,6 +1558,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ svelte_compiler = { path = "crates/svelte_compiler" }
 svelte_component_semantics = { path = "crates/svelte_component_semantics" }
 svelte_transform_css = { path = "crates/svelte_transform_css" }
 svelte_css = { path = "crates/svelte_css" }
+napi_compiler = { path = "crates/napi_compiler" }
 
 compact_str = "0.9.0"
 glob = "0.3.2"

--- a/crates/napi_compiler/Cargo.toml
+++ b/crates/napi_compiler/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "napi_compiler"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+napi = { version = "2.16.16", default-features = false, features = ["napi8"] }
+napi-derive = "2.16.13"
+svelte_compiler = { workspace = true }
+svelte_diagnostics = { workspace = true }
+
+[build-dependencies]
+napi-build = "2.1.4"

--- a/crates/napi_compiler/build.rs
+++ b/crates/napi_compiler/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/crates/napi_compiler/src/lib.rs
+++ b/crates/napi_compiler/src/lib.rs
@@ -1,0 +1,203 @@
+use napi_derive::napi;
+use svelte_compiler::{
+    CompileOptions, CompileResult, CssMode, GenerateMode, ModuleCompileOptions, Namespace,
+};
+use svelte_diagnostics::LineIndex;
+
+#[napi(object)]
+pub struct NativeDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub severity: String,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+    pub frame: Option<String>,
+}
+
+#[napi(object)]
+pub struct NativeCompileResult {
+    pub js: Option<String>,
+    pub css: Option<String>,
+    pub diagnostics: Vec<NativeDiagnostic>,
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct NativeCompileOptions {
+    pub dev: Option<bool>,
+    pub filename: Option<String>,
+    pub root_dir: Option<String>,
+    pub name: Option<String>,
+    pub custom_element: Option<bool>,
+    pub namespace: Option<String>,
+    pub css: Option<String>,
+    pub runes: Option<bool>,
+    pub preserve_comments: Option<bool>,
+    pub preserve_whitespace: Option<bool>,
+    pub disclose_version: Option<bool>,
+    pub hmr: Option<bool>,
+    pub accessors: Option<bool>,
+    pub immutable: Option<bool>,
+    pub compatibility_component_api: Option<u8>,
+    pub experimental_async: Option<bool>,
+    pub generate: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct NativeModuleCompileOptions {
+    pub dev: Option<bool>,
+    pub filename: Option<String>,
+    pub root_dir: Option<String>,
+    pub generate: Option<String>,
+}
+
+#[napi]
+pub fn compile(source: String, options: Option<NativeCompileOptions>) -> NativeCompileResult {
+    let options = to_compile_options(options.unwrap_or_default());
+    let result = svelte_compiler::compile(&source, &options);
+    to_node_result(result, &source)
+}
+
+#[napi(js_name = "compileModule")]
+pub fn compile_module(
+    source: String,
+    options: Option<NativeModuleCompileOptions>,
+) -> NativeCompileResult {
+    let options = to_module_compile_options(options.unwrap_or_default());
+    let result = svelte_compiler::compile_module(&source, &options);
+    to_node_result(result, &source)
+}
+
+fn to_compile_options(native: NativeCompileOptions) -> CompileOptions {
+    let mut options = CompileOptions::default();
+    if let Some(value) = native.dev {
+        options.dev = value;
+    }
+    if let Some(value) = native.generate {
+        options.generate = parse_generate_mode(&value);
+    }
+    if let Some(value) = native.filename {
+        options.filename = value;
+    }
+    if let Some(value) = native.root_dir {
+        options.root_dir = Some(value);
+    }
+    if let Some(value) = native.name {
+        options.name = Some(value);
+    }
+    if let Some(value) = native.custom_element {
+        options.custom_element = value;
+    }
+    if let Some(value) = native.namespace {
+        options.namespace = parse_namespace(&value);
+    }
+    if let Some(value) = native.css {
+        options.css = parse_css_mode(&value);
+    }
+    if let Some(value) = native.runes {
+        options.runes = Some(value);
+    }
+    if let Some(value) = native.preserve_comments {
+        options.preserve_comments = value;
+    }
+    if let Some(value) = native.preserve_whitespace {
+        options.preserve_whitespace = value;
+    }
+    if let Some(value) = native.disclose_version {
+        options.disclose_version = value;
+    }
+    if let Some(value) = native.hmr {
+        options.hmr = value;
+    }
+    if let Some(value) = native.accessors {
+        options.accessors = value;
+    }
+    if let Some(value) = native.immutable {
+        options.immutable = value;
+    }
+    if let Some(value) = native.compatibility_component_api {
+        options.compatibility_component_api = value;
+    }
+    if let Some(value) = native.experimental_async {
+        options.experimental.async_ = value;
+    }
+    options
+}
+
+fn to_module_compile_options(native: NativeModuleCompileOptions) -> ModuleCompileOptions {
+    let mut options = ModuleCompileOptions::default();
+    if let Some(value) = native.dev {
+        options.dev = value;
+    }
+    if let Some(value) = native.generate {
+        options.generate = parse_generate_mode(&value);
+    }
+    if let Some(value) = native.filename {
+        options.filename = value;
+    }
+    if let Some(value) = native.root_dir {
+        options.root_dir = Some(value);
+    }
+    options
+}
+
+fn parse_generate_mode(raw: &str) -> GenerateMode {
+    match raw {
+        "server" => GenerateMode::Server,
+        "false" => GenerateMode::False,
+        _ => GenerateMode::Client,
+    }
+}
+
+fn parse_namespace(raw: &str) -> Namespace {
+    match raw {
+        "svg" => Namespace::Svg,
+        "mathml" => Namespace::MathMl,
+        _ => Namespace::Html,
+    }
+}
+
+fn parse_css_mode(raw: &str) -> CssMode {
+    match raw {
+        "injected" => CssMode::Injected,
+        _ => CssMode::External,
+    }
+}
+
+fn to_node_result(result: CompileResult, source: &str) -> NativeCompileResult {
+    let line_index = LineIndex::new(source);
+
+    let diagnostics = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            let (start_line, start_col) = line_index.line_col(diagnostic.span.start as usize);
+            let (end_line, end_col) = line_index.line_col(diagnostic.span.end as usize);
+            let mut message = diagnostic.kind.message();
+            if let Some(url) = diagnostic.kind.svelte_doc_url() {
+                message.push('\n');
+                message.push_str(&url);
+            }
+
+            NativeDiagnostic {
+                code: diagnostic.kind.code().to_string(),
+                message,
+                severity: format!("{:?}", diagnostic.severity),
+                start_line: start_line as u32,
+                start_col: start_col as u32,
+                end_line: end_line as u32,
+                end_col: end_col as u32,
+                frame: line_index.code_frame(source, diagnostic.span),
+            }
+        })
+        .collect();
+
+    NativeCompileResult {
+        js: result.js,
+        css: result.css,
+        diagnostics,
+    }
+}

--- a/packages/svelte-rs2/README.md
+++ b/packages/svelte-rs2/README.md
@@ -1,0 +1,43 @@
+# @mrwaip/svelte-rs2 (canary facade)
+
+## Compiler entrypoint
+
+Use `@mrwaip/svelte-rs2/compiler`.
+
+```js
+import { compile, compileModule } from '@mrwaip/svelte-rs2/compiler';
+```
+
+## Canary compatibility policy
+
+This package currently exposes only `compile` and `compileModule` through a Node native addon.
+
+### Result shape
+
+Both `compile` and `compileModule` return a stable canary shape:
+
+- `js: null | { code, map }`
+- `css: null | { code, map, hasGlobal }`
+- `warnings: Warning[]`
+- `metadata: { canary, hasCss, unsupported }`
+- `ast: null`
+
+### Source map policy
+
+- `js.map` and `css.map` are always `null` in the current canary.
+- There is no source-map generation yet.
+
+### AST policy
+
+- `ast` is always `null` in the current canary.
+- AST output is intentionally not exposed until the public shape is finalized.
+
+### Unsupported options policy
+
+- `ast`, `sourcemap`, `outputFilename` **throw** immediately.
+- `modernAst` is accepted but produces a warning with code `unsupported_option_ignored`.
+
+### Diagnostics policy
+
+- Rust diagnostics with severity `Error` are rethrown as JS exceptions.
+- Non-error diagnostics are returned through `warnings`.

--- a/packages/svelte-rs2/compiler/index.d.ts
+++ b/packages/svelte-rs2/compiler/index.d.ts
@@ -1,0 +1,79 @@
+export type Warning = {
+  code: string;
+  message: string;
+  filename: string | null;
+  start: { line: number; column: number } | null;
+  end: { line: number; column: number } | null;
+  frame: string | null;
+};
+
+export type CompileJsResult = {
+  code: string;
+  map: object | null;
+};
+
+export type CompileCssResult = {
+  code: string;
+  map: object | null;
+  hasGlobal: boolean | null;
+};
+
+export type CompileMetadata = {
+  canary: true;
+  hasCss: boolean;
+  unsupported: {
+    ast: 'not_returned';
+    sourceMap: 'always_null';
+    unsupportedOptions: Array<'ast' | 'sourcemap' | 'outputFilename'>;
+  };
+};
+
+export interface CompileOptions {
+  dev?: boolean;
+  filename?: string;
+  rootDir?: string;
+  name?: string;
+  customElement?: boolean;
+  namespace?: 'html' | 'svg' | 'mathml';
+  css?: 'external' | 'injected';
+  runes?: boolean;
+  preserveComments?: boolean;
+  preserveWhitespace?: boolean;
+  discloseVersion?: boolean;
+  hmr?: boolean;
+  accessors?: boolean;
+  immutable?: boolean;
+  compatibility?: {
+    componentApi?: number;
+  };
+  experimental?: {
+    async?: boolean;
+  };
+  generate?: 'client' | 'server' | false;
+  modernAst?: boolean;
+  ast?: never;
+  sourcemap?: never;
+  outputFilename?: never;
+}
+
+export interface ModuleCompileOptions {
+  dev?: boolean;
+  filename?: string;
+  rootDir?: string;
+  generate?: 'client' | 'server' | false;
+  modernAst?: boolean;
+  ast?: never;
+  sourcemap?: never;
+  outputFilename?: never;
+}
+
+export type CompileResult = {
+  js: CompileJsResult | null;
+  css: CompileCssResult | null;
+  warnings: Warning[];
+  metadata: CompileMetadata;
+  ast: null;
+};
+
+export declare function compile(source: string, options?: CompileOptions): CompileResult;
+export declare function compileModule(source: string, options?: ModuleCompileOptions): CompileResult;

--- a/packages/svelte-rs2/compiler/index.js
+++ b/packages/svelte-rs2/compiler/index.js
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const UNSUPPORTED_THROW_OPTIONS = new Set(['ast', 'sourcemap', 'outputFilename']);
+const UNSUPPORTED_WARN_OPTIONS = new Set(['modernAst']);
+
+function loadNativeAddon() {
+  const localPath = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    './native/svelte-rs2.node'
+  );
+
+  if (fs.existsSync(localPath)) {
+    return require(localPath);
+  }
+
+  throw new Error(
+    'Native addon was not found at packages/svelte-rs2/compiler/native/svelte-rs2.node. Build crates/napi_compiler and place the .node artifact there.'
+  );
+}
+
+const native = loadNativeAddon();
+
+function assertSupportedOptions(options) {
+  for (const key of Object.keys(options)) {
+    if (UNSUPPORTED_THROW_OPTIONS.has(key)) {
+      throw new Error(`Unsupported option in canary: ${key}`);
+    }
+  }
+}
+
+function collectOptionWarnings(options) {
+  const warnings = [];
+  for (const key of Object.keys(options)) {
+    if (UNSUPPORTED_WARN_OPTIONS.has(key)) {
+      warnings.push({
+        code: 'unsupported_option_ignored',
+        message: `Option ${key} is ignored in canary`,
+        filename: options.filename ?? null,
+        start: null,
+        end: null,
+        frame: null
+      });
+    }
+  }
+  return warnings;
+}
+
+function normalizeGenerate(value) {
+  if (value === false || value === 'false') return 'false';
+  if (value === 'server') return 'server';
+  return 'client';
+}
+
+function normalizeCompileOptions(options = {}) {
+  assertSupportedOptions(options);
+
+  return {
+    dev: Boolean(options.dev),
+    filename: typeof options.filename === 'string' ? options.filename : '(unknown)',
+    root_dir: typeof options.rootDir === 'string' ? options.rootDir : undefined,
+    name: typeof options.name === 'string' ? options.name : undefined,
+    custom_element: Boolean(options.customElement),
+    namespace:
+      options.namespace === 'svg' || options.namespace === 'mathml' ? options.namespace : 'html',
+    css: options.css === 'injected' ? 'injected' : 'external',
+    runes: typeof options.runes === 'boolean' ? options.runes : undefined,
+    preserve_comments: Boolean(options.preserveComments),
+    preserve_whitespace: Boolean(options.preserveWhitespace),
+    disclose_version:
+      typeof options.discloseVersion === 'boolean' ? options.discloseVersion : undefined,
+    hmr: Boolean(options.hmr),
+    accessors: Boolean(options.accessors),
+    immutable: Boolean(options.immutable),
+    compatibility_component_api:
+      typeof options.compatibility?.componentApi === 'number'
+        ? options.compatibility.componentApi
+        : undefined,
+    experimental_async: Boolean(options.experimental?.async),
+    generate: normalizeGenerate(options.generate)
+  };
+}
+
+function normalizeModuleCompileOptions(options = {}) {
+  assertSupportedOptions(options);
+
+  return {
+    dev: Boolean(options.dev),
+    filename: typeof options.filename === 'string' ? options.filename : '(unknown)',
+    root_dir: typeof options.rootDir === 'string' ? options.rootDir : undefined,
+    generate: normalizeGenerate(options.generate)
+  };
+}
+
+function normalizeDiagnostic(diagnostic, filenameFallback) {
+  return {
+    code: diagnostic.code,
+    message: diagnostic.message,
+    filename: filenameFallback,
+    start: {
+      line: diagnostic.start_line,
+      column: diagnostic.start_col
+    },
+    end: {
+      line: diagnostic.end_line,
+      column: diagnostic.end_col
+    },
+    frame: diagnostic.frame ?? null
+  };
+}
+
+function normalizeCompileResponse(nativeResult, filename, optionWarnings = []) {
+  const warnings = [...optionWarnings];
+  const errors = [];
+
+  for (const diagnostic of nativeResult.diagnostics ?? []) {
+    const normalized = normalizeDiagnostic(diagnostic, filename ?? null);
+    if (diagnostic.severity === 'Error') {
+      errors.push(normalized);
+    } else {
+      warnings.push(normalized);
+    }
+  }
+
+  if (errors.length > 0) {
+    const error = new Error(errors[0].message || 'Compilation failed');
+    error.code = errors[0].code;
+    error.warnings = warnings;
+    error.diagnostics = errors;
+    throw error;
+  }
+
+  return {
+    js: nativeResult.js == null ? null : { code: nativeResult.js, map: null },
+    css:
+      nativeResult.css == null
+        ? null
+        : {
+            code: nativeResult.css,
+            map: null,
+            hasGlobal: null
+          },
+    warnings,
+    metadata: {
+      canary: true,
+      hasCss: nativeResult.css != null,
+      unsupported: {
+        ast: 'not_returned',
+        sourceMap: 'always_null',
+        unsupportedOptions: ['ast', 'sourcemap', 'outputFilename']
+      }
+    },
+    ast: null
+  };
+}
+
+export function compile(source, options = {}) {
+  if (typeof source !== 'string') {
+    throw new TypeError('compile(source, options): source must be a string');
+  }
+
+  const normalizedOptions = normalizeCompileOptions(options);
+  const optionWarnings = collectOptionWarnings(options);
+  const nativeResult = native.compile(source, normalizedOptions);
+  return normalizeCompileResponse(nativeResult, normalizedOptions.filename, optionWarnings);
+}
+
+export function compileModule(source, options = {}) {
+  if (typeof source !== 'string') {
+    throw new TypeError('compileModule(source, options): source must be a string');
+  }
+
+  const normalizedOptions = normalizeModuleCompileOptions(options);
+  const optionWarnings = collectOptionWarnings(options);
+  const nativeResult = native.compileModule(source, normalizedOptions);
+  return normalizeCompileResponse(nativeResult, normalizedOptions.filename, optionWarnings);
+}

--- a/packages/svelte-rs2/compiler/native/.gitignore
+++ b/packages/svelte-rs2/compiler/native/.gitignore
@@ -1,0 +1,2 @@
+*.node
+!.gitkeep

--- a/packages/svelte-rs2/package.json
+++ b/packages/svelte-rs2/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@mrwaip/svelte-rs2",
+  "version": "0.0.0-canary.0",
+  "type": "module",
+  "exports": {
+    "./compiler": {
+      "types": "./compiler/index.d.ts",
+      "default": "./compiler/index.js"
+    }
+  },
+  "scripts": {
+    "smoke": "node ./scripts/smoke.mjs"
+  }
+}

--- a/packages/svelte-rs2/scripts/smoke.mjs
+++ b/packages/svelte-rs2/scripts/smoke.mjs
@@ -1,0 +1,70 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit', cwd: repoRoot });
+}
+
+function copyNativeAddon() {
+  const targetDir = path.resolve(packageRoot, 'compiler/native');
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const ext = process.platform === 'darwin' ? 'dylib' : process.platform === 'win32' ? 'dll' : 'so';
+  const srcName = process.platform === 'win32' ? 'napi_compiler.dll' : `libnapi_compiler.${ext}`;
+  const srcPath = path.resolve(repoRoot, 'target/debug', srcName);
+  const dstPath = path.resolve(targetDir, 'svelte-rs2.node');
+
+  if (!fs.existsSync(srcPath)) {
+    throw new Error(`Native library was not produced: ${srcPath}`);
+  }
+
+  fs.copyFileSync(srcPath, dstPath);
+}
+
+run('cargo build -p napi_compiler');
+copyNativeAddon();
+
+const api = await import('@mrwaip/svelte-rs2/compiler');
+
+const compileResult = api.compile('<script>let count = 1;</script><h1>{count}</h1>', {
+  filename: 'Counter.svelte'
+});
+
+if (!compileResult || typeof compileResult !== 'object') {
+  throw new Error('compile must return an object');
+}
+if (!compileResult.js || typeof compileResult.js.code !== 'string') {
+  throw new Error('compile result must contain js.code');
+}
+if (!Array.isArray(compileResult.warnings)) {
+  throw new Error('compile result must contain warnings array');
+}
+if (!('metadata' in compileResult)) {
+  throw new Error('compile result must contain metadata');
+}
+
+const moduleResult = api.compileModule('let x = $state(1); export { x };', {
+  filename: 'mod.svelte.js'
+});
+
+if (!moduleResult || typeof moduleResult !== 'object') {
+  throw new Error('compileModule must return an object');
+}
+if (!moduleResult.js || typeof moduleResult.js.code !== 'string') {
+  throw new Error('compileModule result must contain js.code');
+}
+if (!Array.isArray(moduleResult.warnings)) {
+  throw new Error('compileModule result must contain warnings array');
+}
+if (!('metadata' in moduleResult)) {
+  throw new Error('compileModule result must contain metadata');
+}
+
+console.log('Smoke tests passed');


### PR DESCRIPTION
### Motivation
- Provide a Node native binding to the Rust compiler so consumers can call `compile`/`compileModule` from JS without using WASM. 
- Surface a stable canary JS API that normalizes options and returns a stable result shape (`js`, `css`, `warnings`, `metadata`, `ast: null`).
- Keep Rust internals private by converting `svelte_compiler` results into stable Node DTOs rather than exposing internal types directly.
- Document and enforce an explicit canary policy for unsupported options, source maps, and AST exposure.

### Description
- Added a new crate `crates/napi_compiler` with `cdylib` build, `napi`/`napi-derive`/`napi-build` dependencies and `build.rs` configured for `.node` artifact production.
- Implemented N-API exports in `crates/napi_compiler/src/lib.rs`: `compile(source, options)` and `compileModule(source, options)` that call `svelte_compiler::compile` and `svelte_compiler::compile_module`, and convert results into `NativeCompileResult`/`NativeDiagnostic` DTOs.
- Implemented option conversion helpers (`to_compile_options`, `to_module_compile_options`, `parse_generate_mode`, `parse_namespace`, `parse_css_mode`) so the native layer accepts JS-friendly inputs and maps them to `CompileOptions`/`ModuleCompileOptions`.
- Added JS facade package `packages/svelte-rs2` exporting `./compiler` with `compiler/index.js` (native loader, option normalization, response normalization, unsupported-option policy), TypeScript declarations `compiler/index.d.ts`, README documenting canary limits, and a black-box smoke script `packages/svelte-rs2/scripts/smoke.mjs` that builds the native crate, copies the `.node` artifact, imports the facade, and validates the result shape.
- Wired the new crate into the workspace `Cargo.toml` and updated `Cargo.lock` to include the new N-API dependencies.

### Testing
- Ran `cargo check -p napi_compiler` and it completed successfully. ✅
- Ran the facade smoke script with `node packages/svelte-rs2/scripts/smoke.mjs`, which builds the native crate, copies the artifact, imports the facade, calls `compile` and `compileModule`, and validated required result fields; the script finished with `Smoke tests passed`. ✅
- Formatting applied with `cargo fmt` and quick re-check `cargo check -p napi_compiler` re-run completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8169f0d4483219df8bdf364964d6b)