### PR TITLE
diagnose: add parity repro for nested each SVG clock and record follow-up

### DIFF
--- a/specs/each-block.md
+++ b/specs/each-block.md
@@ -1,10 +1,10 @@
 # Each Block
 
 ## Current state
-- **Working**: 18/18 passing client-side `{#each}` use cases.
-- **Just landed**: `collection_id` inner-scope shadowing. When any binding declared inside the each body shadows an outer-scope name, the render callback now emits the extra `$$index, $$array` parameters to match the reference compiler. Detection lives in `crates/svelte_analyze/src/passes/template_side_tables.rs::leave_each_block` via the new `ScopeTable::own_binding_names` accessor; codegen consumes `Ctx::each_needs_collection_id` in `crates/svelte_codegen_client/src/template/each_block.rs` and synthesises both names with `ctx.gen_ident`. (test: `each_inner_shadow`)
-- **Next**: complete; parser-strictness around malformed item-less keyed headers is intentionally not tracked as remaining `{#each}` roadmap work here
-- Last updated: 2026-04-08
+- **Working**: 18/19 passing client-side `{#each}` use cases.
+- **New diagnosis (2026-04-11)**: nested `{#each}` callback params in runes mode are being rewritten to `$.get(...)` inside template-attribute expressions (`transform="rotate(...)"`), which diverges from reference output for non-reactive loop params. Captured by ignored parity case `clock_svg_derived_onmount`. Likely first owning layer: template expression transform/classification for each-scope identifiers.
+- **Next**: fix each-scope identifier classification so non-reactive nested each params (`minute`, `offset`) are emitted as plain identifiers in template expressions, then unignore `clock_svg_derived_onmount`.
+- Last updated: 2026-04-11
 
 ## Source
 
@@ -44,6 +44,7 @@
 - [x] Diagnostic: runes-mode reassignment or binding to an each item should raise `each_item_invalid_assignment`.
 - [x] Inner-scope shadowing: when an each block's inner scope declares a binding that shadows an outer scope name, emit `$$index, $$array` as extra render-callback params (reference: `collection_id` logic in `EachBlock.js` lines 112–123 and 316–318). Runes-only: legacy `transitive_deps`/reassigned-item rewrites are tracked separately. (test: `each_inner_shadow`)
 - [x] Parser support for item-less each blocks with index: `{#each expression, index}`. Compiler coverage exists via `each_block_no_item_with_index`; the stale ignored parser unit test should not keep the roadmap feature open.
+- [ ] Nested each callback params in runes mode remain plain identifiers in template-attribute expressions (no `$.get(...)` wrapping and no extra fallback coercion noise) when the collection expression is non-reactive literals. (test: `clock_svg_derived_onmount`)
 
 ## Out of scope
 
@@ -96,3 +97,4 @@
 - [x] `validate_each_animation_missing_key`
 - [x] `validate_each_animation_invalid_placement`
 - [x] `validate_each_item_invalid_assignment`
+- [ ] `clock_svg_derived_onmount`

--- a/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case-rust.js
+++ b/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case-rust.js
@@ -1,0 +1,65 @@
+import * as $ from "svelte/internal/client";
+import { onMount } from "svelte";
+var root_2 = $.from_svg(`<line class="minor svelte-1kjtqer" y1="42" y2="45"></line>`);
+var root_1 = $.from_svg(`<line class="major svelte-1kjtqer" y1="35" y2="45"></line><!>`, 1);
+var root = $.from_svg(`<svg viewBox="-50 -50 100 100" class="svelte-1kjtqer"><circle class="clock-face svelte-1kjtqer" r="48"></circle><!><line class="hour svelte-1kjtqer" y1="2" y2="-20"></line><line class="minute svelte-1kjtqer" y1="4" y2="-30"></line><g><line class="second svelte-1kjtqer" y1="10" y2="-38"></line><line class="second-counterweight svelte-1kjtqer" y1="10" y2="2"></line></g></svg>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let time = $.state($.proxy(new Date()));
+	let hours = $.derived(() => $.get(time).getHours());
+	let minutes = $.derived(() => $.get(time).getMinutes());
+	let seconds = $.derived(() => $.get(time).getSeconds());
+	onMount(() => {
+		const interval = setInterval(() => {
+			$.set(time, new Date(), true);
+		}, 1e3);
+		return () => {
+			clearInterval(interval);
+		};
+	});
+	var svg = root();
+	var node = $.sibling($.child(svg));
+	$.each(node, 16, () => [
+		0,
+		5,
+		10,
+		15,
+		20,
+		25,
+		30,
+		35,
+		40,
+		45,
+		50,
+		55
+	], $.index, ($$anchor, minute) => {
+		var fragment = root_1();
+		var line = $.first_child(fragment);
+		var node_1 = $.sibling(line);
+		$.each(node_1, 16, () => [
+			1,
+			2,
+			3,
+			4
+		], $.index, ($$anchor, offset) => {
+			var line_1 = root_2();
+			$.template_effect(() => $.set_attribute(line_1, "transform", `rotate(${6 * ($.get(minute) + $.get(offset)) ?? ""})`));
+			$.append($$anchor, line_1);
+		});
+		$.template_effect(() => $.set_attribute(line, "transform", `rotate(${30 * $.get(minute) ?? ""})`));
+		$.append($$anchor, fragment);
+	});
+	var line_2 = $.sibling(node);
+	var line_3 = $.sibling(line_2);
+	var g = $.sibling(line_3);
+	$.next();
+	$.reset(g);
+	$.reset(svg);
+	$.template_effect(() => {
+		$.set_attribute(line_2, "transform", `rotate(${30 * $.get(hours) + $.get(minutes) / 2 ?? ""})`);
+		$.set_attribute(line_3, "transform", `rotate(${6 * $.get(minutes) + $.get(seconds) / 10 ?? ""})`);
+		$.set_attribute(g, "transform", `rotate(${6 * $.get(seconds) ?? ""})`);
+	});
+	$.append($$anchor, svg);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case-svelte.css
+++ b/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case-svelte.css
@@ -1,0 +1,37 @@
+
+	svg.svelte-1kjtqer {
+		width: 100%;
+		height: 100%;
+	}
+
+	.clock-face.svelte-1kjtqer {
+		stroke: #333;
+		fill: white;
+	}
+
+	.minor.svelte-1kjtqer {
+		stroke: #999;
+		stroke-width: 0.5;
+	}
+
+	.major.svelte-1kjtqer {
+		stroke: #333;
+		stroke-width: 1;
+	}
+
+	.hour.svelte-1kjtqer {
+		stroke: #333;
+	}
+
+	.minute.svelte-1kjtqer {
+		stroke: #666;
+	}
+
+	.second.svelte-1kjtqer,
+	.second-counterweight.svelte-1kjtqer {
+		stroke: rgb(180, 0, 0);
+	}
+
+	.second-counterweight.svelte-1kjtqer {
+		stroke-width: 3;
+	}

--- a/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case-svelte.js
+++ b/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case-svelte.js
@@ -1,0 +1,63 @@
+import * as $ from "svelte/internal/client";
+import { onMount } from "svelte";
+var root_2 = $.from_svg(`<line class="minor svelte-1kjtqer" y1="42" y2="45"></line>`);
+var root_1 = $.from_svg(`<line class="major svelte-1kjtqer" y1="35" y2="45"></line><!>`, 1);
+var root = $.from_svg(`<svg viewBox="-50 -50 100 100" class="svelte-1kjtqer"><circle class="clock-face svelte-1kjtqer" r="48"></circle><!><line class="hour svelte-1kjtqer" y1="2" y2="-20"></line><line class="minute svelte-1kjtqer" y1="4" y2="-30"></line><g><line class="second svelte-1kjtqer" y1="10" y2="-38"></line><line class="second-counterweight svelte-1kjtqer" y1="10" y2="2"></line></g></svg>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let time = $.state($.proxy(new Date()));
+	let hours = $.derived(() => $.get(time).getHours());
+	let minutes = $.derived(() => $.get(time).getMinutes());
+	let seconds = $.derived(() => $.get(time).getSeconds());
+	onMount(() => {
+		const interval = setInterval(() => {
+			$.set(time, new Date(), true);
+		}, 1e3);
+		return () => {
+			clearInterval(interval);
+		};
+	});
+	var svg = root();
+	var node = $.sibling($.child(svg));
+	$.each(node, 16, () => [
+		0,
+		5,
+		10,
+		15,
+		20,
+		25,
+		30,
+		35,
+		40,
+		45,
+		50,
+		55
+	], $.index, ($$anchor, minute) => {
+		var fragment = root_1();
+		var line = $.first_child(fragment);
+		var node_1 = $.sibling(line);
+		$.each(node_1, 16, () => [
+			1,
+			2,
+			3,
+			4
+		], $.index, ($$anchor, offset) => {
+			var line_1 = root_2();
+			$.template_effect(() => $.set_attribute(line_1, "transform", `rotate(${6 * (minute + offset)})`));
+			$.append($$anchor, line_1);
+		});
+		$.template_effect(() => $.set_attribute(line, "transform", `rotate(${30 * minute})`));
+		$.append($$anchor, fragment);
+	});
+	var line_2 = $.sibling(node);
+	var line_3 = $.sibling(line_2);
+	var g = $.sibling(line_3);
+	$.reset(svg);
+	$.template_effect(() => {
+		$.set_attribute(line_2, "transform", `rotate(${30 * $.get(hours) + $.get(minutes) / 2})`);
+		$.set_attribute(line_3, "transform", `rotate(${6 * $.get(minutes) + $.get(seconds) / 10})`);
+		$.set_attribute(g, "transform", `rotate(${6 * $.get(seconds)})`);
+	});
+	$.append($$anchor, svg);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case.svelte
+++ b/tasks/compiler_tests/cases2/clock_svg_derived_onmount/case.svelte
@@ -1,0 +1,78 @@
+<script>
+	import { onMount } from 'svelte';
+
+	let time = $state(new Date());
+
+	let hours = $derived(time.getHours());
+	let minutes = $derived(time.getMinutes());
+	let seconds = $derived(time.getSeconds());
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			time = new Date();
+		}, 1000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	});
+</script>
+
+<svg viewBox="-50 -50 100 100">
+	<circle class="clock-face" r="48" />
+
+	{#each [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55] as minute}
+		<line class="major" y1="35" y2="45" transform="rotate({30 * minute})" />
+
+		{#each [1, 2, 3, 4] as offset}
+			<line class="minor" y1="42" y2="45" transform="rotate({6 * (minute + offset)})" />
+		{/each}
+	{/each}
+
+	<line class="hour" y1="2" y2="-20" transform="rotate({30 * hours + minutes / 2})" />
+	<line class="minute" y1="4" y2="-30" transform="rotate({6 * minutes + seconds / 10})" />
+
+	<g transform="rotate({6 * seconds})">
+		<line class="second" y1="10" y2="-38" />
+		<line class="second-counterweight" y1="10" y2="2" />
+	</g>
+</svg>
+
+<style>
+	svg {
+		width: 100%;
+		height: 100%;
+	}
+
+	.clock-face {
+		stroke: #333;
+		fill: white;
+	}
+
+	.minor {
+		stroke: #999;
+		stroke-width: 0.5;
+	}
+
+	.major {
+		stroke: #333;
+		stroke-width: 1;
+	}
+
+	.hour {
+		stroke: #333;
+	}
+
+	.minute {
+		stroke: #666;
+	}
+
+	.second,
+	.second-counterweight {
+		stroke: rgb(180, 0, 0);
+	}
+
+	.second-counterweight {
+		stroke-width: 3;
+	}
+</style>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2774,3 +2774,9 @@ fn snippet_destructure_default_state_ref() {
 fn snippet_destructure_default_mutated_state_ref() {
     assert_compiler("snippet_destructure_default_mutated_state_ref");
 }
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn clock_svg_derived_onmount() {
+    assert_compiler("clock_svg_derived_onmount");
+}


### PR DESCRIPTION
### Motivation
- Reproduce and capture a parity mismatch where nested `{#each}` callback params in an SVG `transform` attribute are being rewritten to `$.get(...)` and coerced with `?? ""`, diverging from the reference compiler output.
- The failure appears to originate in template-expression transform/classification for each-scope identifiers, so a focused repro and spec entry are needed before implementing a fix.
- Make the repro durable in the test registry while keeping the default suite green using the diagnose workflow semantics.

### Description
- Added a new compiler parity case `tasks/compiler_tests/cases2/clock_svg_derived_onmount/case.svelte` and its generated snapshots `case-svelte.js`, `case-rust.js`, and `case-svelte.css` to capture the divergence.
- Registered the case in the test registry with an ignored test entry in `tasks/compiler_tests/test_v3.rs` as `#[ignore = "diagnose: pending fix"]` so the repro is durable but does not break the default CI.
- Updated `specs/each-block.md` Current state and Use cases to record the diagnosis, mark the item open, and assign the likely owning layer and next step.
- Ran snapshot generation to capture current outputs so the mismatch is persisted for follow-up work.

### Testing
- Ran `just generate` to regenerate snapshots and it completed successfully.
- Ran `just test-case-verbose clock_svg_derived_onmount` (which executes the ignored case with `--include-ignored`) and it failed with a JS output mismatch, as expected for the captured diagnosis.
- Ran `just test-case clock_svg_derived_onmount` and it also failed (expected) demonstrating the recorded `case-rust.js` / `case-svelte.js` divergence is reproducible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4f2fbb1c8321860ea60402be5380)