### PR TITLE
diagnose: keyframe-percentage element scoping + bind:this ordering with class directive

### DIFF
--- a/specs/bind-directives.md
+++ b/specs/bind-directives.md
@@ -1,9 +1,9 @@
 # bind:*
 
 ## Current state
-- **Working**: 16/18 use cases
-- **Tests**: 60/62 green
-- Last updated: 2026-04-11
+- **Working**: 16/19 use cases
+- **Tests**: 60/63 green
+- Last updated: 2026-04-29
 
 ## Source
 
@@ -39,6 +39,7 @@ ROADMAP.md — Bindings
   Existing tests: `bind_resize_observer`, `bind_resize_observer_border_box_size`, `bind_resize_observer_device_pixel_content_box_size`
 - [x] `bind:this` on elements, components, `<svelte:element>`, and getter/setter sequence form
   Existing tests: `bind_this`, `bind_this_sequence`, `component_bind_this`, `component_bind_this_variants`, `svelte_element_bind`
+- [ ] `bind:this` on a regular element with children and a class/style directive must be emitted after the element's `$.reset(...)` (and after the dynamic-class/style `$.template_effect`), matching the reference visit order; today the call is emitted before the inner `$.child(...)` walk (test: `bind_this_with_children_and_class_directive`)
 - [x] Media read/write bindings
   Existing tests: `bind_media_rw`, `bind_media_ro`, `bind_media_property`, `bind_img`
 - [x] `<svelte:window>` and `<svelte:document>` bindings
@@ -104,6 +105,7 @@ ROADMAP.md — Bindings
 - [x] `bind_textarea_value`
 - [x] `bind_this`
 - [x] `bind_this_sequence`
+- [ ] `bind_this_with_children_and_class_directive`
 - [x] `bind_use_deferral`
 - [x] `component_bind_prop_forward`
 - [x] `component_bind_this`

--- a/specs/css-pipeline.md
+++ b/specs/css-pipeline.md
@@ -1,9 +1,9 @@
 # CSS
 
 ## Current state
-- **Working**: 14/14 use cases
-- **Tests**: 95/95 green
-- Last updated: 2026-04-12
+- **Working**: 14/15 use cases
+- **Tests**: 95/96 green
+- Last updated: 2026-04-29
 
 ## Source
 Project CSS pipeline parity work and follow-up diagnostic audit.
@@ -16,6 +16,7 @@ Project CSS pipeline parity work and follow-up diagnostic audit.
 - [x] Selector matching covers type, class, id, attribute presence, static attribute matcher/value selectors, and bounded dynamic attribute expansion with reference-conservative behavior where required (tests: `css_scoped_id_selector`, `css_scoped_attr_presence`, `css_scoped_attr_value_selector`, `css_scoped_attr_matcher_operators`, `css_scoped_attr_name_casefolding`, `css_dynamic_attr_selector_match`, `concat_attribute_selector_no_match`)
 - [x] `:global(...)`, bare `:global`, `:global { ... }`, and `:global(...)` inside `:is(...)`, `:where(...)`, `:not(...)`, and `:has(...)` match the reference transform/analyze behavior for valid CSS (tests: `css_global_basic`, `css_global_compound`, `css_global_block`, `css_global_in_pseudo`)
 - [x] Scoped keyframes and `-global-` escapes are rewritten correctly (test: `css_keyframes_scoped`)
+- [ ] `@keyframes` containing percentage selectors (`0%`, `50%`, `100%`) marks every component element as scoped, matching the reference compiler's parse-keyframe-bodies-as-rules quirk; `from`/`to` keyword keyframes do not (test: `css_keyframes_percentage_scopes_all`)
 - [x] Unused selector warnings and emitted-CSS pruning work for descendant/child/sibling combinators, pseudo selectors, nesting selectors, escaped class/id selectors, and snippet/component boundaries (tests: `css_unused_external`, `css_unused_injected`, `css_pseudo_compound_unused_but_scoped`, `css_pseudo_has`, `css_nesting_selector_scoped`, `css_root_has_scoped`, `css_escaped_selector_scoped`, `css_snippet_descendant_scope_boundary`, `css_snippet_sibling_boundary`, `css_component_snippet_descendant_boundary`)
 - [x] Diagnostic parity for CSS pruning covers `:is(...)`, `:where(...)`, implicit nesting, `:root:has(...)`, escaped selectors, attribute concatenation, and conservative no-match cases where the reference compiler reports `css_unused_selector` (tests: `is_selector_match`, `is_selector_no_match`, `is_selector_compound_no_match`, `where_selector_match`, `where_selector_complex_branch_conservative`, `implicit_nesting_match`, `root_has_match`, `escaped_selector_match`, `concat_attribute_selector_no_match`, `type_selector_no_match`, `class_selector_no_match`, `id_selector_no_match`, `descendant_combinator_no_match`, `child_combinator_indirect_no_match`, `adjacent_sibling_combinator_no_match`, `general_sibling_combinator_no_match`, `multiple_selectors_mixed`, `media_query_unused_selector`, `no_elements_all_unused`)
 - [x] CSS serializer specificity matches the reference for nested selectors and pseudo selector lists, including implicit nesting and `:root:has(...)` handling (tests: `css_pseudo_has`, `css_nesting_selector_scoped`, `css_root_has_scoped`)
@@ -79,6 +80,7 @@ Project CSS pipeline parity work and follow-up diagnostic audit.
 - [x] `css_global_block`
 - [x] `css_global_in_pseudo`
 - [x] `css_keyframes_scoped`
+- [ ] `css_keyframes_percentage_scopes_all`
 - [x] `css_unused_external`
 - [x] `css_unused_injected`
 - [x] `css_pseudo_compound_unused_but_scoped`

--- a/tasks/compiler_tests/cases2/bind_this_with_children_and_class_directive/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_this_with_children_and_class_directive/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<span>x</span>`);
+var root = $.from_html(`<div><!></div>`);
+export default function App($$anchor) {
+	let dynamicEl;
+	let counter = 0;
+	var div = root();
+	$.bind_this(div, ($$value) => dynamicEl = $$value, () => dynamicEl);
+	$.set_class(div, 1, "", null, {}, { state: counter > 0 });
+	var node = $.child(div);
+	{
+		var consequent = ($$anchor) => {
+			var span = root_1();
+			$.append($$anchor, span);
+		};
+		$.if(node, ($$render) => {
+			if (counter) $$render(consequent);
+		});
+	}
+	$.reset(div);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/bind_this_with_children_and_class_directive/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_this_with_children_and_class_directive/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+var root_1 = $.from_html(`<span>x</span>`);
+var root = $.from_html(`<div><!></div>`);
+export default function App($$anchor) {
+	let dynamicEl;
+	let counter = 0;
+	var div = root();
+	$.set_class(div, 1, "", null, {}, { state: counter > 0 });
+	var node = $.child(div);
+	{
+		var consequent = ($$anchor) => {
+			var span = root_1();
+			$.append($$anchor, span);
+		};
+		$.if(node, ($$render) => {
+			if (counter) $$render(consequent);
+		});
+	}
+	$.reset(div);
+	$.bind_this(div, ($$value) => dynamicEl = $$value, () => dynamicEl);
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/bind_this_with_children_and_class_directive/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_this_with_children_and_class_directive/case.svelte
@@ -1,0 +1,13 @@
+<script>
+    let dynamicEl;
+    let counter = $state(0);
+</script>
+
+<div
+    class:state={counter > 0}
+    bind:this={dynamicEl}
+>
+    {#if counter}
+        <span>x</span>
+    {/if}
+</div>

--- a/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case-rust.js
+++ b/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case-rust.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p>plain</p> <button>btn</button>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(2);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case-svelte.css
+++ b/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case-svelte.css
@@ -1,0 +1,5 @@
+
+    @keyframes svelte-a7w5kd-pulse {
+        0% { opacity: 0.4; }
+        100% { opacity: 1; }
+    }

--- a/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case-svelte.js
+++ b/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case-svelte.js
@@ -1,0 +1,7 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<p class="svelte-a7w5kd">plain</p> <button class="svelte-a7w5kd">btn</button>`, 1);
+export default function App($$anchor) {
+	var fragment = root();
+	$.next(2);
+	$.append($$anchor, fragment);
+}

--- a/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case.svelte
+++ b/tasks/compiler_tests/cases2/css_keyframes_percentage_scopes_all/case.svelte
@@ -1,0 +1,9 @@
+<style>
+    @keyframes pulse {
+        0% { opacity: 0.4; }
+        100% { opacity: 1; }
+    }
+</style>
+
+<p>plain</p>
+<button>btn</button>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -343,6 +343,18 @@ fn css_keyframes_scoped() {
 }
 
 #[rstest]
+#[ignore = "diagnose: pending fix"]
+fn css_keyframes_percentage_scopes_all() {
+    assert_compiler("css_keyframes_percentage_scopes_all");
+}
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn bind_this_with_children_and_class_directive() {
+    assert_compiler("bind_this_with_children_and_class_directive");
+}
+
+#[rstest]
 fn head_position_with_body() {
     assert_compiler("head_position_with_body");
 }


### PR DESCRIPTION
Capture two parity gaps surfaced by the benchmark component:

- @keyframes with percentage selectors (0%, 100%) marks every element as
  scoped in the reference compiler (a side effect of parsing keyframe
  bodies as Rules with Percentage selectors); ours skips @keyframes in
  css-prune. Test: css_keyframes_percentage_scopes_all.
- bind:this on a regular element with children plus a class:/style:
  directive is emitted before $.reset(...) instead of after. Test:
  bind_this_with_children_and_class_directive.

Both registered as #[ignore = "diagnose: pending fix"]; default suite
stays green.