### PR TITLE
Validate $props/$props.id in module scripts and add dev-mode ownership mutation checks for prop member writes

### DIFF
--- a/crates/svelte_analyze/src/validate/mod.rs
+++ b/crates/svelte_analyze/src/validate/mod.rs
@@ -34,6 +34,7 @@ pub fn validate(
     validate_module_program(parsed, diags);
     if let Some(module_program) = &parsed.module_program {
         let offset = parsed.module_script_content_span.map_or(0, |s| s.start);
+        runes::validate_module_props_runes(data, module_program, offset, runes, diags);
         stores::validate_module(data, module_program, offset, diags);
         validate_perf_class_warnings(module_program, offset, 0, diags);
     }

--- a/crates/svelte_analyze/src/validate/runes.rs
+++ b/crates/svelte_analyze/src/validate/runes.rs
@@ -37,29 +37,23 @@ pub(super) fn validate(
     runes: bool,
     diags: &mut Vec<Diagnostic>,
 ) {
-    let mut v = RuneValidator {
-        diags,
-        offset,
-        runes,
-        custom_element: data.output.custom_element,
-        in_var_declarator_init: false,
-        in_class_property_init: false,
-        in_constructor_body: false,
-        in_this_assign_rhs: false,
-        in_expression_statement_expr: false,
-        current_expr_stmt_span: None,
-        fn_body_first_stmt_span: None,
-        in_generator: false,
-        function_depth: 0,
-        has_props_rune: false,
-        has_props_id: false,
-        in_props_destructure: false,
-    };
+    let mut v = RuneValidator::new(data, diags, offset, runes, true);
     v.visit_program(program);
     validate_derived_invalid_export(data, program, offset, diags);
     validate_state_invalid_export(data, program, offset, diags);
     validate_state_referenced_locally_derived(data, program, offset, diags);
     validate_rest_prop_illegal_access(data, program, offset, diags);
+}
+
+pub(super) fn validate_module_props_runes(
+    data: &AnalysisData,
+    program: &oxc_ast::ast::Program<'_>,
+    offset: u32,
+    runes: bool,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let mut v = RuneValidator::new(data, diags, offset, runes, false);
+    v.visit_program(program);
 }
 
 struct RuneValidator<'a> {
@@ -90,10 +84,40 @@ struct RuneValidator<'a> {
     /// True when visiting the binding pattern of a `$props()` destructure.
     /// Used for `$bindable()` placement validation.
     in_props_destructure: bool,
+    /// True for `<script>`, false for `<script module>`.
+    is_instance_script: bool,
     custom_element: bool,
 }
 
 impl RuneValidator<'_> {
+    fn new<'a>(
+        data: &AnalysisData,
+        diags: &'a mut Vec<Diagnostic>,
+        offset: u32,
+        runes: bool,
+        is_instance_script: bool,
+    ) -> RuneValidator<'a> {
+        RuneValidator {
+            diags,
+            offset,
+            runes,
+            in_var_declarator_init: false,
+            in_class_property_init: false,
+            in_constructor_body: false,
+            in_this_assign_rhs: false,
+            in_expression_statement_expr: false,
+            current_expr_stmt_span: None,
+            fn_body_first_stmt_span: None,
+            in_generator: false,
+            function_depth: 0,
+            has_props_rune: false,
+            has_props_id: false,
+            in_props_destructure: false,
+            is_instance_script,
+            custom_element: data.output.custom_element,
+        }
+    }
+
     fn span(&self, oxc: oxc_span::Span) -> Span {
         Span::new(oxc.start + self.offset, oxc.end + self.offset)
     }
@@ -502,6 +526,22 @@ impl<'a> Visit<'a> for RuneValidator<'_> {
             walk_call_expression(self, call);
             return;
         };
+
+        if !self.is_instance_script {
+            match rune {
+                RuneKind::Props => self.diags.push(Diagnostic::error(
+                    DiagnosticKind::PropsInvalidPlacement,
+                    self.span(call.span),
+                )),
+                RuneKind::PropsId => self.diags.push(Diagnostic::error(
+                    DiagnosticKind::PropsIdInvalidPlacement,
+                    self.span(call.span),
+                )),
+                _ => {}
+            }
+            walk_call_expression(self, call);
+            return;
+        }
 
         if matches!(
             rune,

--- a/crates/svelte_codegen_client/src/lib.rs
+++ b/crates/svelte_codegen_client/src/lib.rs
@@ -53,6 +53,7 @@ pub fn generate<'a>(
     let script_imports = script_output.imports;
     let script_body = script_output.body;
     let has_tracing = script_output.has_tracing;
+    let needs_ownership_validator = script_output.needs_ownership_validator;
     let mut script_comments = script_output.comments;
     let mut script_source_text = script_output.source_text;
     let mut script_span_end = script_output.program_span_end;
@@ -156,6 +157,16 @@ pub fn generate<'a>(
     }
     if ctx.state.needs_binding_group {
         fn_body.push(ctx.b.const_stmt("binding_group", ctx.b.empty_array_expr()));
+    }
+
+    if ctx.state.dev && needs_ownership_validator {
+        fn_body.push(ctx.b.const_stmt(
+            "$$ownership_validator",
+            ctx.b.call_expr(
+                "$.create_ownership_validator",
+                [Arg::Ident("$$props")],
+            ),
+        ));
     }
 
     // Store subscription setup:

--- a/crates/svelte_codegen_client/src/script/model.rs
+++ b/crates/svelte_codegen_client/src/script/model.rs
@@ -114,6 +114,7 @@ pub(super) struct ScriptTransformer<'b, 'a> {
     pub(super) is_ts: bool,
     pub(super) function_info_stack: Vec<FunctionInfo>,
     pub(super) has_tracing: bool,
+    pub(super) needs_ownership_validator: bool,
     pub(super) component_source: &'b str,
     pub(super) script_content_start: u32,
     pub(super) filename: &'b str,
@@ -188,6 +189,33 @@ impl<'b, 'a> ScriptTransformer<'b, 'a> {
             return false;
         };
         self.component_scoping.is_rest_prop(sym_id)
+    }
+
+    pub(super) fn prop_source_alias_for_ref(
+        &self,
+        id: &oxc_ast::ast::IdentifierReference<'a>,
+    ) -> Option<String> {
+        let ref_id = id.reference_id.get()?;
+        let sym_id = self.component_scoping.get_reference(ref_id).symbol_id()?;
+        if !self.component_scoping.is_prop_source(sym_id) {
+            return None;
+        }
+        let local_name = self.component_scoping.symbol_name(sym_id);
+        let props_gen = self.props_gen.as_ref()?;
+        props_gen
+            .props
+            .iter()
+            .find(|p| p.is_prop_source && p.local_name == local_name)
+            .map(|p| p.prop_name.clone())
+    }
+
+    pub(super) fn prop_alias_for_local_name(&self, local_name: &str) -> Option<String> {
+        let props_gen = self.props_gen.as_ref()?;
+        props_gen
+            .props
+            .iter()
+            .find(|p| p.local_name == local_name)
+            .map(|p| p.prop_name.clone())
     }
 
     pub(super) fn extract_assign_member_store_root<'t>(

--- a/crates/svelte_codegen_client/src/script/pipeline.rs
+++ b/crates/svelte_codegen_client/src/script/pipeline.rs
@@ -17,6 +17,7 @@ pub struct ScriptOutput<'a> {
     pub imports: Vec<Statement<'a>>,
     pub body: Vec<Statement<'a>>,
     pub has_tracing: bool,
+    pub needs_ownership_validator: bool,
     pub comments: Vec<Comment>,
     pub source_text: &'a str,
     pub program_span_end: u32,
@@ -28,6 +29,7 @@ pub fn gen_script<'a>(ctx: &mut Ctx<'a>, dev: bool) -> ScriptOutput<'a> {
             imports: vec![],
             body: vec![],
             has_tracing: false,
+            needs_ownership_validator: false,
             comments: vec![],
             source_text: "",
             program_span_end: 0,
@@ -315,6 +317,7 @@ fn run_transform<'a>(
         is_ts,
         function_info_stack: Vec::new(),
         has_tracing: false,
+        needs_ownership_validator: false,
         component_source,
         script_content_start,
         filename,
@@ -351,6 +354,7 @@ fn run_transform<'a>(
     }
 
     let has_tracing = transformer.has_tracing;
+    let needs_ownership_validator = transformer.needs_ownership_validator;
 
     if is_ts {
         reattach_orphaned_comments(&mut program);
@@ -373,6 +377,7 @@ fn run_transform<'a>(
         imports,
         body,
         has_tracing,
+        needs_ownership_validator,
         comments,
         source_text,
         program_span_end,

--- a/crates/svelte_codegen_client/src/script/traverse/assignments.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/assignments.rs
@@ -7,8 +7,102 @@ use crate::builder::Arg;
 use super::super::{PropKind, ScriptTransformer};
 
 impl<'a> ScriptTransformer<'_, 'a> {
-    pub(super) fn transform_assignment(
+    fn prop_mutation_info_from_member(
         &self,
+        target: &oxc_ast::ast::MemberExpression<'a>,
+    ) -> Option<(String, String, Vec<String>)> {
+        if !self.dev || self.is_in_ignored_stmt("ownership_invalid_mutation") {
+            return None;
+        }
+
+        let mut root = target.object();
+        let mut segments_rev: Vec<String> = vec![match target {
+            oxc_ast::ast::MemberExpression::StaticMemberExpression(member) => {
+                member.property.name.as_str().to_string()
+            }
+            oxc_ast::ast::MemberExpression::ComputedMemberExpression(member) => {
+                let Expression::StringLiteral(lit) = &member.expression else {
+                    return None;
+                };
+                lit.value.as_str().to_string()
+            }
+            oxc_ast::ast::MemberExpression::PrivateFieldExpression(_) => return None,
+        }];
+        loop {
+            match root {
+                Expression::StaticMemberExpression(member) => {
+                    segments_rev.push(member.property.name.as_str().to_string());
+                    root = &member.object;
+                }
+                Expression::ComputedMemberExpression(member) => {
+                    let Expression::StringLiteral(lit) = &member.expression else {
+                        return None;
+                    };
+                    segments_rev.push(lit.value.as_str().to_string());
+                    root = &member.object;
+                }
+                _ => break,
+            }
+        }
+        let Expression::Identifier(root_id) = root else {
+            return None;
+        };
+        segments_rev.reverse();
+
+        if root_id.name.as_str() == "$$props" {
+            let prop_alias = segments_rev.first()?.clone();
+            return Some((prop_alias, "$$props".to_string(), segments_rev));
+        }
+
+        let (prop_alias, root_name) = match self.prop_kind_for_ref(root_id) {
+            Some(PropKind::Source) => (
+                self.prop_source_alias_for_ref(root_id)?,
+                root_id.name.to_string(),
+            ),
+            Some(PropKind::NonSource(prop_name)) => (prop_name, root_id.name.to_string()),
+            None => (
+                self.prop_alias_for_local_name(root_id.name.as_str())?,
+                root_id.name.to_string(),
+            ),
+        };
+        Some((prop_alias, root_name, segments_rev))
+    }
+
+    fn wrap_prop_mutation_validation_from_info(
+        &mut self,
+        node: &mut Expression<'a>,
+        prop_alias: String,
+        root_name: String,
+        segments: Vec<String>,
+        span_start: u32,
+    ) {
+        self.needs_ownership_validator = true;
+
+        let offset = self.script_content_start + span_start;
+        let (line, col) = crate::script::location::compute_line_col(self.component_source, offset);
+
+        let mut path: Vec<Expression<'a>> = Vec::with_capacity(1 + segments.len());
+        path.push(self.b.str_expr(&root_name));
+        for seg in segments {
+            path.push(self.b.str_expr(&seg));
+        }
+
+        let expr = self.b.move_expr(node);
+        let wrapped = self.b.call_expr(
+            "$$ownership_validator.mutation",
+            [
+                Arg::Str(prop_alias),
+                Arg::Expr(self.b.array_expr(path)),
+                Arg::Expr(expr),
+                Arg::Num(line as f64),
+                Arg::Num(col as f64),
+            ],
+        );
+        *node = wrapped;
+    }
+
+    pub(super) fn transform_assignment(
+        &mut self,
         node: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a, ()>,
     ) {
@@ -130,6 +224,12 @@ impl<'a> ScriptTransformer<'_, 'a> {
         let Expression::AssignmentExpression(assign) = &*node else {
             return;
         };
+        let mutation_info = assign
+            .left
+            .as_member_expression()
+            .and_then(|m| self.prop_mutation_info_from_member(m));
+        let left_span_start = assign.span.start;
+        let is_expr_stmt = matches!(ctx.parent(), Ancestor::ExpressionStatementExpression(_));
         let fn_name = match assign.operator {
             oxc_ast::ast::AssignmentOperator::Assign => "$.assign",
             oxc_ast::ast::AssignmentOperator::LogicalAnd => "$.assign_and",
@@ -137,10 +237,19 @@ impl<'a> ScriptTransformer<'_, 'a> {
             oxc_ast::ast::AssignmentOperator::LogicalNullish => "$.assign_nullish",
             _ => return,
         };
-        if !svelte_transform::rune_refs::should_proxy(&assign.right) {
+        if is_expr_stmt {
+            if let Some((prop_alias, root_name, segments)) = mutation_info.clone() {
+                self.wrap_prop_mutation_validation_from_info(
+                    node,
+                    prop_alias,
+                    root_name,
+                    segments,
+                    left_span_start,
+                );
+            }
             return;
         }
-        if matches!(ctx.parent(), Ancestor::ExpressionStatementExpression(_)) {
+        if !svelte_transform::rune_refs::should_proxy(&assign.right) {
             return;
         }
         let is_static = matches!(
@@ -155,8 +264,7 @@ impl<'a> ScriptTransformer<'_, 'a> {
             return;
         }
 
-        // Capture span before moving (spans are Copy)
-        let left_span_start = assign.span.start;
+        // Capture location before moving (spans are Copy)
         let offset = self.script_content_start + left_span_start;
         let (line, col) = crate::script::location::compute_line_col(self.component_source, offset);
         let loc = format!(
@@ -203,10 +311,19 @@ impl<'a> ScriptTransformer<'_, 'a> {
                 ],
             );
         }
+        if let Some((prop_alias, root_name, segments)) = mutation_info {
+            self.wrap_prop_mutation_validation_from_info(
+                node,
+                prop_alias,
+                root_name,
+                segments,
+                left_span_start,
+            );
+        }
     }
 
     pub(super) fn transform_update(
-        &self,
+        &mut self,
         node: &mut Expression<'a>,
         _ctx: &mut TraverseCtx<'a, ()>,
     ) {
@@ -300,6 +417,27 @@ impl<'a> ScriptTransformer<'_, 'a> {
                 alloc, &base_name, mutation, untracked,
             );
         }
+    }
+
+    pub(super) fn rewrite_prop_update_ownership_exit(&mut self, node: &mut Expression<'a>) {
+        let Expression::UpdateExpression(upd) = node else {
+            return;
+        };
+        let span_start = upd.span.start;
+        let Some(member) = upd.argument.as_member_expression() else {
+            return;
+        };
+        let Some((prop_alias, root_name, segments)) = self.prop_mutation_info_from_member(member)
+        else {
+            return;
+        };
+        self.wrap_prop_mutation_validation_from_info(
+            node,
+            prop_alias,
+            root_name,
+            segments,
+            span_start,
+        );
     }
 
     pub(super) fn rewrite_private_assignment_exit(&self, node: &mut Expression<'a>) -> bool {

--- a/crates/svelte_codegen_client/src/script/traverse/mod.rs
+++ b/crates/svelte_codegen_client/src/script/traverse/mod.rs
@@ -242,6 +242,7 @@ impl<'a> Traverse<'a, ()> for ScriptTransformer<'_, 'a> {
     }
 
     fn exit_expression(&mut self, node: &mut Expression<'a>, _ctx: &mut TraverseCtx<'a, ()>) {
+        self.rewrite_prop_update_ownership_exit(node);
         if self.rewrite_private_assignment_exit(node) {
             return;
         }

--- a/crates/svelte_compiler/src/tests.rs
+++ b/crates/svelte_compiler/src/tests.rs
@@ -391,6 +391,94 @@ const id = $props.id();
 }
 
 #[test]
+fn compile_dev_props_member_mutation_uses_ownership_validator() {
+    let opts = CompileOptions {
+        dev: true,
+        ..Default::default()
+    };
+    let result = compile(
+        r#"<script>
+let { user } = $props();
+function rename() {
+    user.name = 'next';
+}
+</script>"#,
+        &opts,
+    );
+    let js = result
+        .js
+        .unwrap_or_else(|| panic!("compile produced no JS"));
+    assert!(
+        js.contains("$.create_ownership_validator($$props)"),
+        "expected ownership validator setup, got:\n{js}"
+    );
+    assert!(
+        js.contains("$$ownership_validator.mutation(\"user\""),
+        "expected ownership mutation wrapper for prop member write, got:\n{js}"
+    );
+}
+
+#[test]
+fn compile_dev_bindable_prop_member_mutation_uses_prop_alias() {
+    let opts = CompileOptions {
+        dev: true,
+        ..Default::default()
+    };
+    let result = compile(
+        r#"<script>
+let { value: local = $bindable() } = $props();
+function bump() {
+    local.count = 1;
+}
+</script>"#,
+        &opts,
+    );
+    let js = result
+        .js
+        .unwrap_or_else(|| panic!("compile produced no JS"));
+    assert!(
+        js.contains("$$ownership_validator.mutation(\"value\""),
+        "expected ownership mutation wrapper to use prop alias, got:\n{js}"
+    );
+    assert!(
+        js.contains("\"count\""),
+        "expected ownership mutation path to include mutated member, got:\n{js}"
+    );
+}
+
+#[test]
+fn compile_dev_bindable_prop_member_update_uses_ownership_validator() {
+    let opts = CompileOptions {
+        dev: true,
+        ..Default::default()
+    };
+    let result = compile(
+        r#"<script>
+let { value: local = $bindable() } = $props();
+function bump() {
+    local.count++;
+}
+</script>"#,
+        &opts,
+    );
+    let js = result
+        .js
+        .unwrap_or_else(|| panic!("compile produced no JS"));
+    assert!(
+        js.contains("$.create_ownership_validator($$props)"),
+        "expected ownership validator setup, got:\n{js}"
+    );
+    assert!(
+        js.contains("$$ownership_validator.mutation(\"value\""),
+        "expected ownership mutation wrapper for update expression, got:\n{js}"
+    );
+    assert!(
+        js.contains("\"count\""),
+        "expected ownership mutation path to include updated member, got:\n{js}"
+    );
+}
+
+#[test]
 fn attribute_invalid_name_digit_start() {
     let result = compile(r#"<div 1foo="x"></div>"#, &CompileOptions::default());
     assert!(

--- a/specs/props-bindable.md
+++ b/specs/props-bindable.md
@@ -1,11 +1,15 @@
 # $props / $bindable
 
 ## Current state
-- **Working**: 19/22 use cases
+- **Working**: 20/22 use cases
 - **Completed (2026-04-03)**: added compiler-level pipeline tests for `$props.id()` validation edge cases (`compile_props_id_invalid_placement`, `compile_props_id_duplicate_with_props`) in `crates/svelte_compiler/src/tests.rs`
 - **Completed (2026-04-11)**: identifier-pattern `$props()` bindings no longer trigger a false-positive `store_rune_conflict`; analyzer store validation now excludes props-owned bindings and the focused parity case `props_identifier_no_store_rune_conflict` passes alongside the existing positive `store_rune_conflict` analyzer test.
-- **Next**: Verify and add coverage for `$props()` and `$props.id()` rejection inside `<script module>` (`ast_type !== 'instance'` check in reference `CallExpression.js`), then track dev-mode ownership mutation validation here instead of leaving it only in ROADMAP.
-- Last updated: 2026-04-11
+- **Completed (2026-04-12)**: `$props()` / `$props.id()` in `<script module>` now emit `props_invalid_placement` / `props_id_invalid_placement` via analyzer validation, with focused diagnostic parity coverage (`validate_props_invalid_placement_in_module_script`, `validate_props_id_invalid_placement_in_module_script`).
+- **Completed (2026-04-12)**: module-script `$props()` / `$props.id()` validation now flows through `validate/runes.rs` instead of a parallel module-only validator, preserving reference parity for module invalid-placement behavior while avoiding duplicated call-walker logic.
+- **Completed (2026-04-12)**: follow-up review cleanup deduplicated `RuneValidator` initialization for instance/module entrypoints while keeping module placement diagnostics and test coverage unchanged.
+- **In progress (2026-04-12)**: dev-mode ownership mutation validation now wraps prop / bindable-prop member writes for both assignment and update expressions with `$$ownership_validator.mutation(...)`, and emits `$.create_ownership_validator($$props)` when needed; computed-path parity remains.
+- **Next**: Complete computed member-path ownership mutation parity.
+- Last updated: 2026-04-12
 
 ## Source
 
@@ -39,12 +43,12 @@ ROADMAP.md — `$props` / `$bindable`
 - [x] `$bindable()` validation: `bindable_invalid_location` and argument-count checks
 - [x] `$props()` validation: `props_invalid_placement`, `props_duplicate`, and rune argument-count checks
 - [x] Identifier-pattern `$props()` bindings like `let props = $props()` must not emit a false-positive `store_rune_conflict` warning (diagnostic test: `props_identifier_no_store_rune_conflict`)
-- [ ] `$props()` and `$props.id()` rejected inside `<script module>` — reference: `ast_type !== 'instance'` check in `CallExpression.js`
+- [x] `$props()` and `$props.id()` rejected inside `<script module>` — reference: `ast_type !== 'instance'` check in `CallExpression.js`
 - [x] `$props.id()` validation: `props_id_invalid_placement`, duplicate detection with `$props()`, zero-argument enforcement
 - [x] `$props()` pattern validation: `props_invalid_pattern` and `props_invalid_identifier`
 - [x] `props_illegal_name` for MemberExpression access on rest props
 - [x] Custom-element warning: `custom_element_props_identifier` for identifier/rest `$props()` in custom elements
-- [ ] Dev-mode ownership mutation validation for prop / bindable-prop member writes via `$$ownership_validator.mutation(...)`
+- [ ] Dev-mode ownership mutation validation for prop / bindable-prop member writes via `$$ownership_validator.mutation(...)` (partial: assignment/update member writes covered; computed-path cases still open)
 - [ ] `$$props` / `$$restProps` legacy compatibility (Tier 7)
 
 ## Reference
@@ -94,3 +98,10 @@ ROADMAP.md — `$props` / `$bindable`
 - [x] analyze unit: `custom_element_props_identifier` warning (4 tests)
 - [x] analyze unit: `validate_props_identifier_no_store_rune_conflict`
 - [x] `props_identifier_no_store_rune_conflict`
+- [x] diagnostic parity: `validate_props_invalid_placement_in_module_script`
+- [x] diagnostic parity: `validate_props_id_invalid_placement_in_module_script`
+- [x] diagnostic parity: `validate_props_invalid_arguments_in_module_script`
+- [x] diagnostic parity: `validate_props_id_invalid_arguments_in_module_script`
+- [x] compiler unit: `compile_dev_props_member_mutation_uses_ownership_validator`
+- [x] compiler unit: `compile_dev_bindable_prop_member_mutation_uses_prop_alias`
+- [x] compiler unit: `compile_dev_bindable_prop_member_update_uses_ownership_validator`

--- a/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_arguments_in_module_script/case-rust.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_arguments_in_module_script/case-rust.json
@@ -1,0 +1,8 @@
+[
+  {
+    "severity": "error",
+    "code": "props_id_invalid_placement",
+    "start": 27,
+    "end": 39
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_arguments_in_module_script/case-svelte.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_arguments_in_module_script/case-svelte.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "props_id_invalid_placement",
+    "end": 39,
+    "severity": "error",
+    "start": 27
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_arguments_in_module_script/case.svelte
+++ b/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_arguments_in_module_script/case.svelte
@@ -1,0 +1,3 @@
+<script module>
+const id = $props.id(1);
+</script>

--- a/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_placement_in_module_script/case-rust.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_placement_in_module_script/case-rust.json
@@ -1,0 +1,8 @@
+[
+  {
+    "severity": "error",
+    "code": "props_id_invalid_placement",
+    "start": 27,
+    "end": 38
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_placement_in_module_script/case-svelte.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_placement_in_module_script/case-svelte.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "props_id_invalid_placement",
+    "end": 38,
+    "severity": "error",
+    "start": 27
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_placement_in_module_script/case.svelte
+++ b/tasks/diagnostic_tests/cases/props/validate_props_id_invalid_placement_in_module_script/case.svelte
@@ -1,0 +1,3 @@
+<script module>
+const id = $props.id();
+</script>

--- a/tasks/diagnostic_tests/cases/props/validate_props_invalid_arguments_in_module_script/case-rust.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_invalid_arguments_in_module_script/case-rust.json
@@ -1,0 +1,8 @@
+[
+  {
+    "severity": "error",
+    "code": "props_invalid_placement",
+    "start": 32,
+    "end": 41
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_invalid_arguments_in_module_script/case-svelte.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_invalid_arguments_in_module_script/case-svelte.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "props_invalid_placement",
+    "end": 41,
+    "severity": "error",
+    "start": 32
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_invalid_arguments_in_module_script/case.svelte
+++ b/tasks/diagnostic_tests/cases/props/validate_props_invalid_arguments_in_module_script/case.svelte
@@ -1,0 +1,3 @@
+<script module>
+let { value } = $props(1);
+</script>

--- a/tasks/diagnostic_tests/cases/props/validate_props_invalid_placement_in_module_script/case-rust.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_invalid_placement_in_module_script/case-rust.json
@@ -1,0 +1,8 @@
+[
+  {
+    "severity": "error",
+    "code": "props_invalid_placement",
+    "start": 32,
+    "end": 40
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_invalid_placement_in_module_script/case-svelte.json
+++ b/tasks/diagnostic_tests/cases/props/validate_props_invalid_placement_in_module_script/case-svelte.json
@@ -1,0 +1,8 @@
+[
+  {
+    "code": "props_invalid_placement",
+    "end": 40,
+    "severity": "error",
+    "start": 32
+  }
+]

--- a/tasks/diagnostic_tests/cases/props/validate_props_invalid_placement_in_module_script/case.svelte
+++ b/tasks/diagnostic_tests/cases/props/validate_props_invalid_placement_in_module_script/case.svelte
@@ -1,0 +1,3 @@
+<script module>
+let { value } = $props();
+</script>

--- a/tasks/diagnostic_tests/test_diagnostics.rs
+++ b/tasks/diagnostic_tests/test_diagnostics.rs
@@ -1111,6 +1111,14 @@ mod props {
         validate_props_invalid_placement_inside_function,
         "props/validate_props_invalid_placement_inside_function"
     );
+    diagnostic_case!(
+        validate_props_invalid_placement_in_module_script,
+        "props/validate_props_invalid_placement_in_module_script"
+    );
+    diagnostic_case!(
+        validate_props_invalid_arguments_in_module_script,
+        "props/validate_props_invalid_arguments_in_module_script"
+    );
     diagnostic_case!(validate_props_duplicate, "props/validate_props_duplicate");
     diagnostic_case!(
         validate_props_and_props_id_coexist,
@@ -1123,6 +1131,14 @@ mod props {
     diagnostic_case!(
         validate_props_id_invalid_placement_inside_function,
         "props/validate_props_id_invalid_placement_inside_function"
+    );
+    diagnostic_case!(
+        validate_props_id_invalid_placement_in_module_script,
+        "props/validate_props_id_invalid_placement_in_module_script"
+    );
+    diagnostic_case!(
+        validate_props_id_invalid_arguments_in_module_script,
+        "props/validate_props_id_invalid_arguments_in_module_script"
     );
     diagnostic_case!(
         validate_props_illegal_name_rest_member_access,


### PR DESCRIPTION
### Motivation
- Ensure `$props()` / `$props.id()` usages are rejected inside `<script module>` with the same diagnostics as the instance-script analyzer while avoiding duplicated call-walker logic.
- Centralize rune validation entrypoints for instance vs module scripts by sharing the `RuneValidator` while preserving placement diagnostics parity.
- Improve dev-mode safety by wrapping prop / bindable-prop member writes with an ownership validator so mutations can be validated at runtime during development.

### Description
- Invoke `runes::validate_module_props_runes` from the main `validate` flow to run rune placement checks for `<script module>` and avoid a separate module-only walker (`crates/svelte_analyze/src/validate/mod.rs`).
- Add `RuneValidator::new` and an `is_instance_script` flag to `crates/svelte_analyze/src/validate/runes.rs` and use it to emit `props_invalid_placement` / `props_id_invalid_placement` for module scripts while keeping instance-script behavior unchanged.
- Propagate a `needs_ownership_validator` flag through the codegen pipeline (`script::gen_script`, `ScriptTransformer`, and `ScriptOutput`) and inject `$.create_ownership_validator($$props)` into generated code when dev-mode validation is required (`crates/svelte_codegen_client/src/lib.rs`, `script/pipeline.rs`).
- Implement detection of prop/bindable member mutation targets and wrap assignment/update expressions with `$$ownership_validator.mutation(...)` in dev builds, including helpers to resolve prop aliases and to build mutation paths (`crates/svelte_codegen_client/src/script/model.rs`, `script/traverse/assignments.rs`, `script/traverse/mod.rs`).
- Add diagnostic test cases and compiler-unit tests to cover module-script invalid placement/argument diagnostics and dev-mode ownership-validator behavior, and update specs (`specs/props-bindable.md`, `tasks/diagnostic_tests/*`, `crates/svelte_compiler/src/tests.rs`, `tasks/diagnostic_tests/test_diagnostics.rs`).

### Testing
- Added and ran diagnostic test cases under `tasks/diagnostic_tests/cases/props/*` covering `validate_props_invalid_placement_in_module_script`, `validate_props_invalid_arguments_in_module_script`, `validate_props_id_invalid_placement_in_module_script`, and `validate_props_id_invalid_arguments_in_module_script`, and they passed.
- Ran the compiler unit tests including `compile_dev_props_member_mutation_uses_ownership_validator`, `compile_dev_bindable_prop_member_mutation_uses_prop_alias`, and `compile_dev_bindable_prop_member_update_uses_ownership_validator`, and they passed.
- Ran the existing analyzer and codegen test suites that exercise rune validation and props handling (unit/diagnostic pipelines), and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db54bcf4cc83218e19adac3cf3dc3f)