### PR TITLE
Diagnose: keyed {#each} index-key mismatch - add focused failing test

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Details per feature live in `specs/` — run `/audit <feature>` to generate or u
 - [ ] Element — [spec](specs/element.md)
 - [x] `<Component>` / component — [spec](specs/component-node.md)
 - [x] `{#if}` / `{:else}` — [spec](specs/if-block.md)
-- [x] `{#each}` — [spec](specs/each-block.md)
+- [ ] `{#each}` — [spec](specs/each-block.md)
 - [x] `{#await}` — [spec](specs/await-block.md)
 - [x] `{#key}` — [spec](specs/key-block.md)
 - [x] `{#snippet}` / `{@render}` — [spec](specs/snippet-block.md)

--- a/specs/each-block.md
+++ b/specs/each-block.md
@@ -1,10 +1,11 @@
 # Each Block
 
 ## Current state
-- **Working**: 18/18 passing client-side `{#each}` use cases.
+- **Working**: 18/19 passing client-side `{#each}` use cases.
 - **Just landed**: `collection_id` inner-scope shadowing. When any binding declared inside the each body shadows an outer-scope name, the render callback now emits the extra `$$index, $$array` parameters to match the reference compiler. Detection lives in `crates/svelte_analyze/src/passes/template_side_tables.rs::leave_each_block` via the new `ScopeTable::own_binding_names` accessor; codegen consumes `Ctx::each_needs_collection_id` in `crates/svelte_codegen_client/src/template/each_block.rs` and synthesises both names with `ctx.gen_ident`. (test: `each_inner_shadow`)
-- **Next**: complete; parser-strictness around malformed item-less keyed headers is intentionally not tracked as remaining `{#each}` roadmap work here
-- Last updated: 2026-04-08
+- **Open bug (2026-04-11 diagnose)**: keyed `{#each}` with key expression exactly equal to the index identifier (example: `{#each facts as fact, i (i)}`) does not match reference output. Rust currently emits a generic key callback `(fact, i) => i` and sets each flags to `23`, while the reference emits `$.index` and flags `21` (test: `each_key_is_index_literal_diagnose`, ignored pending fix).
+- **Next**: fix index-key specialization so `{#each ... , i (i)}` emits `$.index` plus matching each flags, then unignore `each_key_is_index_literal_diagnose`
+- Last updated: 2026-04-11
 
 ## Source
 
@@ -30,6 +31,7 @@
 - [x] Item iteration with index: `{#each items as item, i}`.
 - [x] Non-keyed each-block index identifier in interpolated text is NOT wrapped in `?? ""` (reference treats bare `index` as `is_defined`). Keyed each blocks transform `i` into `$.get(i)` (a call expression), so those correctly keep the `?? ""` fallback. (test: `each_index_text_no_coalesce`)
 - [x] Keyed each blocks, including key expressions that reference the index.
+- [ ] Keyed each blocks where the key expression is exactly the index identifier should emit `$.index` and the same each flags as the reference compiler (test: `each_key_is_index_literal_diagnose`).
 - [x] Key-is-item optimization in runes mode.
 - [x] Destructured object and array patterns.
 - [x] Destructured defaults inside each context.
@@ -76,6 +78,7 @@
 - [x] `each_block`
 - [x] `each_keyed_index`
 - [x] `each_key_uses_index`
+- [ ] `each_key_is_index_literal_diagnose`
 - [x] `each_key_is_item`
 - [x] `each_destructured_obj`
 - [x] `each_destructured_array`

--- a/tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case-rust.js
+++ b/tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case-rust.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<li> </li>`);
+var root = $.from_html(`<ol></ol>`);
+export default function App($$anchor) {
+	const facts = [
+		"Cats have five toes on their front paws, but only four on the back.",
+		"A group of flamingos is called a 'flamboyance'.",
+		"Bananas are berries, but strawberries aren't."
+	];
+	var ol = root();
+	$.each(ol, 23, () => facts, (fact, i) => i, ($$anchor, fact) => {
+		var li = root_1();
+		var text = $.child(li, true);
+		$.reset(li);
+		$.template_effect(() => $.set_text(text, $.get(fact)));
+		$.append($$anchor, li);
+	});
+	$.reset(ol);
+	$.append($$anchor, ol);
+}

--- a/tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case-svelte.js
+++ b/tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case-svelte.js
@@ -1,0 +1,20 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<li> </li>`);
+var root = $.from_html(`<ol></ol>`);
+export default function App($$anchor) {
+	const facts = [
+		"Cats have five toes on their front paws, but only four on the back.",
+		"A group of flamingos is called a 'flamboyance'.",
+		"Bananas are berries, but strawberries aren't."
+	];
+	var ol = root();
+	$.each(ol, 21, () => facts, $.index, ($$anchor, fact) => {
+		var li = root_1();
+		var text = $.child(li, true);
+		$.reset(li);
+		$.template_effect(() => $.set_text(text, $.get(fact)));
+		$.append($$anchor, li);
+	});
+	$.reset(ol);
+	$.append($$anchor, ol);
+}

--- a/tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case.svelte
+++ b/tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case.svelte
@@ -1,0 +1,13 @@
+<script>
+	const facts = [
+		'Cats have five toes on their front paws, but only four on the back.',
+		"A group of flamingos is called a 'flamboyance'.",
+		"Bananas are berries, but strawberries aren't."
+	];
+</script>
+
+<ol>
+	{#each facts as fact, i (i)}
+		<li>{fact}</li>
+	{/each}
+</ol>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -2168,6 +2168,12 @@ fn each_keyed_index() {
 }
 
 #[rstest]
+#[ignore = "diagnose: pending fix"]
+fn each_key_is_index_literal_diagnose() {
+    assert_compiler("each_key_is_index_literal_diagnose");
+}
+
+#[rstest]
 fn each_key_uses_index() {
     assert_compiler("each_key_uses_index");
 }


### PR DESCRIPTION
### Motivation
- A repro using `{#each facts as fact, i (i)}` revealed a parity gap where the Rust compiler emits a generic key callback and different each-flags instead of the reference fast-path `$.index` + matching flags.
- Capture the failure as a durable, focused test so the owning spec can track the bug and follow-up work can be scheduled correctly.

### Description
- Added a new compiler test case `tasks/compiler_tests/cases2/each_key_is_index_literal_diagnose/case.svelte` reproducing the `{#each ... , i (i)}` scenario and generated `case-svelte.js` and `case-rust.js` snapshots.
- Registered an ignored diagnose-owned test in `tasks/compiler_tests/test_v3.rs` as `#[ignore = "diagnose: pending fix"]` for `each_key_is_index_literal_diagnose` so the suite remains green.
- Updated `specs/each-block.md` to record an open bug, add the focused test to the spec `Test cases`, and describe the expected vs actual output.
- Reopened the `{#each}` item in `ROADMAP.md` to reflect the newly discovered open gap.

### Testing
- Ran `just generate` to produce `case-svelte.js` (succeeded).
- Ran `just test-case-verbose each_key_is_index_literal_diagnose` which executes the single ignored test with `--include-ignored`; it reproduced the JS mismatch (test failed as expected), demonstrating the parity regression.
- The generated snapshots (`case-svelte.js` and `case-rust.js`) were recorded for review and follow-up implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4f5fa6b883219444e971020f00ca)