### PR TITLE
diagnose: add component onclick-state repro and track parity gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Details per feature live in `specs/` — run `/audit <feature>` to generate or u
 ## Template
 
 - [ ] Element — [spec](specs/element.md)
-- [x] `<Component>` / component — [spec](specs/component-node.md)
+- [ ] `<Component>` / component — [spec](specs/component-node.md)
 - [x] `{#if}` / `{:else}` — [spec](specs/if-block.md)
 - [x] `{#each}` — [spec](specs/each-block.md)
 - [x] `{#await}` — [spec](specs/await-block.md)

--- a/specs/component-node.md
+++ b/specs/component-node.md
@@ -1,14 +1,12 @@
 # ComponentNode
 
 ## Current state
-- **Working**: 15/15 component-tag use cases
-- **Current slice:** root-aware dotted dynamic component refs
-- **Completed slice:** root-aware dotted dynamic component refs
-- **Done in this slice:** analyze now retains the resolved component root symbol for any bound component tag, and client codegen rebuilds dotted dynamic refs from `TemplateBindingReadKind`, so roots like `<registry.Widget />` lower through the same `Identifier` / `ThunkCall` / `$.get` / `$.safe_get` / `$$props` semantics as ordinary template reads
-- **Why this slice came next:** post-implementation review found one remaining codegen gap: dotted dynamic component refs still bypassed template binding read semantics for their root binding, so props-backed roots like `<registry.Widget />` lowered as plain `registry.Widget` instead of `$$props.registry.Widget`
-- **Repro:** `just test-case component_dynamic_dotted_props_root`
-- **Next:** `component-node` use cases are fully covered again; if future reference gaps are found, record them as new unchecked use cases before resuming
-- **Verification:** `just generate`, `just test-case component_dynamic_dotted_props_root`, `just test-case component_dynamic_dotted`, `just test-case component_dynamic_props_access`, `just test-case component_local_underscored_bind_this`, `just test-analyzer`, and `just test-compiler` passed on 2026-04-11
+- **Working**: 15/16 component-tag use cases
+- **Current slice:** diagnose follow-up for component `onclick` callback props that mutate `$state`
+- **Done this session:** added ignored parity repro `diagnose_component_onclick_state`; Rust currently memoizes inline `onclick={() => count++}` into a derived getter on component props, while reference output keeps the inline callback expression directly in props
+- **Repro:** `just test-case-verbose diagnose_component_onclick_state`
+- **Next:** decide whether callback-prop memoization ownership belongs to analyze classification (`has_call`) or component prop emission in client codegen, then port a fix and unignore the diagnosis case
+- **Verification:** `just generate` passed; `just test-case-verbose diagnose_component_onclick_state` fails with JS mismatch on 2026-04-11 (expected for diagnosis tracking)
 - Last updated: 2026-04-11
 
 ## Source
@@ -40,6 +38,7 @@
 - [x] Default children lower to `children` prop plus `$$slots.default` (tests: `component_children`, `component_element_children`)
 - [x] Snippet children and snippet props lower correctly (tests: `component_snippet_prop`, `component_snippet_with_children`, `component_multiple_snippets`, `component_snippet_only`)
 - [x] Complex expression props memoize when needed (tests: `component_prop_has_call`, `component_prop_has_call_multi`, `component_prop_has_call_mixed`, `component_prop_memo_state`)
+- [ ] Inline callback component props that mutate `$state` (for example `onclick={() => count++}`) should stay as direct callback expressions instead of being memoized through derived getter wrappers (test: `diagnose_component_onclick_state`)
 - [x] `on:` directives on components serialize into `$$events`, including dev-mode shared-handler wrapping parity (tests: `component_events`, `component_events_dev_apply`)
 - [x] Child nodes with `slot="name"` serialize into named `$$slots.<name>` instead of default children (tests: `component_named_slot`)
 - [x] Runes-mode dotted or stateful component references lower through `$.component(...)`, including dotted roots whose first segment is a lowercase JS identifier containing `_` or `$` and dynamic refs read from `$$props` (tests: `component_dynamic_dotted`, `component_dynamic_dotted_identifier_root`, `component_dynamic_props_access`)
@@ -86,5 +85,6 @@
 - [x] `component_dynamic_props_access`
 - [x] `component_dynamic_dotted_props_root`
 - [x] `component_local_underscored_bind_this`
+- [ ] `diagnose_component_onclick_state`
 - [x] analyzer unit tests: component invalid directive, component `on:` modifier validation, component illegal colon warning, component unquoted attribute sequence
 - [x] analyzer unit tests: duplicate named slot, explicit default-slot conflict, distinct named slots, whitespace-only default-slot false-positive guard

--- a/tasks/compiler_tests/cases2/diagnose_component_onclick_state/case-rust.js
+++ b/tasks/compiler_tests/cases2/diagnose_component_onclick_state/case-rust.js
@@ -1,0 +1,21 @@
+import * as $ from "svelte/internal/client";
+import Button from "./Button.svelte";
+export default function App($$anchor) {
+	let count = $.state(0);
+	{
+		let $0 = $.derived(() => () => $.update(count));
+		Button($$anchor, {
+			theme: "primary",
+			get onclick() {
+				return $.get($0);
+			},
+			children: ($$anchor, $$slotProps) => {
+				$.next();
+				var text = $.text();
+				$.template_effect(() => $.set_text(text, `Clicked ${$.get(count) ?? ""} times`));
+				$.append($$anchor, text);
+			},
+			$$slots: { default: true }
+		});
+	}
+}

--- a/tasks/compiler_tests/cases2/diagnose_component_onclick_state/case-svelte.js
+++ b/tasks/compiler_tests/cases2/diagnose_component_onclick_state/case-svelte.js
@@ -1,0 +1,16 @@
+import * as $ from "svelte/internal/client";
+import Button from "./Button.svelte";
+export default function App($$anchor) {
+	let count = $.state(0);
+	Button($$anchor, {
+		theme: "primary",
+		onclick: () => $.update(count),
+		children: ($$anchor, $$slotProps) => {
+			$.next();
+			var text = $.text();
+			$.template_effect(() => $.set_text(text, `Clicked ${$.get(count) ?? ""} times`));
+			$.append($$anchor, text);
+		},
+		$$slots: { default: true }
+	});
+}

--- a/tasks/compiler_tests/cases2/diagnose_component_onclick_state/case.svelte
+++ b/tasks/compiler_tests/cases2/diagnose_component_onclick_state/case.svelte
@@ -1,0 +1,6 @@
+<script>
+	import Button from './Button.svelte';
+	let count = $state(0);
+</script>
+
+<Button theme="primary" onclick={() => count++}>Clicked {count} times</Button>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2774,3 +2774,9 @@ fn snippet_destructure_default_state_ref() {
 fn snippet_destructure_default_mutated_state_ref() {
     assert_compiler("snippet_destructure_default_mutated_state_ref");
 }
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn diagnose_component_onclick_state() {
+    assert_compiler("diagnose_component_onclick_state");
+}


### PR DESCRIPTION
### Motivation
- Capture and track a parity regression where inline component callback props that mutate `$state` are memoized incorrectly in the Rust output compared to the reference compiler. 
- Provide a durable, focused test to drive the follow-up porting work and record ownership in the component spec.

### Description
- Added a focused e2e repro `tasks/compiler_tests/cases2/diagnose_component_onclick_state/case.svelte` exercising `onclick={() => count++}` with `$state` and generated matching snapshots (`case-svelte.js`, `case-rust.js`).
- Registered the case in the compiler test registry by adding an ignored test in `tasks/compiler_tests/test_v3.rs` (`#[ignore = "diagnose: pending fix"]`) so CI remains green while the issue is tracked.
- Updated `specs/component-node.md` to record the diagnosis, the likely owning layer, the new unchecked use case, and the test-case entry.
- Re-opened the `<Component>` roadmap item in `ROADMAP.md` to reflect the spec is no longer fully complete.

### Testing
- Ran `just generate`, which succeeded and produced the generated JS snapshots for the new case.
- Ran `just test-case-verbose diagnose_component_onclick_state` (with ignored tests included) and observed an expected JS mismatch: the Rust output memoizes the inline callback via a derived getter while the reference keeps the inline callback; the test failed as intended to capture the parity gap.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4f1b99d48321b05d579ec49a2038)