### PR TITLE
Add ignored diagnose case for input shorthand prop lowering mismatch

### DIFF
--- a/specs/unknown.md
+++ b/specs/unknown.md
@@ -2,8 +2,8 @@
 
 ## Current state
 
-- **Working**: 0 recorded unknown items
-- **Next**: first unowned repro or failing test discovered by `/diagnose`
+- **Working**: 1 recorded unknown item
+- **Next**: Input shorthand `{value}` / `{disabled}` on `<input>` from `$props()` lowers as generic attrs instead of input-special runtime updates
 - Last updated: 2026-04-11
 
 ## Source
@@ -12,6 +12,7 @@
 
 ## Use cases
 
+- [ ] Input shorthand `{value}` / `{disabled}` on `<input>` from `$props()` should lower through input-special value/boolean paths (`$.remove_input_defaults`, `$.set_value`, `input.disabled = ...`) but currently compiles as generic attributes — layer: analysis; repro/test: diagnose_props_bindable_icon_component; candidate specs: bind-directives.md, element.md; suggested spec: bind-directives.md
 ## Out of scope
 
 - Implementing compiler fixes directly in this spec
@@ -31,3 +32,4 @@
 - `tasks/compiler_tests/cases2/`
 
 ## Test cases
+- [ ] diagnose_props_bindable_icon_component

--- a/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case-rust.js
+++ b/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case-rust.js
@@ -1,0 +1,33 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<div class="ui-input-icon svelte-nbptzh"><!></div>`);
+var root = $.from_html(`<div class="ui-input-wrapper svelte-nbptzh"><!> <input class="ui-input svelte-nbptzh"/></div>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = $.prop($$props, "value", 11, ""), placeholder = $.prop($$props, "placeholder", 3, ""), type = $.prop($$props, "type", 3, "text"), disabled = $.prop($$props, "disabled", 3, false);
+	var div = root();
+	var node = $.child(div);
+	{
+		var consequent = ($$anchor) => {
+			var div_1 = root_1();
+			var node_1 = $.child(div_1);
+			$.component(node_1, () => $$props.icon, ($$anchor, Icon_1) => {
+				Icon_1($$anchor, {});
+			});
+			$.reset(div_1);
+			$.append($$anchor, div_1);
+		};
+		$.if(node, ($$render) => {
+			if ($$props.icon) $$render(consequent);
+		});
+	}
+	var input = $.sibling(node, 2);
+	$.reset(div);
+	$.template_effect(() => {
+		$.set_attribute(input, "value", value());
+		$.set_attribute(input, "placeholder", placeholder());
+		$.set_attribute(input, "type", type());
+		$.set_attribute(input, "disabled", disabled());
+	});
+	$.append($$anchor, div);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case-svelte.css
+++ b/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case-svelte.css
@@ -1,0 +1,35 @@
+
+	.ui-input-wrapper.svelte-nbptzh {
+		display: flex;
+		align-items: center;
+		position: relative;
+	}
+	.ui-input-icon.svelte-nbptzh {
+		margin-right: 0.7em;
+		width: 1.3em;
+		height: 1.3em;
+		flex-shrink: 0;
+		color: #0070f3;
+		opacity: 0.85;
+	}
+	.ui-input.svelte-nbptzh {
+		flex: 1 1 0;
+		padding: 0.5em 1em;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		font-size: 1em;
+		outline: none;
+		transition: border 0.2s;
+		background: #fff;
+		color: #222;
+	}
+	.ui-input.svelte-nbptzh:focus {
+		border-color: #0070f3;
+	}
+	.ui-input[disabled].svelte-nbptzh {
+		background: #f3f3f3;
+		color: #aaa;
+		border-color: #e0e0e0;
+		cursor: not-allowed;
+		opacity: 0.7;
+	}

--- a/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case-svelte.js
+++ b/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case-svelte.js
@@ -1,0 +1,34 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<div class="ui-input-icon svelte-nbptzh"><!></div>`);
+var root = $.from_html(`<div class="ui-input-wrapper svelte-nbptzh"><!> <input class="ui-input svelte-nbptzh"/></div>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let value = $.prop($$props, "value", 11, ""), placeholder = $.prop($$props, "placeholder", 3, ""), type = $.prop($$props, "type", 3, "text"), disabled = $.prop($$props, "disabled", 3, false);
+	var div = root();
+	var node = $.child(div);
+	{
+		var consequent = ($$anchor) => {
+			var div_1 = root_1();
+			var node_1 = $.child(div_1);
+			$.component(node_1, () => $$props.icon, ($$anchor, Icon_1) => {
+				Icon_1($$anchor, {});
+			});
+			$.reset(div_1);
+			$.append($$anchor, div_1);
+		};
+		$.if(node, ($$render) => {
+			if ($$props.icon) $$render(consequent);
+		});
+	}
+	var input = $.sibling(node, 2);
+	$.remove_input_defaults(input);
+	$.reset(div);
+	$.template_effect(() => {
+		$.set_value(input, value());
+		$.set_attribute(input, "placeholder", placeholder());
+		$.set_attribute(input, "type", type());
+		input.disabled = disabled();
+	});
+	$.append($$anchor, div);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case.svelte
+++ b/tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/case.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import type { Component } from 'svelte';
+	type Props = {
+		value?: string;
+		placeholder?: string;
+		type?: 'text' | 'password' | 'email' | 'search' | 'number' | 'tel' | 'url';
+		disabled?: boolean;
+		icon?: Component;
+	};
+
+	let {
+		value = $bindable(''),
+		placeholder = '',
+		type = 'text',
+		disabled = false,
+		icon: Icon
+	}: Props = $props();
+</script>
+
+<div class="ui-input-wrapper">
+	{#if Icon}
+		<div class="ui-input-icon">
+			<Icon />
+		</div>
+	{/if}
+	<input {value} {placeholder} {type} {disabled} class="ui-input" />
+</div>
+
+<style>
+	.ui-input-wrapper {
+		display: flex;
+		align-items: center;
+		position: relative;
+	}
+	.ui-input-icon {
+		margin-right: 0.7em;
+		width: 1.3em;
+		height: 1.3em;
+		flex-shrink: 0;
+		color: #0070f3;
+		opacity: 0.85;
+	}
+	.ui-input {
+		flex: 1 1 0;
+		padding: 0.5em 1em;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		font-size: 1em;
+		outline: none;
+		transition: border 0.2s;
+		background: #fff;
+		color: #222;
+	}
+	.ui-input:focus {
+		border-color: #0070f3;
+	}
+	.ui-input[disabled] {
+		background: #f3f3f3;
+		color: #aaa;
+		border-color: #e0e0e0;
+		cursor: not-allowed;
+		opacity: 0.7;
+	}
+</style>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2774,3 +2774,9 @@ fn snippet_destructure_default_state_ref() {
 fn snippet_destructure_default_mutated_state_ref() {
     assert_compiler("snippet_destructure_default_mutated_state_ref");
 }
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn diagnose_props_bindable_icon_component() {
+    assert_compiler("diagnose_props_bindable_icon_component");
+}


### PR DESCRIPTION
### Motivation
- Capture a reproducible compiler-output mismatch where shorthand input attributes originating from `$props()` are lowered as generic attributes instead of the input-special path (runtime `$.remove_input_defaults` / `$.set_value` / `input.disabled = ...`).
- Isolate the failure into a durable test so ownership can be resolved (likely analyzer classification vs. codegen consumption) without changing compiler implementation in this session.

### Description
- Added a new compiler repro under `tasks/compiler_tests/cases2/diagnose_props_bindable_icon_component/` including `case.svelte`, generated reference artifacts `case-svelte.js` and `case-svelte.css`, and the Rust output snapshot `case-rust.js` generated by `just generate`.
- Registered the case in `tasks/compiler_tests/test_v3.rs` as an ignored diagnose test with `#[ignore = "diagnose: pending fix"]` so default test runs remain green.
- Recorded the triage entry in `specs/unknown.md` describing the repro, likely owning layer (analysis), candidate specs (`bind-directives.md`, `element.md`), and the persistent test name.

### Testing
- Ran `just generate` to produce the JS/CSS snapshots and it completed successfully.
- Ran the focused test with `cargo test -p compiler_tests --test compiler_tests_v3 diagnose_props_bindable_icon_component -- --nocapture` and the test was ignored as intended (passed because ignored).
- Ran the same test including ignored tests with `cargo test -p compiler_tests --test compiler_tests_v3 diagnose_props_bindable_icon_component -- --include-ignored --nocapture` and it failed as expected, preserving the repro for follow-up implementation work.
- Ran the suite invocation `cargo test` for the modified test module and observed overall test status remains green with the new case ignored.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4ebd96648321a53871320256122b)