### PR TITLE
diagnose: add focused repro for TS script comment leakage

### DIFF
--- a/specs/unknown.md
+++ b/specs/unknown.md
@@ -2,8 +2,8 @@
 
 ## Current state
 
-- **Working**: 0 recorded unknown items
-- **Next**: first unowned repro or failing test discovered by `/diagnose`
+- **Working**: 1 recorded unknown item
+- **Next**: TS script comment leaks into client output and perturbs template cursor state
 - Last updated: 2026-04-11
 
 ## Source
@@ -11,6 +11,8 @@
 - User request: create a durable triage spec for problems that do not yet map to one owning feature spec
 
 ## Use cases
+
+- [ ] TS script comment leaks into client output and perturbs template cursor state — layer: codegen; repro/test: diagnose_svg_city_icon; candidate specs: none; suggested spec: typescript-script-stripping
 
 ## Out of scope
 
@@ -31,3 +33,5 @@
 - `tasks/compiler_tests/cases2/`
 
 ## Test cases
+
+- [ ] diagnose_svg_city_icon

--- a/tasks/compiler_tests/cases2/diagnose_svg_city_icon/case-rust.js
+++ b/tasks/compiler_tests/cases2/diagnose_svg_city_icon/case-rust.js
@@ -1,0 +1,9 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_svg(`<svg viewBox="0 0 24 24" fill="none" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="11" width="6" height="10" stroke="#0070f3" stroke-width="2"></rect><rect x="9" y="7" width="6" height="14" stroke="#0070f3" stroke-width="2"></rect><rect x="15" y="3" width="6" height="18" stroke="#0070f3" stroke-width="2"></rect></svg>`);
+export default function App($$anchor) {
+	var svg = root();
+	$.next(2);
+	$.reset(svg);
+	$.append($$anchor, svg);
+	// City icon
+}

--- a/tasks/compiler_tests/cases2/diagnose_svg_city_icon/case-svelte.js
+++ b/tasks/compiler_tests/cases2/diagnose_svg_city_icon/case-svelte.js
@@ -1,0 +1,6 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_svg(`<svg viewBox="0 0 24 24" fill="none" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="11" width="6" height="10" stroke="#0070f3" stroke-width="2"></rect><rect x="9" y="7" width="6" height="14" stroke="#0070f3" stroke-width="2"></rect><rect x="15" y="3" width="6" height="18" stroke="#0070f3" stroke-width="2"></rect></svg>`);
+export default function App($$anchor) {
+	var svg = root();
+	$.append($$anchor, svg);
+}

--- a/tasks/compiler_tests/cases2/diagnose_svg_city_icon/case.svelte
+++ b/tasks/compiler_tests/cases2/diagnose_svg_city_icon/case.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	// City icon
+</script>
+
+<svg viewBox="0 0 24 24" fill="none" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+	<rect x="3" y="11" width="6" height="10" stroke="#0070f3" stroke-width="2" />
+	<rect x="9" y="7" width="6" height="14" stroke="#0070f3" stroke-width="2" />
+	<rect x="15" y="3" width="6" height="18" stroke="#0070f3" stroke-width="2" />
+</svg>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2774,3 +2774,9 @@ fn snippet_destructure_default_state_ref() {
 fn snippet_destructure_default_mutated_state_ref() {
     assert_compiler("snippet_destructure_default_mutated_state_ref");
 }
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn diagnose_svg_city_icon() {
+    assert_compiler("diagnose_svg_city_icon");
+}


### PR DESCRIPTION
### Motivation

- Capture a reproducible mismatch where a `<script lang="ts">` containing only a comment leaks into emitted client JS and perturbs template cursor bookkeeping, so the failure is durable and triaged.  
- The issue appears to originate in client emission (extra `$.next`, `$.reset` and trailing `// City icon`), so the first owning layer is recorded as `codegen` for follow-up.

### Description

- Add a focused compiler repro `tasks/compiler_tests/cases2/diagnose_svg_city_icon/case.svelte` containing the minimal TS script comment + SVG markup.  
- Register the case in the e2e suite with an ignored test in `tasks/compiler_tests/test_v3.rs` using `#[ignore = "diagnose: pending fix"]`.  
- Commit generated snapshots `case-svelte.js` (reference) and `case-rust.js` (current Rust output) under `tasks/compiler_tests/cases2/diagnose_svg_city_icon/`.  
- Record the unowned follow-up in `specs/unknown.md` with the owning-layer hypothesis and link to the repro test for triage and a future `port` session.

### Testing

- Ran `just generate` to produce snapshots, which completed successfully.  
- Ran `just test-case-verbose diagnose_svg_city_icon`, which reproduced the expected mismatch (test failed with JS output diff showing extra `$.next`, `$.reset`, and leaked comment); the test is intentionally ignored in the suite pending a fix.  
- Default test suite remains green because the new case is registered with `#[ignore = "diagnose: pending fix"]`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4eff68b08321ac9d20d425733bd9)