### PR TITLE
docs: sync CODEBASE_MAP and ROADMAP with current code

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -6,14 +6,16 @@ Rust компилятор Svelte v5. Компилирует `.svelte` → client
 
 ```
 source: &str
-  → svelte_parser::parse_with_js → (Component, ParserResult, Vec<Diagnostic>)
+  → svelte_parser::parse_with_js → (Component, JsAst, Vec<Diagnostic>)
   → svelte_parser::parse_css_block → Option<(StyleSheet, Vec<Diagnostic>)>
-  → svelte_analyze::analyze_with_options → (AnalysisData, ParserResult, Vec<Diagnostic>)
+  → svelte_analyze::analyze_with_options → (AnalysisData, JsAst, Vec<Diagnostic>)
   → svelte_analyze::analyze_css_pass → mutates AnalysisData (used selectors, hash, keyframes)
   → svelte_transform_css::transform_css_with_usage → String (scoped CSS)
-  → svelte_transform::transform_component → (mutates ParserResult in-place, returns TransformData)
-  → svelte_codegen_client::generate → String (JS)
+  → svelte_transform::transform_component(&mut CompileContext, &TransformOptions) → TransformData (mutates JsAst in place)
+  → svelte_codegen_client::generate(CompileContext, &CodegenOptions, TransformData, css) → String (JS)
 ```
+
+Transform and codegen take a shared `svelte_types::CompileContext { alloc, component, analysis, js_arena, ident_gen }`.
 
 Entry point: `svelte_compiler::compile` / `svelte_compiler::compile_module`
 
@@ -85,9 +87,11 @@ Entry point: `svelte_compiler::compile` / `svelte_compiler::compile_module`
 ### `svelte_parser`
 `crates/svelte_parser/src/lib.rs` — парсер + JS pre-parsing.
 
-Public API: `parse_with_js` (Svelte source → Component + ParserResult), `parse_module` (`.svelte.js`/`.svelte.ts`), `parse_css_block` (топ-уровневый `<style>` → `svelte_css::StyleSheet`).
+Public API: `parse_with_js` (Svelte source → Component + JsAst), `parse_module` (`.svelte.js`/`.svelte.ts`), `parse_css_block` (топ-уровневый `<style>` → `svelte_css::StyleSheet`).
 
-Shared types в `types.rs`: `ParserResult` (instance/module/standalone OXC Programs + template expressions/statements keyed by span offset), `ExprHandle`, `StmtHandle`, `ParsedCeConfig`, `CePropConfig`, `CeShadowMode`.
+Shared types в `types.rs`: `JsAst<'a>` (instance/module OXC `Program`s + template expressions/statements; pending по span-offset, после bind — по `OxcNodeId`), `ParsedCeConfig`, `CePropConfig`, `CeShadowMode`.
+
+`svelte_ast` владеет `ExprRef` / `StmtRef` (late-bound `OxcNodeId`); сами OXC `Expression`/`Statement` хранит `JsAst` в caller-owned `Allocator`.
 
 Подмодули: `scanner/`, `parse_js.rs`, `walk_js.rs` (обход template для сбора JS-фрагментов), `html.rs` (HTML character reference decoding), `html_entities.rs`, `attr_convert.rs`, `handlers.rs`, `svelte_elements.rs`.
 
@@ -134,21 +138,21 @@ CSS analysis вызывается отдельно из `svelte_compiler` чер
 
 **Ключевые модули:**
 - `lib.rs` — entry points, `AnalyzeOptions`, `RuntimePlan` builder
-- `passes/` — все analysis passes (по одному модулю на pass)
+- `passes/` — все analysis passes (по одному модулю на pass) + `executor.rs`, `bundles.rs` (объединённые multi-visitor walks для template execution stage), `js_analyze/` (script body / runes / async blockers / pickled awaits / needs_context / expression_info), `template_validation/` (включая `a11y.rs`), `dynamism.rs`, `element_flags.rs`, `content_types.rs`, `bind_semantics.rs`
 - `block_semantics/` — типы для control-flow блоков (`AwaitBlockSemantics`, `EachBlockSemantics`, `IfBlockSemantics`, `KeyBlockSemantics`, `SnippetBlockSemantics`, `RenderTagBlockSemantics`, `ConstTagBlockSemantics`)
 - `reactivity_semantics/` — reactive declarations и signals
-- `types/` — `data.rs` (`AnalysisData`), `script.rs`
+- `types/` — `data/` (модульный `AnalysisData` + поддержки: `analysis`, `async_data`, `attr_index`, `codegen_view`, `css`, `directive_modifier_flags`, `element_facts`, `elements`, `expr`, `fragment_facts`, `fragment_namespaces`, `ignore`, `pickled_await_offsets`, `proxy_state_inits`, `rich_content_facts`, `runtime`, `script_rune_calls`, `template_data`, `template_element_index`, `template_topology`), `script.rs`, `markers.rs`, `node_table.rs`
 - `scope.rs` — `ComponentScoping` (wraps `ComponentSemantics`)
 - `validate/`, `passes/template_validation/` — семантические и template-level проверки (включая a11y warnings)
 - `walker/` — общая инфраструктура обхода template
 - `css.rs`, `passes/css_analyze.rs`, `passes/css_prune.rs`, `passes/css_prune_index.rs` — CSS pipeline
 - `utils/` — `IdentGen`, `script_info`, helpers (`is_capture_event`, `is_delegatable_event`, `is_passive_event`, `is_regular_dom_property`, `normalize_regular_attribute_name`, etc.)
 
-**Ключевые типы данных** (`types/data.rs`):
+**Ключевые типы данных** (`types/data/`):
 - `AnalysisData<'a>` — центральная side table, keyed by `NodeId`. Содержит ScriptAnalysis, TemplateAnalysis, ReactivitySemantics, BlockAnalysis, ElementAnalysis, FragmentFacts, RichContentFacts, CssAnalysis, CodegenView, RuntimePlan, и десятки специализированных side-tables
 - `ElementFacts` владеет нормализованными per-element attribute facts (`AttrIndex` — внутренний by-name primitive). Consumer-pass’ы используют `AnalysisData` accessors (`has_attribute`, `attribute`, `string_attribute`, `bind_directive`, `expression_attribute`, etc.), не `attr_index(...)` напрямую
-- `ExpressionInfo` / `ExpressionKind` / `ExprHandle` / `ExprDeps` / `ExprRole` / `ExprSite` — per-expression analysis
-- `ParsedExprs<'a>` (через `ParserResult<'a>`) — OXC Expression ASTs
+- `ExpressionInfo` / `ExpressionKind` / `ExprDeps` / `ExprRole` / `ExprSite` — per-expression analysis (адресуется по `OxcNodeId` JS-узла, привязанного через `ExprRef`/`StmtRef`)
+- `JsAst<'a>` (re-export из `svelte_parser`) — OXC `Program`s + bound expression/statement nodes
 - `RuntimePlan` — финальный план для codegen (`needs_push`, `has_component_exports`, `has_bindable`, `has_stores`, etc.)
 - `RuntimeRuneKind`, `OptimizedRuneSemantics` — rune-related semantics
 - `CssAnalysis` — hash, keyframes, used_selectors, inject_styles
@@ -159,8 +163,8 @@ CSS analysis вызывается отдельно из `svelte_compiler` чер
 `crates/svelte_codegen_client/src/` — generates client-side JS from AST + AnalysisData.
 
 **Top-level:**
-- `lib.rs` — `generate()` entry point
-- `context.rs` — `Ctx<'a>` (центральный контекст: ast_builder, component, analysis, transform_data, ident_gen, module_hoisted)
+- `lib.rs` — `generate(CompileContext, &CodegenOptions, TransformData, css)` и `generate_module(...)` entry points
+- `context.rs` — `Ctx<'a> = { query: CodegenQuery, state: CodegenState }` (Deref/DerefMut в `state`). `CodegenQuery`: component + analysis + per-id accessors (`element`, `if_block`, `each_block`, `expression`, `expr_deps`, `runtime_plan`, …). `CodegenState`: `Builder`, `JsAst`, `IdentGen`, `TransformData`, hoisted statements, delegated events, css text, dev/async flags
 - `custom_element.rs` — custom element wrapper
 
 **`script/`** — script-side codegen
@@ -183,17 +187,24 @@ CSS analysis вызывается отдельно из `svelte_compiler` чер
 ### `svelte_transform`
 `crates/svelte_transform/src/` — mutates OXC expression ASTs in-place (после analyze, до generate).
 
-Перезаписывает: rune references → `$.get/set/update`, prop sources → thunk calls, prop non-sources → `$$props.name`, each-block context → `$.get`, snippet params → thunk calls, destructured const aliases → `$.get(tmp).prop`. Также: TS-cleanup, derived calls, inspect runes, location injection (dev mode).
+Перезаписывает: rune references → `$.get/set/update`, prop sources → thunk calls, prop non-sources → `$$props.name`, each-block context → `$.get`, snippet params → thunk calls, destructured const aliases → `$.get(tmp).prop`. Также: TS-cleanup, derived calls, inspect runes, location injection (dev mode), legacy `$:` reactive statements, legacy props/state.
 
-Public API: `transform_component(...) → TransformData`, `transform_script(...)`, `compute_line_col`, `sanitize_location`, `IgnoreQuery`, `TransformScriptOutput`.
+Public API: `transform_component(&mut svelte_types::CompileContext, &svelte_types::TransformOptions) → TransformData`, `transform_script(...)`, `compute_line_col`, `sanitize_location`, `IgnoreQuery`, `TransformScriptOutput`.
 
 **Структура:**
 - `lib.rs` — entry, `transform_component`
 - `data.rs` — `TransformData` (output)
 - `rune_refs.rs` — rune reference rewrites
-- `transformer/` — `mod.rs`, `entry.rs`, `template_entry.rs`, `model.rs`, `assignments.rs`, `derived.rs`, `inspect.rs`, `location.rs`, `props.rs`, `rewrites.rs`, `runes.rs`, `state.rs`, `statement_passes.rs`, `template_rewrites.rs`, `ts_cleanup.rs`
+- `transformer/` — `mod.rs`, `entry.rs`, `template_entry.rs`, `template_rewrites.rs`, `model.rs`, `builders.rs`, `assignments.rs`, `derived.rs`, `inspect.rs`, `location.rs`, `props.rs`, `props_legacy.rs`, `rewrites.rs`, `runes.rs`, `state.rs`, `state_legacy.rs`, `legacy_reactive.rs`, `statement_passes.rs`, `ts_cleanup.rs`
 
-Template entry собирает `ExprHandle`/`StmtHandle` через структурный обход Svelte-AST, затем `oxc_traverse` гоняет `ComponentTransformer` по reusable synthetic `Program`.
+Template entry собирает `ExprRef`/`StmtRef` через структурный обход Svelte-AST, читает узлы по `OxcNodeId` из `JsAst`, затем `oxc_traverse` гоняет `ComponentTransformer` по reusable synthetic `Program`.
+
+---
+
+### `svelte_types`
+`crates/svelte_types/src/lib.rs` — общие типы для transform/codegen/compiler.
+
+Публикует `CompileContext<'a, 'ctx> { alloc, component, analysis, js_arena, ident_gen }` (мутабельно прокидывает `JsAst` и `IdentGen` вниз по pipeline'у), `TransformOptions { dev }`, `CodegenOptions { dev, experimental_async, filename }`.
 
 ---
 
@@ -225,19 +236,21 @@ Codegen завёрнут в `catch_unwind` для надёжности; ошиб
 ```
 svelte_span → svelte_diagnostics → svelte_ast → svelte_css
   → svelte_component_semantics → svelte_parser → svelte_ast_builder
-  → svelte_analyze → svelte_transform → svelte_transform_css
-  → svelte_codegen_client → svelte_compiler → { wasm_compiler, napi_compiler }
+  → svelte_analyze → svelte_transform_css
+  → svelte_types → { svelte_transform, svelte_codegen_client }
+  → svelte_compiler → { wasm_compiler, napi_compiler }
 ```
 
 ## Ключевые инварианты
 
-- OXC Expression ASTs живут в `ParsedExprs<'a>` (аллокатор принадлежит caller'у), не выходят в публичный API
+- OXC Expression/Statement ASTs живут в `JsAst<'a>` (аллокатор принадлежит `svelte_compiler`), не выходят в публичный API; в analyze они адресуются через `OxcNodeId`, привязанный в `ComponentSemanticsBuilder` к `ExprRef`/`StmtRef` Svelte-AST
 - `ComponentScoping` — owned, lifetime-free (`ComponentSemantics` внутри)
-- Все поля `AnalysisData` — owned, без lifetime параметров (кроме `ParsedExprs<'a>`)
-- AST хранит `Span`; parser парсит JS один раз в `ParsedExprs`; transform мутирует; codegen использует
+- Все поля `AnalysisData` — owned, без lifetime параметров (кроме `JsAst<'a>`-зависимостей через analyze API)
+- AST хранит `Span`; parser парсит JS один раз в `JsAst`; transform мутирует; codegen использует
 - `u32` везде где возможно (`NodeId`, `FragmentId`, `Span`, `CssNodeId`)
 - `ConcatPart` (svelte_ast) и аналоги в svelte_analyze — **разные типы** для разных фаз
 - Sub-struct поля — `pub(crate)`, снаружи через методы
 - Каждый analyze pass — изолированный модуль; зависимости описаны через `DataToken`, выполнение в фиксированном порядке стадий
 - CSS pipeline отдельный: `svelte_css` (parser/AST/printer) и `svelte_transform_css` (мутации) — analyze CSS интегрирован в `svelte_analyze::passes::css_*`, но запускается из `svelte_compiler`
+- Transform и codegen получают одинаковый `svelte_types::CompileContext` — единый владелец `Allocator`/`JsAst`/`IdentGen` на всю оставшуюся часть pipeline'а
 - Codegen — «dumb»: всю логику решает analyze, codegen только эмитит. Transform только мутирует JS AST, не делает классификацию.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 
 - [x] `$state` / `$state.raw` — [spec](specs/state-rune.md)
 - [x] `$derived` / `$derived.by` — [spec](specs/derived-state.md)
-- [ ] `$props` / `$bindable` / `$props.id` — [spec](specs/props-bindable.md)
+- [x] `$props` / `$bindable` / `$props.id` — [spec](specs/props-bindable.md)
 - [x] `$effect` / `$effect.pre` — [spec](specs/effect-runes.md)
 - [x] `$inspect` / `$inspect.trace`  — [spec](specs/inspect-runes.md)
 - [ ] `$host` — [spec](specs/host-rune.md)
@@ -71,8 +71,8 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 
 ## Template
 
-- [ ] Element — [spec](specs/element.md)
-- [ ] `<Component>` / component — [spec](specs/component-node.md)
+- [x] Element — [spec](specs/element.md)
+- [x] `<Component>` / component — [spec](specs/component-node.md)
 - [x] `{#if}` / `{:else}` — [spec](specs/if-block.md)
 - [ ] `{#each}` — [spec](specs/each-block.md)
 - [x] `{#await}` — [spec](specs/await-block.md)
@@ -82,7 +82,7 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 - [x] `{@const}` — [spec](specs/const-tag.md)
 - [x] `{@debug}` — [spec](specs/debug-tag.md)
 - [x] Text / ExpressionTag — [spec](specs/text-expression-tag.md)
-- [ ] Experimental async — [spec](specs/experimental-async.md)
+- [x] Experimental async — [spec](specs/experimental-async.md)
 
 ## Attributes & Spreads
 
@@ -99,7 +99,7 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 - [x] Svelte 5 event attributes — [spec](specs/events.md)
 - [x] Event delegation — [spec](specs/events.md)
 - [x] Event modifiers (capture, passive) — [spec](specs/events.md)
-- [ ] `on:event` legacy — [spec](specs/events.md)
+- [x] `on:event` legacy — [spec](specs/events.md)
 
 ## Bindings
 
@@ -120,11 +120,11 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 
 ## Special Elements
 
-- [ ] [`<svelte:options>`](specs/svelte-options.md)
+- [x] [`<svelte:options>`](specs/svelte-options.md)
 - [ ] `<svelte:head>` / `<title>` — [spec](specs/svelte-head-title.md)
-- [ ] `<svelte:window>` / `<svelte:document>` / `<svelte:body>` — [spec](specs/svelte-window-document-body.md)
+- [x] `<svelte:window>` / `<svelte:document>` / `<svelte:body>` — [spec](specs/svelte-window-document-body.md)
 - [ ] `<svelte:element>` — [spec](specs/svelte-element.md)
-- [ ] `<svelte:boundary>` ([spec](./specs/svelte-boundary.md))
+- [x] `<svelte:boundary>` ([spec](./specs/svelte-boundary.md))
 
 ## CSS
 
@@ -162,6 +162,7 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 ## Compiler Infrastructure
 
 - [x] Filename-derived component naming — [spec](specs/filename-derived-component-name.md)
+- [x] TypeScript script stripping — [spec](specs/typescript-script-stripping.md)
 - [ ] `discloseVersion` option
 - [ ] `preserveComments` option
 - [ ] HMR
@@ -177,5 +178,5 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 - [ ] `<svelte:self>` — [spec](specs/svelte-self.md)
 - [ ] `<svelte:component>` — [spec](specs/svelte-component.md)
 - [ ] `export let` props / `$$props` / `$$restProps` — [spec](specs/legacy-export-let.md)
-- [ ] `$:` reactive assignments — [spec](specs/legacy-reactive-assignments.md)
+- [x] `$:` reactive assignments — [spec](specs/legacy-reactive-assignments.md)
 - [ ] `beforeUpdate` / `afterUpdate` — [spec](specs/before-update-after-update.md)

--- a/SEMANTIC_LAYER_ARCHITECTURE.md
+++ b/SEMANTIC_LAYER_ARCHITECTURE.md
@@ -57,19 +57,15 @@ same bar.
   `ReferenceId`, `SymbolId`, enum variants, bools, numeric payloads. No
   `String`, `Box<str>`, `&str`, `Cow<str>` in stored facts or answers. Text is
   resolved at consumption time via identity-keyed lookups.
-- **Parser-handle ban.** `StmtHandle` and `ExprHandle` are parser-internal
-  indices into `ParserResult.stmts` / `.exprs` and **must not** appear in
-  cluster payloads (`block_semantics::*`, `attribute_semantics::*`,
-  `element_shape_semantics::*`, …). Payloads carry `OxcNodeId` as the
-  sole AST hook; consumers resolve the statement / expression on demand
-  through `ComponentSemantics::js_storage()` / the equivalent `kind(id)` /
-  `node(id)` lookup, not through handle tables. Handles remain legal
-  inside the parser and analyze-local side tables that own their own
-  identity (e.g. `TemplateSemanticsData::snippet_stmt_handles`), but
-  they never cross into a cluster answer variant. Rationale: handles
-  are a second identity system layered over the same AST — hauling them
-  into cluster payloads forces consumers to mix two identities and
-  turns payloads into JSON-shuffling thin wrappers over `ParserResult`.
+- **`OxcNodeId` is the sole AST hook.** Cluster payloads carry `OxcNodeId`
+  for any reference into JS AST; consumers resolve the statement /
+  expression on demand through `JsAst::expr(id)` / `JsAst::stmt(id)`.
+  The historical `StmtHandle` / `ExprHandle` parser-side indices (and the
+  `ParserResult.stmts` / `.exprs` tables they pointed into) have been
+  removed — `JsAst` is now keyed by `OxcNodeId` directly. Do not
+  reintroduce a parallel handle system layered over the same AST: a
+  second identity forces consumers to mix two systems and turns
+  payloads into JSON-shuffling thin wrappers.
 - **No binding-pattern repack.** `BindingPattern` subtrees
   (`$props`, `$state`, `$derived`, `{@const}`, `{#snippet}` params,
   `{#each … as pat}`, `{#await … then pat}`, `let:` directives, etc.)
@@ -103,7 +99,7 @@ same bar.
   never the four underlying facts.
 - **Dependency Boundary.** Each cluster builds on `ComponentSemantics` and AST,
   not on legacy Svelte-specific classification tables. Concretely: a cluster
-  builder's signature accepts only AST (`&Component` and `&ParserResult` —
+  builder's signature accepts only AST (`&Component` and `&JsAst` —
   the latter is the parser's pre-parsed JS store for template spans and is
   considered part of the AST surface, not a separate cluster),
   `ComponentSemantics`, `ReactivitySemantics`, and narrow analyzer-output
@@ -436,114 +432,41 @@ Surfaces marked deprecated as the first step of each kind migration:
   owning cluster's payload for higher-level answers.
 - Attribute dynamism / ExpressionInfo bit combinations re-derived in consumers
 - Element-kind AST dispatch in template traversal
-- `FragmentItem` — duplicates Block / ElementShape node-kind
-  discrimination; see "Prerequisite: Kill `FragmentItem`" below
 - Async-specific side tables (`AsyncEmissionPlan`, pickled-await bookkeeping)
+
+Already removed:
+- `FragmentItem` / `LoweredFragment` — the codegen-side dispatcher
+  that conflated lowering facts with node-kind discrimination has been
+  deleted. Codegen now walks fragment children through
+  `svelte_codegen_client::codegen::fragment::prepare` (emit-time
+  hoisting + whitespace normalization + `ContentStrategy`) without
+  duplicating Block / ElementShape kind dispatch.
 
 Deletion is gradual and per-kind; parallel ownership is contained by the
 `#[deprecated]` warning.
 
-## Prerequisite: Kill `FragmentItem`
+## Historical: `FragmentItem` killed
 
-The codegen consumer path in `svelte_codegen_client` does not walk the
-Svelte AST directly. It walks `LoweredFragment { items: Vec<FragmentItem> }`
-produced by `svelte_analyze`, where `FragmentItem` is an enum that
-discriminates template items by AST node kind:
+The earlier prerequisite slice — replacing the analyze-side
+`LoweredFragment { items: Vec<FragmentItem> }` dispatcher with a
+codegen-side fragment plan that does not duplicate Block / ElementShape
+node-kind discrimination — has landed.
 
-```rust
-pub enum FragmentItem {
-    Element(NodeId),
-    ComponentNode(NodeId),
-    IfBlock(NodeId),
-    EachBlock(NodeId),
-    AwaitBlock(NodeId),
-    KeyBlock(NodeId),
-    RenderTag(NodeId),
-    HtmlTag(NodeId),
-    SvelteElement(NodeId),
-    SvelteBoundary(NodeId),
-    SlotElementLegacy(NodeId),
-    SvelteFragmentLegacy(NodeId),
-    TextConcat { parts: Vec<LoweredTextPart>, has_expr: bool },
-}
-```
+Today fragment children are walked in
+`svelte_codegen_client::codegen::fragment` (`mod.rs`, `prepare.rs`,
+`process_children.rs`, `types.rs`). `prepare` does the genuine
+lowering work — hoist structural nodes (snippets, const-tags,
+debug-tags, `<svelte:head>`, `<svelte:window>` / `<svelte:document>` /
+`<svelte:body>`, head titles), trim whitespace per Svelte rules,
+coalesce adjacent `Text` + `{expression}` into a single `Concat`, and
+classify the result into `ContentStrategy` — and dispatches each child
+through Block Semantics + AST node-kind matches without going through a
+parallel discriminator.
 
-This enum conflates two very different things:
-
-1. **Real lowering facts that AST does not carry.** `TextConcat` merges a
-   run of adjacent `Text` / `ExpressionTag` / `Text` nodes into a single
-   runtime `$.set_text` target; lowering also filters hoisted nodes
-   (`SnippetBlock`, `SvelteHead`, `{@const}`, `{@debug}`, `<svelte:window>`,
-   whitespace-only text) and normalizes sibling order per the reference
-   compiler's whitespace rules. These are genuine additions over AST.
-2. **Node-kind discrimination that Block / ElementShape Semantics now
-   own.** Every `FragmentItem::*Block(id)` / `*Tag(id)` / `*Element(id)` /
-   `ComponentNode(id)` / `SvelteBoundary(id)` variant is redundant with a
-   one-query `block_semantics(id)` or `element_shape_semantics(id)` lookup.
-
-The consequence: as long as `FragmentItem` is the codegen dispatcher, a
-migrated cluster cannot produce a clean root consumer point. The Root
-Consumer Migration Rule is violated by construction — every block-kind
-emission currently starts at a `match FragmentItem::*` site, and a
-`match block_semantics(id)` inside a single FragmentItem arm is a
-meaningless narrowing (one-variant match inside a variant). The form the
-architecture actually wants is:
-
-```rust
-for &node_id in fragment_plan {  // plan = filtered, ordered NodeIds + TextConcat pseudo-items
-    match analysis.block_semantics(node_id) {
-        BlockSemantics::Each(sem) => gen_each_block(ctx, node_id, sem, ...),
-        BlockSemantics::If(sem)   => gen_if_block(...),
-        BlockSemantics::Await(..) => gen_await_block(...),
-        ...
-        BlockSemantics::NonSpecial => match analysis.element_shape_semantics(node_id) {
-            ElementShapeSemantics::Html(..) => process_element(...),
-            ElementShapeSemantics::Component(..) => gen_component(...),
-            ...
-        }
-    }
-}
-```
-
-This is not achievable inside the Block Semantics migration. It requires
-a separate initiative:
-
-### Separate slice: **kill `FragmentItem`**
-
-Scope:
-- Reshape `LoweredFragment` to hold a plan of `NodeId`s (plus
-  `TextConcat` as an explicit pseudo-node or side table) without
-  duplicating node-kind discrimination.
-- Replace `FragmentItem::*` matches across `svelte_codegen_client`
-  (~250 call sites) and `svelte_analyze` consumers with Block / ElementShape
-  Semantics queries, falling back to AST node-kind reads only where the
-  cluster does not yet own the decision.
-- Preserve lowering's genuine work: whitespace collapse, hoisted-node
-  filtering, TextConcat merging, fragment-scoped flags consumed by
-  codegen (`ContentStrategy`, `has_dynamic_children`, etc.).
-- Remove `FragmentItem` once no consumer references it.
-
-Ordering vs. the semantic clusters:
-- **Precedes** end-to-end Block Semantics consumer migration. Until it
-  lands, block-kind consumer migrations can only land as transitional
-  `match block_semantics(id)` inserted inside the existing `FragmentItem`
-  dispatcher, which is tolerated but not the target form.
-- **Independent** of Attribute Semantics (attributes live on element
-  nodes, not on fragment items).
-- **Coordinates with** ElementShape Semantics: both need the semantic
-  dispatcher in codegen; landing ElementShape and the FragmentItem kill
-  in the same slice may be the simplest path.
-
-Migration unit: not a cluster. A dedicated infrastructure slice with its
-own spec. It does not add new semantic meaning; it removes a duplicated
-dispatcher that blocks the cluster migrations from reaching their target
-consumer shape.
-
-Until this slice lands, the Block Semantics payload is built and unit
-tested, but consumer code for block kinds either (a) reads the payload
-from inside a FragmentItem arm (acceptable transitional form), or
-(b) does not migrate its consumer at all and only lives as an
-analyzer-side contract (preferred when no clean consumer path exists).
+The target form for downstream cluster migrations is therefore already
+in place: each child resolves through `block_semantics(node_id)`
+first, then ElementShape (today still AST node-kind based, until that
+cluster lands).
 
 ## Open: Кто отдаёт семантику для ExpressionTag в шаблонах
 


### PR DESCRIPTION
CODEBASE_MAP.md:
- Replace stale `ParserResult`/`ExprHandle`/`StmtHandle`/`ParsedExprs`
  references with `JsAst`/`ExprRef`/`StmtRef`/`OxcNodeId`
- Document new `svelte_types` crate (`CompileContext`, `TransformOptions`,
  `CodegenOptions`) and updated transform/codegen entry signatures
- Update analyze passes module list and `types/data/` directory layout
- Update transformer file list (`builders.rs`, `legacy_reactive.rs`,
  `props_legacy.rs`, `state_legacy.rs`)
- Update `Ctx<'a>` description to reflect `CodegenQuery` + `CodegenState`
  split, plus updated dependency graph and invariants

ROADMAP.md:
- Mark items complete based on spec status: $props/$bindable, Element,
  Component, experimental async, on:event legacy, <svelte:options>,
  <svelte:window>/document/body, <svelte:boundary>, $: reactive
  assignments
- Add TypeScript script stripping under Compiler Infrastructure