### PR TITLE
diagnose: add compiler parity case for TS $props/$bindable checkbox shorthand mismatch

### DIFF
--- a/specs/unknown.md
+++ b/specs/unknown.md
@@ -2,8 +2,8 @@
 
 ## Current state
 
-- **Working**: 0 recorded unknown items
-- **Next**: first unowned repro or failing test discovered by `/diagnose`
+- **Working**: 1 recorded unknown item
+- **Next**: TS `$props` + `$bindable` checkbox binding emits non-reference codegen for `bind:checked` and `{disabled}` shorthand
 - Last updated: 2026-04-11
 
 ## Source
@@ -11,6 +11,8 @@
 - User request: create a durable triage spec for problems that do not yet map to one owning feature spec
 
 ## Use cases
+
+- [ ] TS `$props` + `$bindable` checkbox binding emits non-reference codegen for `bind:checked` and `{disabled}` shorthand — layer: codegen; repro/test: props_bindable_checkbox_disabled_shorthand_ts; candidate specs: specs/props-bindable.md, specs/bind-directives.md; suggested spec: none
 
 ## Out of scope
 
@@ -31,3 +33,5 @@
 - `tasks/compiler_tests/cases2/`
 
 ## Test cases
+
+- [ ] props_bindable_checkbox_disabled_shorthand_ts

--- a/tasks/compiler_tests/cases2/props_bindable_checkbox_disabled_shorthand_ts/case-rust.js
+++ b/tasks/compiler_tests/cases2/props_bindable_checkbox_disabled_shorthand_ts/case-rust.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="checkbox"/>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let checked = $.prop($$props, "checked", 15, false), disabled = $.prop($$props, "disabled", 3, false);
+	var input = root();
+	$.remove_input_defaults(input);
+	$.template_effect(() => $.set_attribute(input, "disabled", disabled()));
+	$.bind_checked(input, () => $.get(checked), ($$value) => $.set(checked, $$value));
+	$.append($$anchor, input);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/props_bindable_checkbox_disabled_shorthand_ts/case-svelte.js
+++ b/tasks/compiler_tests/cases2/props_bindable_checkbox_disabled_shorthand_ts/case-svelte.js
@@ -1,0 +1,12 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<input type="checkbox"/>`);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	let checked = $.prop($$props, "checked", 15, false), disabled = $.prop($$props, "disabled", 3, false);
+	var input = root();
+	$.remove_input_defaults(input);
+	$.template_effect(() => input.disabled = disabled());
+	$.bind_checked(input, checked);
+	$.append($$anchor, input);
+	$.pop();
+}

--- a/tasks/compiler_tests/cases2/props_bindable_checkbox_disabled_shorthand_ts/case.svelte
+++ b/tasks/compiler_tests/cases2/props_bindable_checkbox_disabled_shorthand_ts/case.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	type Props = {
+		checked?: boolean;
+		disabled?: boolean;
+	};
+
+	let { checked = $bindable(false), disabled = false }: Props = $props();
+</script>
+
+<input type="checkbox" bind:checked {disabled} />

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2774,3 +2774,9 @@ fn snippet_destructure_default_state_ref() {
 fn snippet_destructure_default_mutated_state_ref() {
     assert_compiler("snippet_destructure_default_mutated_state_ref");
 }
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn props_bindable_checkbox_disabled_shorthand_ts() {
+    assert_compiler("props_bindable_checkbox_disabled_shorthand_ts");
+}


### PR DESCRIPTION
### Motivation
- Capture a reproducible codegen parity mismatch when a TypeScript `$props()` destructure with `$bindable()` is combined with a checkbox using `bind:checked` and the `{disabled}` shorthand. 
- The failure appears to be a codegen divergence: the reference emits a direct DOM property assignment + direct bind signal while the Rust implementation emits an attribute setter and wrapper closures.
- Record this as a durable triage item so ownership and the next implementation steps can be planned.

### Description
- Add a focused compiler test case `props_bindable_checkbox_disabled_shorthand_ts` under `tasks/compiler_tests/cases2/` containing the minimal TS repro `case.svelte` and the generated snapshots (`case-svelte.js` and `case-rust.js`).
- Register the case in `tasks/compiler_tests/test_v3.rs` as ignored with `#[ignore = "diagnose: pending fix"]` to keep the default test suite stable.
- Update `specs/unknown.md` with one unchecked use case describing the problem, classifying the first owning layer as `codegen`, and listing candidate specs `specs/props-bindable.md` and `specs/bind-directives.md`.
- The generated snapshot difference shows the reference doing `input.disabled = disabled()` and `$.bind_checked(input, checked)` while Rust emits `$.set_attribute(input, "disabled", disabled())` and a closure-backed `$.bind_checked(...get/set...)`.

### Testing
- Ran `just generate` to produce the case snapshots, which completed successfully.
- Ran `just test-case-verbose props_bindable_checkbox_disabled_shorthand_ts` to reproduce the mismatch and observed a deterministic JS mismatch (expected failure for diagnose flow).
- Ran `cargo test -p compiler_tests --test compiler_tests_v3 props_bindable_checkbox_disabled_shorthand_ts` which is ignored by default and therefore the test suite remains green (the ignored case is present as intended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4ed8ee0c832188c95ae6724f2957)