### PR TITLE
diagnose: add ignored compiler repro for scoped CSS class-concat scope-hash omission

### DIFF
--- a/specs/css-pipeline.md
+++ b/specs/css-pipeline.md
@@ -14,8 +14,8 @@
 - **Done**: Component custom-property wrapper lowering — `--*` attrs on a component are pre-classified into a `component_css_props` side-table during analyze, and codegen routes the component through a wrapper element (`<svelte-css-wrapper style="display: contents">` for HTML, `<g>` for SVG) plus `$.css_props(node, () => ({...}))`, with the inner component anchored on `node.lastChild`. Tests: `css_custom_prop_component`, `css_custom_prop_component_svg`. Side change: `CompileOptions.namespace` is now merged into `component.options.namespace` as a fallback inside `compile()` (matches reference behavior); the parser-side `regex_illegal_attribute_character` check skips component tags so `--name` is accepted.
 - **Next**: remaining CSS pipeline gaps — `:global .foo` compound form, unused selector CSS wrapping, nested `<style>` element parity. None scoped to current slice.
 - **Known debt**: `has_global_component` is duplicated between `svelte_analyze` and `svelte_transform_css` — to be resolved when `:global()` work makes the function non-trivial. The earlier blocker noted above (executor.rs / render_tags.rs / template_validation.rs compile errors) is no longer present — removed from tracking.
-- **Open bugs (2026-04-08 diagnose)**: scope-class injection misses 4 variants — element inside `{#snippet}` body, `<svelte:element>` with static class, class-object attribute (third arg to `$.set_class` is `null`), and spread-only element (`$.attribute_effect` emitted with 2 args instead of 6). Isolated by `css_scope_class_in_snippet`, `css_scope_svelte_element_class`, `css_scope_class_object`, `css_scope_spread_attribute` (all `#[ignore]`). Likely unified in the codegen attribute-lowering path (`crates/svelte_codegen_client/src/template/attributes.rs`) + analyze `scoped_elements` propagation.
-- Last updated: 2026-04-08
+- **Open bugs (2026-04-11 diagnose)**: scope-class injection misses 5 variants — element inside `{#snippet}` body, `<svelte:element>` with static class, class-object attribute (third arg to `$.set_class` is `null`), spread-only element (`$.attribute_effect` emitted with 2 args instead of 6), and concatenated class attributes (`class="static {expr}"`) under scoped CSS (missing scope-hash arg in `$.set_class`). Isolated by `css_scope_class_in_snippet`, `css_scope_svelte_element_class`, `css_scope_class_object`, `css_scope_spread_attribute`, `diagnose_scoped_class_concat` (all `#[ignore]`). Likely unified in the codegen attribute-lowering path (`crates/svelte_codegen_client/src/template/attributes.rs`) + analyze `scoped_elements` propagation.
+- Last updated: 2026-04-11
 
 ## Source
 
@@ -48,6 +48,7 @@ ROADMAP.md — CSS
 - [ ] Scope class injection on `<svelte:element this={...}>` with a static `class="..."` — scope class is not appended either at the template HTML root or in the dynamic class argument passed to `$.element` (test: `css_scope_svelte_element_class`, `#[ignore]`, S)
 - [ ] Scope class argument for class-object attributes — when `class={{ active, big }}` is compiled via `$.set_class`, the third argument must be the scope-hash string (`'svelte-xxxxxx'`) instead of `null` so the runtime can merge it with the object classes (test: `css_scope_class_object`, `#[ignore]`, S)
 - [ ] Scope class pass-through for spread attributes — `$.attribute_effect` is emitted with only 2 arguments for `{...rest}` elements, but the reference emits the full 6-argument form including the trailing scope-hash string, so scope styling is lost on spread-only elements (test: `css_scope_spread_attribute`, `#[ignore]`, S)
+- [ ] Scope class argument for concatenated class attributes under scoped CSS — `class="static {expr}"` lowers via `$.set_class`, but the generated call omits the fourth scope-hash argument so scoped selectors do not match (test: `diagnose_scoped_class_concat`, `#[ignore]`, S)
 - [x] Compile result CSS plumbing — `CompileResult.css` field, `analyze_css_pass()` integrated into `compile()`
 - [ ] `css: "external"` output — mode flag not explicitly enforced; external is current default behavior with no special handling
 - [x] `css: "injected"` output — `const $$css = { hash, code }` hoisted module-level const + `$.append_styles($$anchor, $$css)` as first statement in component body (tests: `css_injected`, `css_injected_via_compile_options`)
@@ -115,3 +116,4 @@ ROADMAP.md — CSS
 - [ ] `css_scope_svelte_element_class` (`#[ignore]`)
 - [ ] `css_scope_class_object` (`#[ignore]`)
 - [ ] `css_scope_spread_attribute` (`#[ignore]`)
+- [ ] `diagnose_scoped_class_concat` (`#[ignore]`)

--- a/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case-rust.js
+++ b/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case-rust.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>x</button>`);
+export default function App($$anchor, $$props) {
+	let theme = $.prop($$props, "theme", 3, "primary");
+	var button = root();
+	$.template_effect(() => $.set_class(button, 1, `ui-button ${theme() ?? ""}`));
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case-svelte.css
+++ b/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case-svelte.css
@@ -1,0 +1,4 @@
+
+	.ui-button.primary.svelte-1kokv56 {
+		background: #0070f3;
+	}

--- a/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case-svelte.js
+++ b/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case-svelte.js
@@ -1,0 +1,8 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<button>x</button>`);
+export default function App($$anchor, $$props) {
+	let theme = $.prop($$props, "theme", 3, "primary");
+	var button = root();
+	$.template_effect(() => $.set_class(button, 1, `ui-button ${theme() ?? ""}`, "svelte-1kokv56"));
+	$.append($$anchor, button);
+}

--- a/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case.svelte
+++ b/tasks/compiler_tests/cases2/diagnose_scoped_class_concat/case.svelte
@@ -1,0 +1,11 @@
+<script>
+	let { theme = 'primary' } = $props();
+</script>
+
+<button class="ui-button {theme}">x</button>
+
+<style>
+	.ui-button.primary {
+		background: #0070f3;
+	}
+</style>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2774,3 +2774,10 @@ fn snippet_destructure_default_state_ref() {
 fn snippet_destructure_default_mutated_state_ref() {
     assert_compiler("snippet_destructure_default_mutated_state_ref");
 }
+
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn diagnose_scoped_class_concat() {
+    assert_compiler("diagnose_scoped_class_concat");
+}


### PR DESCRIPTION
### Motivation
- Isolate and record a deterministic parity mismatch where concatenated `class` attributes under scoped CSS (e.g. `class="ui-button {theme}"`) compile without the trailing scope-hash argument in emitted `$.set_class(...)` compared to the reference compiler. 
- Provide a minimal, durable test case and update the CSS spec so the gap is tracked and owned for a future codegen fix.

### Description
- Added a focused compiler test case `tasks/compiler_tests/cases2/diagnose_scoped_class_concat/` containing `case.svelte` plus generated snapshots `case-svelte.js`, `case-rust.js`, and `case-svelte.css`. 
- Registered the case in `tasks/compiler_tests/test_v3.rs` as an ignored test with `#[ignore = "diagnose: pending fix"]` so the suite remains green while preserving the repro. 
- Updated `specs/css-pipeline.md` Current state / Use cases / Test cases to record the newly isolated open bug and bumped the Last updated date to `2026-04-11`. 
- No compiler implementation code was changed; this is strictly a diagnose/test + spec update to drive a future fix in `crates/svelte_codegen_client/src/template/attributes.rs`.

### Testing
- Ran `just generate` to produce the reference snapshots and the `case-svelte.js`/`case-svelte.css` artifacts, and the command completed successfully. 
- Ran `just test-case-verbose diagnose_scoped_class_concat` which reproduced the parity failure as expected, showing Rust output omits the scope-hash argument while the reference `case-svelte.js` contains it, so the test failed intentionally for diagnosis. 
- Captured the failing diff snapshots under `tasks/compiler_tests/cases2/diagnose_scoped_class_concat/` for future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4ecb151c8321b1728563f2088bfe)