### PR TITLE
diagnose: bind:group ordering with stores + JSDoc @type leak

### DIFF
--- a/specs/bind-directives.md
+++ b/specs/bind-directives.md
@@ -1,9 +1,9 @@
 # bind:*
 
 ## Current state
-- **Working**: 16/19 use cases
-- **Tests**: 60/63 green
-- Last updated: 2026-04-29
+- **Working**: 16/20 use cases
+- **Tests**: 60/64 green
+- Last updated: 2026-04-30
 
 ## Source
 
@@ -30,6 +30,7 @@ ROADMAP.md — Bindings
   Existing tests: `bind_textarea_value`, `textarea_child_value_dynamic`
 - [x] `bind:checked`, `bind:group`, and `bind:files`
   Existing tests: `bind_directives_extended`, `bind_function_checked`, `bind_group_*`, `bind_files`, `push_binding_group_order`
+- [ ] `bind:group` with auto-subscribed stores in same component: the synthesized `const binding_group = [];` declaration must be emitted AFTER the store getter constants and `const [$$stores, $$cleanup] = $.setup_stores();` (reference order = `store_setup` → `store_init` → `group_binding_declarations`). Currently emitted before them. (test: `bind_group_order_with_stores`, S)
 - [x] Regular-element `bind:checked` targeting a `$bindable` prop source from `$props()` passes the prop accessor directly to `$.bind_checked(...)` instead of lowering through rune getter/setter closures (test: `props_bindable_checkbox_disabled_shorthand_ts`)
 - [x] Contenteditable bindings: `bind:innerHTML`, `bind:innerText`, `bind:textContent`
   Existing tests: `bind_content_editable`, `bind_contenteditable_flag`, `bind_multiple_on_element`
@@ -112,6 +113,7 @@ ROADMAP.md — Bindings
 - [x] `component_bind_this`
 - [x] `component_bind_this_variants`
 - [x] `push_binding_group_order`
+- [ ] `bind_group_order_with_stores`
 - [x] `props_bindable_checkbox_disabled_shorthand_ts`
 - [x] `svelte_document_bindings`
 - [x] `svelte_element_bind`

--- a/specs/css-pipeline.md
+++ b/specs/css-pipeline.md
@@ -1,9 +1,9 @@
 # CSS
 
 ## Current state
-- **Working**: 14/15 use cases
-- **Tests**: 95/96 green
-- Last updated: 2026-04-29
+- **Working**: 14/17 use cases
+- **Tests**: 95/98 green
+- Last updated: 2026-04-30
 
 ## Source
 Project CSS pipeline parity work and follow-up diagnostic audit.
@@ -12,6 +12,8 @@ Project CSS pipeline parity work and follow-up diagnostic audit.
 
 - [x] Top-level component CSS is extracted from `<style>`, analyzed, transformed, and returned through `CompileResult.css` in external mode (tests: `css_scoped_basic`, `explicit_external_css_mode_returns_compile_result_css`)
 - [x] Injected CSS mode works through compile options and inline `<svelte:options css="injected">` precedence (tests: `css_injected`, `css_injected_via_compile_options`, `inline_css_injected_overrides_external_compile_option`)
+- [ ] Injected CSS `code:` string preserves source whitespace (newlines, indentation, space after `:`, space inside braces) the way reference does — currently our pipeline minifies through lightningcss so non-trivial source CSS (e.g. `@keyframes` blocks) loses formatting and diverges from reference verbatim string. (test: `css_injected_keyframes_preserve_whitespace`, M)
+- [ ] In injected CSS mode, `$.append_styles($$anchor, $$css);` must be emitted AFTER `$.push($$props, ...)` and before the auto-subscribed-store getter consts / `$.setup_stores()` block (reference unshifts append_styles after store_setup is unshifted, so `push → append_styles → store_setup → store_init`). Currently we emit `append_styles` before `$.push(...)` whenever stores are present. (test: `css_injected_append_styles_with_stores_order`, S)
 - [x] Scoped selector marking and scope-class injection work for ordinary elements, snippets, `<svelte:element>`, class-object attrs, and spread attrs (tests: `css_scoped_class_selector`, `css_scope_class_in_snippet`, `css_scope_svelte_element_class`, `css_scope_class_object`, `css_scope_spread_attribute`)
 - [x] Selector matching covers type, class, id, attribute presence, static attribute matcher/value selectors, and bounded dynamic attribute expansion with reference-conservative behavior where required (tests: `css_scoped_id_selector`, `css_scoped_attr_presence`, `css_scoped_attr_value_selector`, `css_scoped_attr_matcher_operators`, `css_scoped_attr_name_casefolding`, `css_dynamic_attr_selector_match`, `concat_attribute_selector_no_match`)
 - [x] `:global(...)`, bare `:global`, `:global { ... }`, and `:global(...)` inside `:is(...)`, `:where(...)`, `:not(...)`, and `:has(...)` match the reference transform/analyze behavior for valid CSS (tests: `css_global_basic`, `css_global_compound`, `css_global_block`, `css_global_in_pseudo`)
@@ -63,6 +65,8 @@ Project CSS pipeline parity work and follow-up diagnostic audit.
 - [x] `css_injected`
 - [x] `css_injected_via_compile_options`
 - [x] `inline_css_injected_overrides_external_compile_option`
+- [ ] `css_injected_keyframes_preserve_whitespace`
+- [ ] `css_injected_append_styles_with_stores_order`
 - [x] `css_scoped_class_selector`
 - [x] `css_scope_class_in_snippet`
 - [x] `css_scope_svelte_element_class`

--- a/specs/typescript-script-stripping.md
+++ b/specs/typescript-script-stripping.md
@@ -1,9 +1,9 @@
 # TypeScript Script Stripping
 
 ## Current state
-- **Working**: 6/7 use cases
-- **Tests**: 6/7 green
-- Last updated: 2026-04-11
+- **Working**: 6/8 use cases
+- **Tests**: 6/8 green
+- Last updated: 2026-04-30
 
 ## Source
 
@@ -18,6 +18,7 @@
 - `<div value={foo as string} />`
 - `{#const value = expr as T}`
 - `<script lang="ts">// comment only</script>`
+- `<script>/** @type {Foo} */ let x;</script>` (JSDoc type annotations on plain JS scripts)
 
 ## Use cases
 
@@ -28,6 +29,7 @@
 - [x] TypeScript wrappers inside regular dynamic attributes are stripped in emitted client output (test: `ts_strip_attribute`)
 - [x] Instance `<script lang="ts">` with surviving runtime JavaScript strips type syntax while preserving the remaining script logic (test: `ts_strip_script_types`)
 - [ ] Comment-only or otherwise effectively-empty `<script lang="ts">` blocks must not preserve orphaned script comments in final client JS, and must not introduce extra template cursor operations such as `$.next(...)` or `$.reset(...)` after the script disappears (test: `diagnose_svg_city_icon`, moderate)
+- [ ] JSDoc `/** @type ... */` annotations on plain `<script>` (non-`lang="ts"`) `let`/`var`/`const` declarations must be stripped from the emitted client JS instead of leaking through as leading comments. Currently only reproduces inside the large `/diagnose` benchmark component (script with stores + runes + `bind:group` + JSDoc-annotated `let show;`); could not be reduced to a focused isolated case during diagnose. Symptom may resolve once `bind_group_order_with_stores` lands since both originate from the same instance-body splice region. (broad-repro only, S–M)
 
 ## Out of scope
 
@@ -56,3 +58,4 @@
 - [x] `ts_strip_attribute`
 - [x] `ts_strip_script_types`
 - [ ] `diagnose_svg_city_icon`
+- [ ] JSDoc `@type` leak on plain `<script>` — broad-repro only; revisit after `bind_group_order_with_stores` lands

--- a/specs/unknown.md
+++ b/specs/unknown.md
@@ -1,8 +1,8 @@
 # Unknown problems
 
 ## Current state
-- **Working**: 0/1 use cases
-- **Tests**: 0/1 green
+- **Working**: 0/0 use cases
+- **Tests**: 0/0 green
 - Last updated: 2026-04-30
 
 ## Source
@@ -11,7 +11,7 @@
 
 ## Use cases
 
-- [ ] JSDoc `/** @type ... */` annotation on a script-level `let` declaration leaks into emitted client JS — layer: codegen; repro/test: only reproduces inside the large `/diagnose` benchmark component (script with stores + runes + `bind:group` + `let show;` annotated). Could not reduce to a focused isolated case during diagnose; symptom may resolve once `bind_group_order_with_stores` is fixed since both originate from the same instance-body splice region. Candidate specs: typescript-script-stripping, bind-directives; suggested spec: typescript-script-stripping
+- None currently recorded
 
 ## Out of scope
 
@@ -32,4 +32,4 @@
 - `tasks/compiler_tests/cases2/`
 
 ## Test cases
-- [ ] JSDoc `@type` leak — broad-repro only; revisit after `bind_group_order_with_stores` lands
+- None currently recorded

--- a/specs/unknown.md
+++ b/specs/unknown.md
@@ -1,9 +1,9 @@
 # Unknown problems
 
 ## Current state
-- **Working**: 0/0 use cases
-- **Tests**: 0/0 green
-- Last updated: 2026-04-11
+- **Working**: 0/1 use cases
+- **Tests**: 0/1 green
+- Last updated: 2026-04-30
 
 ## Source
 
@@ -11,7 +11,7 @@
 
 ## Use cases
 
-- None currently recorded
+- [ ] JSDoc `/** @type ... */` annotation on a script-level `let` declaration leaks into emitted client JS — layer: codegen; repro/test: only reproduces inside the large `/diagnose` benchmark component (script with stores + runes + `bind:group` + `let show;` annotated). Could not reduce to a focused isolated case during diagnose; symptom may resolve once `bind_group_order_with_stores` is fixed since both originate from the same instance-body splice region. Candidate specs: typescript-script-stripping, bind-directives; suggested spec: typescript-script-stripping
 
 ## Out of scope
 
@@ -32,4 +32,4 @@
 - `tasks/compiler_tests/cases2/`
 
 ## Test cases
-- None currently recorded
+- [ ] JSDoc `@type` leak — broad-repro only; revisit after `bind_group_order_with_stores` lands

--- a/tasks/compiler_tests/cases2/bind_group_order_with_stores/case-rust.js
+++ b/tasks/compiler_tests/cases2/bind_group_order_with_stores/case-rust.js
@@ -1,0 +1,32 @@
+import * as $ from "svelte/internal/client";
+import { writable } from "svelte/store";
+var root = $.from_html(`<input type="radio"/> <input type="radio"/> <p> </p>`, 1);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const binding_group = [];
+	const $metrics = () => $.store_get(metrics, "$metrics", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	let metrics = writable([
+		1,
+		2,
+		3
+	]);
+	let group = $.state($.proxy([]));
+	let total = $.derived(() => $metrics().length);
+	var fragment = root();
+	var input = $.first_child(fragment);
+	$.remove_input_defaults(input);
+	input.value = input.__value = "a";
+	var input_1 = $.sibling(input, 2);
+	$.remove_input_defaults(input_1);
+	input_1.value = input_1.__value = "b";
+	var p = $.sibling(input_1, 2);
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(total)));
+	$.bind_group(binding_group, [], input, () => $.get(group), ($$value) => $.set(group, $$value));
+	$.bind_group(binding_group, [], input_1, () => $.get(group), ($$value) => $.set(group, $$value));
+	$.append($$anchor, fragment);
+	$.pop();
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/bind_group_order_with_stores/case-svelte.js
+++ b/tasks/compiler_tests/cases2/bind_group_order_with_stores/case-svelte.js
@@ -1,0 +1,32 @@
+import * as $ from "svelte/internal/client";
+import { writable } from "svelte/store";
+var root = $.from_html(`<input type="radio"/> <input type="radio"/> <p> </p>`, 1);
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	const $metrics = () => $.store_get(metrics, "$metrics", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	const binding_group = [];
+	let metrics = writable([
+		1,
+		2,
+		3
+	]);
+	let group = $.state($.proxy([]));
+	let total = $.derived(() => $metrics().length);
+	var fragment = root();
+	var input = $.first_child(fragment);
+	$.remove_input_defaults(input);
+	input.value = input.__value = "a";
+	var input_1 = $.sibling(input, 2);
+	$.remove_input_defaults(input_1);
+	input_1.value = input_1.__value = "b";
+	var p = $.sibling(input_1, 2);
+	var text = $.child(p, true);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, $.get(total)));
+	$.bind_group(binding_group, [], input, () => $.get(group), ($$value) => $.set(group, $$value));
+	$.bind_group(binding_group, [], input_1, () => $.get(group), ($$value) => $.set(group, $$value));
+	$.append($$anchor, fragment);
+	$.pop();
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/bind_group_order_with_stores/case.svelte
+++ b/tasks/compiler_tests/cases2/bind_group_order_with_stores/case.svelte
@@ -1,0 +1,10 @@
+<script>
+    import { writable } from "svelte/store";
+    let metrics = writable([1, 2, 3]);
+    let group = $state([]);
+    let total = $derived($metrics.length);
+</script>
+
+<input type="radio" bind:group={group} value="a" />
+<input type="radio" bind:group={group} value="b" />
+<p>{total}</p>

--- a/tasks/compiler_tests/cases2/css_injected_append_styles_with_stores_order/case-rust.js
+++ b/tasks/compiler_tests/cases2/css_injected_append_styles_with_stores_order/case-rust.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+import { writable } from "svelte/store";
+var root = $.from_html(`<p class="svelte-sw3owg"> </p>`);
+const $$css = {
+	hash: "svelte-sw3owg",
+	code: "p.svelte-sw3owg {color:red;}"
+};
+export default function App($$anchor, $$props) {
+	$.append_styles($$anchor, $$css);
+	$.push($$props, true);
+	const $store = () => $.store_get(store, "$store", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	let store = writable(0);
+	let count = 0;
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$store() ?? ""} 0`));
+	$.append($$anchor, p);
+	$.pop();
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/css_injected_append_styles_with_stores_order/case-svelte.js
+++ b/tasks/compiler_tests/cases2/css_injected_append_styles_with_stores_order/case-svelte.js
@@ -1,0 +1,22 @@
+import * as $ from "svelte/internal/client";
+import { writable } from "svelte/store";
+var root = $.from_html(`<p class="svelte-sw3owg"> </p>`);
+const $$css = {
+	hash: "svelte-sw3owg",
+	code: "p.svelte-sw3owg {color:red;}"
+};
+export default function App($$anchor, $$props) {
+	$.push($$props, true);
+	$.append_styles($$anchor, $$css);
+	const $store = () => $.store_get(store, "$store", $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	let store = writable(0);
+	let count = 0;
+	var p = root();
+	var text = $.child(p);
+	$.reset(p);
+	$.template_effect(() => $.set_text(text, `${$store() ?? ""} 0`));
+	$.append($$anchor, p);
+	$.pop();
+	$$cleanup();
+}

--- a/tasks/compiler_tests/cases2/css_injected_append_styles_with_stores_order/case.svelte
+++ b/tasks/compiler_tests/cases2/css_injected_append_styles_with_stores_order/case.svelte
@@ -1,0 +1,13 @@
+<svelte:options css="injected" />
+
+<script>
+    import { writable } from "svelte/store";
+    let store = writable(0);
+    let count = $state(0);
+</script>
+
+<style>
+    p { color: red; }
+</style>
+
+<p>{$store} {count}</p>

--- a/tasks/compiler_tests/cases2/css_injected_keyframes_preserve_whitespace/case-rust.js
+++ b/tasks/compiler_tests/cases2/css_injected_keyframes_preserve_whitespace/case-rust.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div class="x svelte-11wc98t">x</div>`);
+const $$css = {
+	hash: "svelte-11wc98t",
+	code: "@keyframes svelte-11wc98t-pulse {0% {opacity:0.4;}100% {opacity:1;}}.x.svelte-11wc98t {animation:svelte-11wc98t-pulse 1s;}"
+};
+export default function App($$anchor) {
+	$.append_styles($$anchor, $$css);
+	var div = root();
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/css_injected_keyframes_preserve_whitespace/case-svelte.js
+++ b/tasks/compiler_tests/cases2/css_injected_keyframes_preserve_whitespace/case-svelte.js
@@ -1,0 +1,11 @@
+import * as $ from "svelte/internal/client";
+var root = $.from_html(`<div class="x svelte-11wc98t">x</div>`);
+const $$css = {
+	hash: "svelte-11wc98t",
+	code: "\n    @keyframes svelte-11wc98t-pulse {\n        0% { opacity: 0.4; }\n        100% { opacity: 1; }\n    }.x.svelte-11wc98t { animation: svelte-11wc98t-pulse 1s;}"
+};
+export default function App($$anchor) {
+	$.append_styles($$anchor, $$css);
+	var div = root();
+	$.append($$anchor, div);
+}

--- a/tasks/compiler_tests/cases2/css_injected_keyframes_preserve_whitespace/case.svelte
+++ b/tasks/compiler_tests/cases2/css_injected_keyframes_preserve_whitespace/case.svelte
@@ -1,0 +1,11 @@
+<svelte:options css="injected" />
+
+<style>
+    @keyframes pulse {
+        0% { opacity: 0.4; }
+        100% { opacity: 1; }
+    }
+    .x { animation: pulse 1s; }
+</style>
+
+<div class="x">x</div>

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -312,6 +312,18 @@ fn bind_group_order_with_stores() {
 }
 
 #[rstest]
+#[ignore = "diagnose: pending fix"]
+fn css_injected_keyframes_preserve_whitespace() {
+    assert_compiler("css_injected_keyframes_preserve_whitespace");
+}
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn css_injected_append_styles_with_stores_order() {
+    assert_compiler("css_injected_append_styles_with_stores_order");
+}
+
+#[rstest]
 fn css_scoped_basic() {
     assert_compiler("css_scoped_basic");
 }

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -306,6 +306,12 @@ fn push_binding_group_order() {
 }
 
 #[rstest]
+#[ignore = "diagnose: pending fix"]
+fn bind_group_order_with_stores() {
+    assert_compiler("bind_group_order_with_stores");
+}
+
+#[rstest]
 fn css_scoped_basic() {
     assert_compiler("css_scoped_basic");
 }


### PR DESCRIPTION
Add ignored `bind_group_order_with_stores` repro and record the
owning use case in specs/bind-directives.md. Track JSDoc @type leak
on script-level let declarations in specs/unknown.md (broad-repro
only; likely linked to the same instance-body splice region).

https://claude.ai/code/session_01N3NgAt4qY1ByZJ3wEwoZYm