### PR TITLE
diagnose: runes+dev+CE benchmark gaps and roadmap actualization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 - [x] `{@const}` — [spec](specs/const-tag.md)
 - [x] `{@debug}` — [spec](specs/debug-tag.md)
 - [ ] Text / ExpressionTag — [spec](specs/text-expression-tag.md)
-- [ ] Experimental async — [spec](specs/experimental-async.md)
+- [x] Experimental async — [spec](specs/experimental-async.md)
 
 ## Attributes & Spreads
 
@@ -113,8 +113,8 @@ SSR remains a separate future track. This roadmap stays client-only until these 
 
 ## Directives
 
-- [ ] `use:action` — [spec](specs/use-action.md)
-- [ ] `transition:` / `in:` / `out:` — [spec](specs/transitions.md)
+- [x] `use:action` — [spec](specs/use-action.md)
+- [x] `transition:` / `in:` / `out:` — [spec](specs/transitions.md)
 - [x] `animate:` — [spec](specs/animate.md)
 - [x] `{@attach}` — [spec](specs/attach-tag.md)
 

--- a/specs/bind-directives.md
+++ b/specs/bind-directives.md
@@ -1,8 +1,8 @@
 # bind:*
 
 ## Current state
-- **Working**: 16/20 use cases
-- **Tests**: 60/64 green
+- **Working**: 16/21 use cases
+- **Tests**: 60/65 green
 - Last updated: 2026-04-30
 
 ## Source
@@ -57,6 +57,7 @@ ROADMAP.md — Bindings
 - [x] Warning parity for rest-pattern each bindings
   `bind_invalid_each_rest`
 - [ ] Dev-mode component prop bindings validate ownership via `$$ownership_validator.binding(...)`
+- [ ] Dev-mode element bind helpers (`$.bind_value`, `$.bind_checked`, `$.bind_group`, `$.bind_select_value`, `$.bind_content_editable`, `$.bind_volume`, `$.bind_paused`, `$.bind_element_size`) take named `function get() {...}` / `function set($$value) {...}` declarations as get/set callbacks instead of arrow expressions. (test: `diagnose_runes_dev_ce_benchmark`)
 
 ## Reference
 
@@ -142,3 +143,4 @@ ROADMAP.md — Bindings
 - [x] `validate_bind_member_expression_no_error`
 - [x] `validate_bind_getter_setter_no_error`
 - [x] `bind_select_static_option_value`
+- [ ] `diagnose_runes_dev_ce_benchmark`

--- a/specs/component-node.md
+++ b/specs/component-node.md
@@ -1,9 +1,9 @@
 # ComponentNode
 
 ## Current state
-- **Working**: 12/13 use cases
-- **Tests**: 19/20 green
-- Last updated: 2026-04-11
+- **Working**: 12/14 use cases
+- **Tests**: 19/21 green
+- Last updated: 2026-04-30
 
 ## Source
 
@@ -38,6 +38,7 @@
 - [x] Runes-mode dotted dynamic component refs whose root binding is non-normal use the same template binding read semantics as ordinary template reads, including `$props()`-backed roots like `<registry.Widget />` (test: `component_dynamic_dotted_props_root`)
 - [x] Runes-mode local component bindings whose tag names include `_` or digits, including `<Derived_1>` from `$derived(Widget)` and `<Const_0>` from `{@const}`, parse and lower through the dynamic-component path with `bind:this` (test: `component_local_underscored_bind_this`)
 - [x] Analyze emits component-specific validation/warnings for invalid directives and attribute edge cases (component-tag directives/modifiers plus direct attribute-name/value checks)
+- [ ] Dev-mode default `children` slot snippet passed to a component is wrapped with `$.wrap_snippet(App, ($$anchor, $$slotProps) => { ... })` (test: `diagnose_runes_dev_ce_benchmark`)
 
 ## Reference
 
@@ -79,3 +80,4 @@
 - [x] analyzer unit tests: component invalid directive, component `on:` modifier validation, component illegal colon warning, component unquoted attribute sequence
 - [x] `component_invalid_directive_use`
 - [x] `component_on_modifier_only_allows_once`
+- [ ] `diagnose_runes_dev_ce_benchmark`

--- a/specs/custom-elements.md
+++ b/specs/custom-elements.md
@@ -1,9 +1,9 @@
 # Custom Elements
 
 ## Current state
-- **Working**: 11/14 use cases
-- **Tests**: 13/15 green
-- Last updated: 2026-04-07
+- **Working**: 11/17 use cases
+- **Tests**: 13/16 green
+- Last updated: 2026-04-30
 
 ## Source
 
@@ -45,6 +45,9 @@
 - [ ] CE mode injects component CSS into JS/shadow-root output even without inline `css="injected"`.
 - [x] `$host()` is available when compiling as a custom element, and CE rest-prop lowering excludes `$$host`.
 - [ ] Object-form `customElement` validation for `props` shape, allowed `type` values, and `shadow` value parity still lives in analyze-only extraction instead of the parser path used by the reference compiler.
+- [ ] Compile-option `customElement: true` (without an inline `<svelte:options customElement>`) emits the `$.create_custom_element(App, propsMeta, [], exports, { mode: "open" })` constructor call at module scope. (test: `diagnose_runes_dev_ce_benchmark`)
+- [ ] CE/legacy instance-script exports (`export const`, `export function`) appear on `$$exports` as `get NAME() { return NAME; }` accessors plus a trailing `...$.legacy_api()` spread instead of plain shorthand properties. (test: `diagnose_runes_dev_ce_benchmark`)
+- [ ] CE rest-prop lowering `$.rest_props($$props, [...keys], "rest")` includes `"$$host"` in the excluded-key list and passes the destructured-binding label `"rest"` as the trailing argument. (test: `diagnose_runes_dev_ce_benchmark`)
 
 ## Out of scope
 
@@ -90,3 +93,4 @@
 - [ ] `custom_element_css_default_injected` — ignored as `missing: custom-element default CSS injection (compiler/codegen)` — effort: moderate
 - [ ] `custom_element_prop_alias` — ignored as `missing: aliased prop accessors in custom elements (analyze/codegen)` — effort: moderate
 - [x] `custom_element_shadow_object`
+- [ ] `diagnose_runes_dev_ce_benchmark`

--- a/specs/snippet-block.md
+++ b/specs/snippet-block.md
@@ -1,9 +1,9 @@
 # SnippetBlock
 
 ## Current state
-- **Working**: 23/23 use cases
-- **Tests**: 25/27 green
-- Last updated: 2026-04-08
+- **Working**: 23/25 use cases
+- **Tests**: 25/28 green
+- Last updated: 2026-04-30
 
 ## Source
 ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
@@ -33,6 +33,8 @@ ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
 - [x] `snippet_shadowing_prop` validation (tests: analyzer unit tests)
 - [x] `snippet_conflict` validation (tests: analyzer unit tests)
 - [x] `snippet_invalid_export` validation (tests: analyzer unit tests)
+- [ ] Dev-mode `{@render snippet(...)}` calls are wrapped in `$.add_svelte_meta(() => snippet(...), "render", App, line, col)` rather than emitted bare. (test: `diagnose_runes_dev_ce_benchmark`)
+- [ ] Snippet parameter object destructuring with a default-initialized nested pattern (e.g. `{ label, values = [counter], meta: { id = propsId } = {} }`) registers the destructured locals (`label`, `values`, `id`) as effect dependencies so reads inside the body are tracked. (test: `diagnose_runes_dev_ce_benchmark`)
 
 ## Reference
 
@@ -85,3 +87,4 @@ ROADMAP Tier 2b: `{#snippet}` — parameter destructuring
 - [x] `validate_snippet_children_without_other_content_has_no_conflict`
 - [x] `snippet_destructure_default_state_ref`
 - [x] `snippet_destructure_default_mutated_state_ref`
+- [ ] `diagnose_runes_dev_ce_benchmark`

--- a/specs/unknown.md
+++ b/specs/unknown.md
@@ -1,17 +1,20 @@
 # Unknown problems
 
 ## Current state
-- **Working**: 0/0 use cases
-- **Tests**: 0/0 green
+- **Working**: 0/3 use cases
+- **Tests**: 0/1 green
 - Last updated: 2026-04-30
 
 ## Source
 
 - User request: create a durable triage spec for problems that do not yet map to one owning feature spec
+- `/diagnose` benchmark component (dev=true, runes=true, customElement=true) — broad repro `diagnose_runes_dev_ce_benchmark`
 
 ## Use cases
 
-- None currently recorded
+- [ ] dev-mode `==` and `===` comparisons in template/snippet expressions are not wrapped with `$.equals` / `$.strict_equals`; layer: transform; repro/test: diagnose_runes_dev_ce_benchmark; candidate specs: text-expression-tag.md, if-block.md; suggested spec: none
+- [ ] `$props()` source-line argument passed to `$.prop($$props, ..., flags, default)` and the location array passed to `$.add_locations(..., [[line, col], ...])` are off (props lines off by 4, `<svelte:head>` array contains a phantom head-root entry); layer: codegen; repro/test: diagnose_runes_dev_ce_benchmark; candidate specs: source-maps.md, props-bindable.md, element.md; suggested spec: none
+- [ ] `$state.raw({...})` declarator in a script that combines `$props()` rest, dev mode, and `customElement: true` is emitted as a plain object literal instead of `$.tag($.state({...}), "name")`, and the corresponding `$state.snapshot(rawData)` reads `rawData` directly instead of `$.get(rawData)`; not reproducible in isolation, only in the combined benchmark; layer: transform; repro/test: diagnose_runes_dev_ce_benchmark; candidate specs: state-rune.md, custom-elements.md; suggested spec: state-rune.md
 
 ## Out of scope
 
@@ -32,4 +35,4 @@
 - `tasks/compiler_tests/cases2/`
 
 ## Test cases
-- None currently recorded
+- [ ] `diagnose_runes_dev_ce_benchmark`

--- a/tasks/compiler_tests/cases2/diagnose_runes_dev_ce_benchmark/case-svelte.js
+++ b/tasks/compiler_tests/cases2/diagnose_runes_dev_ce_benchmark/case-svelte.js
@@ -1,0 +1,600 @@
+App[$.FILENAME] = "(unknown)";
+import * as $ from "svelte/internal/client";
+import { onMount } from "svelte";
+import { writable } from "svelte/store";
+import { fade, fly, slide } from "svelte/transition";
+import { flip } from "svelte/animate";
+import ChildComponent from "./Child.svelte";
+const badge = $.wrap_snippet(App, function($$anchor, text = $.noop, variant = $.noop) {
+	$.validate_snippet_args(...arguments);
+	var span = root_2();
+	let classes;
+	var text_1 = $.child(span, true);
+	$.reset(span);
+	$.template_effect(() => {
+		classes = $.set_class(span, 1, "badge svelte-13nvtxg", null, classes, {
+			primary: $.strict_equals(variant(), "primary"),
+			secondary: $.strict_equals(variant(), "secondary")
+		});
+		$.set_text(text_1, text());
+	});
+	$.append($$anchor, span);
+});
+const card = $.wrap_snippet(App, function($$anchor, heading = $.noop, body = $.noop) {
+	$.validate_snippet_args(...arguments);
+	var div = root_3();
+	var h3 = $.child(div);
+	var text_2 = $.child(h3, true);
+	$.reset(h3);
+	var p = $.sibling(h3, 2);
+	var text_3 = $.child(p, true);
+	$.reset(p);
+	var node_1 = $.sibling(p, 2);
+	$.add_svelte_meta(() => badge(node_1, () => "new", () => "primary"), "render", App, 174, 8);
+	$.reset(div);
+	$.template_effect(() => {
+		$.set_text(text_2, heading());
+		$.set_text(text_3, body());
+	});
+	$.append($$anchor, div);
+});
+export const BENCHMARK_KIND = "compiler";
+export const MODULE_SCALE = 3;
+export function moduleLabel(name) {
+	return `${BENCHMARK_KIND}:${name}`;
+}
+var root_1 = $.add_locations($.from_html(`<meta name="description" content="Benchmark component" class="svelte-13nvtxg"/> <link rel="canonical" href="/benchmark" class="svelte-13nvtxg"/>`, 1), App[$.FILENAME], [[156, 4], [157, 4]]);
+var root_2 = $.add_locations($.from_html(`<span> </span>`), App[$.FILENAME], [[165, 4]]);
+var root_3 = $.add_locations($.from_html(`<div class="card svelte-13nvtxg"><h3 class="svelte-13nvtxg"> </h3> <p class="svelte-13nvtxg"> </p> <!></div>`), App[$.FILENAME], [[
+	171,
+	4,
+	[[172, 8], [173, 8]]
+]]);
+var root_5 = $.add_locations($.from_html(`<span class="svelte-13nvtxg"> </span>`), App[$.FILENAME], [[182, 12]]);
+var root_4 = $.add_locations($.from_html(`<section class="summary svelte-13nvtxg"><h4 class="svelte-13nvtxg"> </h4> <!></section>`), App[$.FILENAME], [[
+	179,
+	4,
+	[[180, 8]]
+]]);
+var root_6 = $.add_locations($.from_html(`<span empty="" class="svelte-13nvtxg"> </span>`), App[$.FILENAME], [[216, 12]]);
+var root_8 = $.add_locations($.from_html(`<h1 class="svelte-13nvtxg">Lorem ipsum dolor sit amet. Chunk 0.</h1>`), App[$.FILENAME], [[225, 16]]);
+var root_10 = $.add_locations($.from_html(`<h2 class="svelte-13nvtxg">EMPTY</h2>`), App[$.FILENAME], [[231, 16]]);
+var root_7 = $.add_locations($.from_html(`<div class="svelte-13nvtxg"><input class="svelte-13nvtxg"/></div> <!>`, 1), App[$.FILENAME], [[
+	220,
+	12,
+	[[221, 16]]
+]]);
+var root_11 = $.add_locations($.from_html(`<p class="svelte-13nvtxg"> </p>`), App[$.FILENAME], [[237, 8]]);
+var root_12 = $.add_locations($.from_html(`<p> </p>`), App[$.FILENAME], [[242, 8]]);
+var root_13 = $.add_locations($.from_html(`<span class="item-less svelte-13nvtxg">Repeated shell chunk 0</span>`), App[$.FILENAME], [[246, 8]]);
+var root_14 = $.add_locations($.from_html(`<p class="svelte-13nvtxg"> </p>`), App[$.FILENAME], [[252, 8]]);
+var root_15 = $.add_locations($.from_html(`<p class="svelte-13nvtxg"> </p>`), App[$.FILENAME], [[254, 8]]);
+var root_16 = $.add_locations($.from_html(`<p class="svelte-13nvtxg">Loading chunk 0...</p>`), App[$.FILENAME], [[250, 8]]);
+var root_17 = $.add_locations($.from_html(`<p class="svelte-13nvtxg"> </p>`), App[$.FILENAME], [[258, 8]]);
+var root_19 = $.add_locations($.from_html(`<strong class="svelte-13nvtxg"> </strong>`), App[$.FILENAME], [[280, 8]]);
+var root_20 = $.add_locations($.from_html(`<div slot="footer" class="svelte-13nvtxg"> </div>`), App[$.FILENAME], [[281, 8]]);
+var root_21 = $.add_locations($.from_html(`<p class="svelte-13nvtxg"> </p>`), App[$.FILENAME], [[295, 12]]);
+var root_22 = $.add_locations($.from_html(`<p class="svelte-13nvtxg"> </p>`), App[$.FILENAME], [[293, 8]]);
+var root = $.add_locations($.from_html(`<div class="chunk-shell benchmark-reset benchmark-host svelte-13nvtxg" data-kind="chunk-0"> <p class="svelte-13nvtxg"> </p> <p class="svelte-13nvtxg"> </p> <!> <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. <!></div> <!> <!> <!> <!> <!> <input class="svelte-13nvtxg"/> <textarea class="svelte-13nvtxg"></textarea> <select class="svelte-13nvtxg"><option class="svelte-13nvtxg">Zero</option><option class="svelte-13nvtxg">One</option></select> <input type="checkbox" class="svelte-13nvtxg"/> <input type="radio" class="svelte-13nvtxg"/> <div contenteditable="" class="svelte-13nvtxg">editable</div> <video class="svelte-13nvtxg"></video> <div class="svelte-13nvtxg">action target</div> <div class="svelte-13nvtxg">transition target</div> <div class="svelte-13nvtxg">in/out target</div> <!> <!> <!> <!> <!> <!> <button class="svelte-13nvtxg">Update store</button> <p class="svelte-13nvtxg"> </p> <!></div>`, 2), App[$.FILENAME], [[
+	187,
+	0,
+	[
+		[189, 4],
+		[190, 4],
+		[195, 4],
+		[261, 4],
+		[262, 4],
+		[
+			263,
+			4,
+			[[264, 8], [265, 8]]
+		],
+		[267, 4],
+		[268, 4],
+		[269, 4],
+		[270, 4],
+		[272, 4],
+		[273, 4],
+		[274, 4],
+		[289, 4],
+		[290, 4]
+	]
+]]);
+const $$css = {
+	hash: "svelte-13nvtxg",
+	code: "\n    body {\n        margin: 0;\n        font-family: \"IBM Plex Sans\", sans-serif;\n        background: #f5f1e8;\n    }\n\n    .benchmark-host {\n        color: #3f2a18;\n    }\n\n    /* :global {*/\n        .benchmark-reset {\n            box-sizing: border-box;\n        }\n    /*}*/\n\n    @keyframes svelte-13nvtxg-pulse {\n        0% { opacity: 0.4; transform: scale(0.98); }\n        100% { opacity: 1; transform: scale(1); }\n    }\n\n    @keyframes marquee {\n        from { transform: translateX(0); }\n        to { transform: translateX(12px); }\n    }\n\n    .chunk-shell.svelte-13nvtxg {\n        padding: 16px;\n        margin: 12px 0;\n        border: 1px solid #d9c7ab;\n        background: linear-gradient(180deg, #fffdf9 0%, #f4ead9 100%);\n    }\n\n    .chunk-shell.svelte-13nvtxg :is(.badge:where(.svelte-13nvtxg), .card:where(.svelte-13nvtxg), .summary:where(.svelte-13nvtxg)) {\n        border-radius: 10px;\n    }\n\n    /* (unused) .chunk-shell.state .summary {\n        animation: pulse 180ms ease-out;\n    }*/\n\n    .summary.svelte-13nvtxg span:where(.svelte-13nvtxg) {\n        display: inline-block;\n        margin-right: 8px;\n    }\n\n    .item-less.svelte-13nvtxg {\n        color: #7a4f2a;\n    }\n\n    [data-index].svelte-13nvtxg {\n        color: var(--custom, #5c4634);\n    }\n"
+};
+export default function App($$anchor, $$props) {
+	const propsId = $.props_id();
+	$.check_target(new.target);
+	$.push($$props, true, App);
+	$.append_styles($$anchor, $$css);
+	const $metrics = () => ($.validate_store(metrics, "metrics"), $.store_get(metrics, "$metrics", $$stores));
+	const $labelStore = () => ($.validate_store(labelStore, "labelStore"), $.store_get(labelStore, "$labelStore", $$stores));
+	const [$$stores, $$cleanup] = $.setup_stores();
+	const binding_group = [];
+	const metricSummary = $.wrap_snippet(App, function($$anchor, $$arg0) {
+		$.validate_snippet_args(...arguments);
+		let label = () => $$arg0?.().label;
+		label();
+		let values = $.derived_safe_equal(() => $.fallback($$arg0?.().values, () => [$.get(counter)], true));
+		$.get(values);
+		let id = $.derived_safe_equal(() => $.fallback($.fallback($$arg0?.().meta, () => ({}), true).id, propsId));
+		$.get(id);
+		var section = root_4();
+		var h4 = $.child(section);
+		var text_4 = $.child(h4, true);
+		$.reset(h4);
+		var node_2 = $.sibling(h4, 2);
+		$.add_svelte_meta(() => $.each(node_2, 17, () => $.get(values), $.index, ($$anchor, value, index) => {
+			var span_1 = root_5();
+			var text_5 = $.child(span_1);
+			$.reset(span_1);
+			$.template_effect(() => $.set_text(text_5, `${index}: ${$.get(value) ?? ""}`));
+			$.append($$anchor, span_1);
+		}), "each", App, 181, 8);
+		$.reset(section);
+		$.template_effect(() => {
+			$.set_attribute(section, "data-id", $.get(id));
+			$.set_text(text_4, label());
+		});
+		$.append($$anchor, section);
+	});
+	let title = $.prop($$props, "title", 7, "Default Title"), count = $.prop($$props, "count", 7, 0), items = $.prop($$props, "items", 23, () => []), config = $.prop($$props, "config", 31, () => $.tag_proxy($.proxy({}), "config")), multiplier = $.prop($$props, "multiplier", 7, 2), visible = $.prop($$props, "visible", 15, false), rest = $.rest_props($$props, [
+		"$$slots",
+		"$$events",
+		"$$legacy",
+		"$$host",
+		"title",
+		"count",
+		"items",
+		"config",
+		"multiplier",
+		"visible"
+	], "rest");
+	let state = $.tag($.state(""), "state");
+	let counter = $.tag($.state(0), "counter");
+	let rawData = $.tag($.state({
+		x: 1,
+		y: 2
+	}), "rawData");
+	let checked = $.tag($.state(false), "checked");
+	let group = $.tag($.state($.proxy([])), "group");
+	let volume = $.tag($.state(.5), "volume");
+	let selected = $.tag($.state("opt-0"), "selected");
+	let inputEl;
+	let componentRef;
+	let dynamicEl;
+	let metrics = writable([
+		1,
+		2,
+		3
+	]);
+	let labelStore = writable("ready");
+	let show;
+	$.set(counter, 10);
+	let doubled = $.tag($.derived(() => count() * multiplier()), "doubled");
+	let computed = $.tag($.derived(() => {
+		return items().length * multiplier() + $.get(counter);
+	}), "computed");
+	let moduleSummary = $.tag($.derived(() => moduleLabel(title()) + ":" + MODULE_SCALE), "moduleSummary");
+	let storeSummary = $.tag($.derived(() => $metrics().length + ":" + $labelStore()), "storeSummary");
+	let snapshot = $.snapshot($.get(rawData));
+	$.user_effect(() => {
+		console.log(...$.log_if_contains_state("log", "Title:", title(), "Count:", count()));
+	});
+	$.user_pre_effect(() => {
+		console.log(...$.log_if_contains_state("log", "Pre effect:", $.get(counter)));
+	});
+	let tracking = $.effect_tracking();
+	$.inspect(() => [$.get(counter), $.get(doubled)], (...$$args) => console.log(...$$args), true);
+	const APP_VERSION = "1.0.0";
+	function formatTitle(prefix) {
+		return prefix + ": " + title();
+	}
+	function addMetric() {
+		$.store_set(metrics, [...$metrics(), $.get(counter)]);
+		$.store_set(labelStore, title());
+	}
+	function action(node, arg) {
+		return { destroy() {} };
+	}
+	function handleClick(e) {
+		$.update(counter);
+	}
+	function getHandler() {
+		return handleClick;
+	}
+	function handleError(error) {
+		console.error(...$.log_if_contains_state("error", error));
+	}
+	let promise = Promise.resolve(42);
+	var $$exports = {
+		get APP_VERSION() {
+			return APP_VERSION;
+		},
+		get formatTitle() {
+			return formatTitle;
+		},
+		get title() {
+			return title();
+		},
+		set title($$value = "Default Title") {
+			title($$value);
+			$.flush();
+		},
+		get count() {
+			return count();
+		},
+		set count($$value = 0) {
+			count($$value);
+			$.flush();
+		},
+		get items() {
+			return items();
+		},
+		set items($$value = []) {
+			items($$value);
+			$.flush();
+		},
+		get config() {
+			return config();
+		},
+		set config($$value = {}) {
+			config($$value);
+			$.flush();
+		},
+		get multiplier() {
+			return multiplier();
+		},
+		set multiplier($$value = 2) {
+			multiplier($$value);
+			$.flush();
+		},
+		get visible() {
+			return visible();
+		},
+		set visible($$value = false) {
+			visible($$value);
+			$.flush();
+		},
+		...$.legacy_api()
+	};
+	var div_1 = root();
+	$.head("q2w0q4", ($$anchor) => {
+		var fragment = root_1();
+		$.next(2);
+		$.deferred_template_effect(() => {
+			$.document.title = `${title() ?? ""} - Benchmark`;
+		});
+		$.append($$anchor, fragment);
+	});
+	$.event("scroll", $.window, handleClick);
+	$.event("visibilitychange", $.document, handleClick);
+	$.event("mouseenter", $.document.body, handleClick);
+	$.action($.document.body, ($$node, $$action_arg) => action?.($$node, $$action_arg), () => $.get(state));
+	$.template_effect(() => {
+		console.log({
+			counter: $.snapshot($.get(counter)),
+			state: $.snapshot($.get(state))
+		});
+		debugger;
+	});
+	var text_6 = $.child(div_1);
+	var p_1 = $.sibling(text_6);
+	var text_7 = $.child(p_1);
+	$.reset(p_1);
+	var p_2 = $.sibling(p_1, 2);
+	var text_8 = $.child(p_2);
+	$.reset(p_2);
+	var node_3 = $.sibling(p_2, 2);
+	$.html(node_3, () => "<b>raw html chunk 0</b>");
+	var div_2 = $.sibling(node_3, 2);
+	let classes_1;
+	var event_handler = $.derived(getHandler);
+	let styles;
+	var node_4 = $.sibling($.child(div_2));
+	{
+		var consequent = ($$anchor) => {
+			const localLen = $.tag($.derived(() => $.get(state).length), "localLen");
+			$.get(localLen);
+			var span_2 = root_6();
+			var text_9 = $.child(span_2);
+			$.reset(span_2);
+			$.template_effect(() => {
+				$.set_attribute(span_2, "title", `${title() ?? ""}: ${$.get(doubled) ?? ""}`);
+				$.set_attribute(span_2, "state", $.get(state));
+				$.set_attribute(span_2, "counter", $.get(counter));
+				$.set_attribute(span_2, "count", count());
+				$.set_text(text_9, `Duis aute irure dolor: ${$.get(localLen) ?? ""}. Chunk 0.`);
+			});
+			$.append($$anchor, span_2);
+		};
+		var alternate_1 = ($$anchor) => {
+			var fragment_1 = root_7();
+			var div_3 = $.first_child(fragment_1);
+			var input = $.child(div_3);
+			$.remove_input_defaults(input);
+			$.reset(div_3);
+			var node_5 = $.sibling(div_3, 2);
+			{
+				var consequent_1 = ($$anchor) => {
+					var h1 = root_8();
+					$.template_effect(() => $.set_attribute(h1, "state", $.get(state)));
+					$.append($$anchor, h1);
+				};
+				var consequent_2 = ($$anchor) => {
+					var text_10 = $.text("Lorem ipsum dolor sit amet. Chunk 0.");
+					$.append($$anchor, text_10);
+				};
+				var alternate = ($$anchor) => {
+					var h2 = root_10();
+					$.append($$anchor, h2);
+				};
+				$.add_svelte_meta(() => $.if(node_5, ($$render) => {
+					if ($.get(counter) > 30) $$render(consequent_1);
+					else if ($.equals($.get(counter), 100)) $$render(consequent_2, 1);
+					else $$render(alternate, -1);
+				}), "if", App, 224, 12);
+			}
+			$.template_effect(() => {
+				$.set_attribute(input, "title", title());
+				$.set_attribute(input, "state", $.get(state));
+				$.set_value(input, count());
+			});
+			$.append($$anchor, fragment_1);
+		};
+		$.add_svelte_meta(() => $.if(node_4, ($$render) => {
+			if ($.get(state)) $$render(consequent);
+			else $$render(alternate_1, -1);
+		}), "if", App, 214, 8);
+	}
+	$.reset(div_2);
+	$.bind_this(div_2, ($$value) => dynamicEl = $$value, () => dynamicEl);
+	var node_6 = $.sibling(div_2, 2);
+	$.add_svelte_meta(() => $.key(node_6, () => $.get(counter), ($$anchor) => {
+		var p_3 = root_11();
+		var text_11 = $.child(p_3);
+		$.reset(p_3);
+		$.template_effect(() => $.set_text(text_11, `Keyed content chunk 0: ${$.get(counter) ?? ""}`));
+		$.transition(3, p_3, () => slide);
+		$.append($$anchor, p_3);
+	}), "key", App, 236, 4);
+	var node_7 = $.sibling(node_6, 2);
+	$.add_svelte_meta(() => $.each(node_7, 27, items, (item) => item.id, ($$anchor, item, idx) => {
+		const itemLabel = $.tag($.derived(() => `${$.get(idx)}:${$.get(item).name}`), "itemLabel");
+		$.get(itemLabel);
+		var p_4 = root_12();
+		$.attribute_effect(p_4, () => ({
+			...rest,
+			"data-index": `chunk-0-${$.get(idx) ?? ""}`
+		}), void 0, void 0, void 0, "svelte-13nvtxg");
+		var text_12 = $.child(p_4, true);
+		$.reset(p_4);
+		$.template_effect(() => $.set_text(text_12, $.get(itemLabel)));
+		$.animation(p_4, () => flip, null);
+		$.append($$anchor, p_4);
+	}), "each", App, 240, 4);
+	var node_8 = $.sibling(node_7, 2);
+	$.add_svelte_meta(() => $.each(node_8, 17, items, $.index, ($$anchor, $$item) => {
+		var span_3 = root_13();
+		$.append($$anchor, span_3);
+	}), "each", App, 245, 4);
+	var node_9 = $.sibling(node_8, 2);
+	$.add_svelte_meta(() => $.await(node_9, () => promise, ($$anchor) => {
+		var p_7 = root_16();
+		$.append($$anchor, p_7);
+	}, ($$anchor, value) => {
+		var p_5 = root_14();
+		var text_13 = $.child(p_5);
+		$.reset(p_5);
+		$.template_effect(() => $.set_text(text_13, `Resolved: ${$.get(value) ?? ""}`));
+		$.append($$anchor, p_5);
+	}, ($$anchor, error) => {
+		var p_6 = root_15();
+		var text_14 = $.child(p_6);
+		$.reset(p_6);
+		$.template_effect(() => $.set_text(text_14, `Error: ${$.get(error).message ?? ""}`));
+		$.append($$anchor, p_6);
+	}), "await", App, 249, 4);
+	var node_10 = $.sibling(node_9, 2);
+	$.add_svelte_meta(() => $.await(node_10, () => promise, null, ($$anchor, quickValue) => {
+		var p_8 = root_17();
+		var text_15 = $.child(p_8);
+		$.reset(p_8);
+		$.template_effect(() => $.set_text(text_15, `Quick resolved: ${$.get(quickValue) ?? ""}`));
+		$.append($$anchor, p_8);
+	}), "await", App, 257, 4);
+	var input_1 = $.sibling(node_10, 2);
+	$.remove_input_defaults(input_1);
+	var textarea = $.sibling(input_1, 2);
+	$.remove_textarea_child(textarea);
+	var select = $.sibling(textarea, 2);
+	var option = $.child(select);
+	option.value = option.__value = "opt-0";
+	var option_1 = $.sibling(option);
+	option_1.value = option_1.__value = "opt-1";
+	$.reset(select);
+	var input_2 = $.sibling(select, 2);
+	$.remove_input_defaults(input_2);
+	var input_3 = $.sibling(input_2, 2);
+	$.remove_input_defaults(input_3);
+	input_3.value = input_3.__value = "opt-0";
+	var div_4 = $.sibling(input_3, 2);
+	$.bind_this(div_4, ($$value) => inputEl = $$value, () => inputEl);
+	var video = $.sibling(div_4, 2);
+	var div_5 = $.sibling(video, 2);
+	$.action(div_5, ($$node, $$action_arg) => action?.($$node, $$action_arg), () => $.get(state));
+	var div_6 = $.sibling(div_5, 2);
+	var div_7 = $.sibling(div_6, 2);
+	var node_11 = $.sibling(div_7, 2);
+	{
+		$.validate_dynamic_element_tag(() => $.get(state) ? "div" : "span");
+		$.validate_void_dynamic_element(() => $.get(state) ? "div" : "span");
+		$.element(node_11, () => $.get(state) ? "div" : "span", false, ($$element, $$anchor) => {
+			$.set_class($$element, 0, "dynamic-0 svelte-13nvtxg");
+			var text_16 = $.text();
+			$.template_effect(() => $.set_text(text_16, `Dynamic element chunk 0: ${title() ?? ""}`));
+			$.append($$anchor, text_16);
+		}, void 0, [275, 4]);
+	}
+	var node_12 = $.sibling(node_11, 2);
+	{
+		let $0 = $.derived(getHandler);
+		$.add_svelte_meta(() => $.bind_this(ChildComponent(node_12, {
+			get title() {
+				return title();
+			},
+			get onclick() {
+				return $.get($0);
+			},
+			children: $.wrap_snippet(App, ($$anchor, $$slotProps) => {
+				var strong = root_19();
+				var text_17 = $.child(strong);
+				$.reset(strong);
+				$.template_effect(() => $.set_text(text_17, `Inline child chunk 0: ${title() ?? ""}`));
+				$.append($$anchor, strong);
+			}),
+			$$slots: {
+				default: true,
+				footer: ($$anchor, $$slotProps) => {
+					var div_8 = root_20();
+					var text_18 = $.child(div_8);
+					$.reset(div_8);
+					$.template_effect(() => $.set_text(text_18, `Footer chunk 0: ${$.get(counter) ?? ""}`));
+					$.append($$anchor, div_8);
+				}
+			}
+		}), ($$value) => componentRef = $$value, () => componentRef), "component", App, 279, 4, { componentTag: "ChildComponent" });
+	}
+	var node_13 = $.sibling(node_12, 2);
+	$.add_svelte_meta(() => badge(node_13, () => "chunk-0", () => "secondary"), "render", App, 284, 4);
+	var node_14 = $.sibling(node_13, 2);
+	$.add_svelte_meta(() => card(node_14, title, () => "Content for chunk 0"), "render", App, 285, 4);
+	var node_15 = $.sibling(node_14, 2);
+	$.add_svelte_meta(() => metricSummary(node_15, () => ({
+		label: title(),
+		values: [
+			count(),
+			$.get(doubled),
+			$.get(counter)
+		],
+		meta: { id: propsId }
+	})), "render", App, 286, 4);
+	var node_16 = $.sibling(node_15, 2);
+	$.add_svelte_meta(() => show?.(node_16), "render", App, 287, 4);
+	var button = $.sibling(node_16, 2);
+	var p_9 = $.sibling(button, 2);
+	var text_19 = $.child(p_9);
+	$.reset(p_9);
+	var node_17 = $.sibling(p_9, 2);
+	{
+		const failed = $.wrap_snippet(App, function($$anchor, error = $.noop) {
+			$.validate_snippet_args(...arguments);
+			var p_10 = root_21();
+			var text_20 = $.child(p_10);
+			$.reset(p_10);
+			$.template_effect(() => $.set_text(text_20, `Error in chunk 0: ${error().message ?? ""}`));
+			$.append($$anchor, p_10);
+		});
+		$.boundary(node_17, {
+			onerror: handleError,
+			failed
+		}, ($$anchor) => {
+			var p_11 = root_22();
+			var text_21 = $.child(p_11);
+			$.reset(p_11);
+			$.template_effect(() => $.set_text(text_21, `Boundary chunk 0: ${title() ?? ""}`));
+			$.append($$anchor, p_11);
+		});
+	}
+	$.reset(div_1);
+	$.template_effect(() => {
+		$.set_text(text_6, `Chunk 0: Lorem ${$.get(state) ?? ""} + ${$.get(state) ?? ""} = Ipsum; `);
+		$.set_text(text_7, `Props: title=${title() ?? ""}, count=${count() ?? ""}, doubled=${$.get(doubled) ?? ""}, computed=${$.get(computed) ?? ""}`);
+		$.set_text(text_8, `Module: ${$.get(moduleSummary) ?? ""} | Store: ${$.get(storeSummary) ?? ""} | Label: ${$labelStore() ?? ""}`);
+		classes_1 = $.set_class(div_2, 1, $.clsx({
+			active: $.get(checked),
+			big: $.get(counter) > 10
+		}), "svelte-13nvtxg", classes_1, {
+			state: $.get(state),
+			staticly: true,
+			invinsible,
+			reactive: $.get(counter)
+		});
+		styles = $.set_style(div_2, "", styles, {
+			color: $.get(state),
+			"font-size": "14px",
+			opacity: $.get(counter) / 100,
+			"--custom": "value-0"
+		});
+		$.set_text(text_19, `Metric count: ${$metrics().length ?? ""}`);
+	});
+	$.delegated("click", div_2, handleClick);
+	$.event("scroll", div_2, handleClick);
+	$.event("click", div_2, handleClick, true);
+	$.event("focus", div_2, function(...$$args) {
+		$.apply(() => $.get(event_handler), this, $$args, App, [208, 17], true, true);
+	});
+	$.bind_value(input_1, function get() {
+		return $.get(state);
+	}, function set($$value) {
+		$.set(state, $$value);
+	});
+	$.bind_value(textarea, function get() {
+		return $.get(state);
+	}, function set($$value) {
+		$.set(state, $$value);
+	});
+	$.bind_select_value(select, function get() {
+		return $.get(selected);
+	}, function set($$value) {
+		$.set(selected, $$value);
+	});
+	$.bind_checked(input_2, function get() {
+		return $.get(checked);
+	}, function set($$value) {
+		$.set(checked, $$value);
+	});
+	$.bind_group(binding_group, [], input_3, function get() {
+		return $.get(group);
+	}, function set($$value) {
+		$.set(group, $$value);
+	});
+	$.bind_element_size(div_4, "clientWidth", function set($$value) {
+		$.set(counter, $$value);
+	});
+	$.bind_content_editable("innerHTML", div_4, function get() {
+		return $.get(state);
+	}, function set($$value) {
+		$.set(state, $$value);
+	});
+	$.bind_volume(video, function get() {
+		return $.get(volume);
+	}, function set($$value) {
+		$.set(volume, $$value);
+	});
+	$.bind_paused(video, function get() {
+		return $.get(checked);
+	}, function set($$value) {
+		$.set(checked, $$value);
+	});
+	$.transition(3, div_6, () => fade);
+	$.transition(1, div_7, () => fly, () => ({ y: 200 }));
+	$.transition(2, div_7, () => fade);
+	$.delegated("click", button, addMetric);
+	$.append($$anchor, div_1);
+	var $$pop = $.pop($$exports);
+	$$cleanup();
+	return $$pop;
+}
+$.delegate(["click"]);
+$.create_custom_element(App, {
+	title: {},
+	count: {},
+	items: {},
+	config: {},
+	multiplier: {},
+	visible: {}
+}, [], ["APP_VERSION", "formatTitle"], { mode: "open" });

--- a/tasks/compiler_tests/cases2/diagnose_runes_dev_ce_benchmark/case.svelte
+++ b/tasks/compiler_tests/cases2/diagnose_runes_dev_ce_benchmark/case.svelte
@@ -1,0 +1,298 @@
+<script module>
+    export const BENCHMARK_KIND = "compiler";
+    export const MODULE_SCALE = 3;
+
+    export function moduleLabel(name) {
+        return `${BENCHMARK_KIND}:${name}`;
+    }
+</script>
+
+<script>
+    import { onMount } from "svelte";
+    import { writable } from "svelte/store";
+    import { fade, fly, slide } from "svelte/transition";
+    import { flip } from "svelte/animate";
+    import ChildComponent from "./Child.svelte";
+
+    let {
+        title = "Default Title",
+        count = 0,
+        items = [],
+        config = $bindable({}),
+        multiplier = 2,
+        visible = $bindable(false),
+        ...rest
+    } = $props();
+
+    const propsId = $props.id();
+
+    let state = $state("");
+    let counter = $state(0);
+    let rawData = $state.raw({ x: 1, y: 2 });
+    let checked = $state(false);
+    let group = $state([]);
+    let volume = $state(0.5);
+    let selected = $state("opt-0");
+    let inputEl;
+    let componentRef;
+    let dynamicEl;
+
+    let metrics = writable([1, 2, 3]);
+    let labelStore = writable("ready");
+
+    /** @type {Function | undefined} */
+    let show;
+
+    counter = 10;
+
+    let doubled = $derived(count * multiplier);
+    let computed = $derived.by(() => {
+        return items.length * multiplier + counter;
+    });
+    let moduleSummary = $derived(moduleLabel(title) + ":" + MODULE_SCALE);
+    let storeSummary = $derived($metrics.length + ":" + $labelStore);
+    let snapshot = $state.snapshot(rawData);
+
+    $effect(() => {
+        console.log("Title:", title, "Count:", count);
+    });
+
+    $effect.pre(() => {
+        console.log("Pre effect:", counter);
+    });
+
+    let tracking = $effect.tracking();
+
+    $inspect(counter, doubled);
+
+    export const APP_VERSION = "1.0.0";
+
+    export function formatTitle(prefix) {
+        return prefix + ": " + title;
+    }
+
+    function addMetric() {
+        $metrics = [...$metrics, counter];
+        $labelStore = title;
+    }
+
+    function action(node, arg) {
+        return { destroy() {} };
+    }
+
+    function handleClick(e) {
+        counter++;
+    }
+
+    function getHandler() {
+        return handleClick;
+    }
+
+    function handleError(error) {
+        console.error(error);
+    }
+
+    let promise = Promise.resolve(42);
+</script>
+
+<style>
+    :global(body) {
+        margin: 0;
+        font-family: "IBM Plex Sans", sans-serif;
+        background: #f5f1e8;
+    }
+
+    :global(.benchmark-host) {
+        color: #3f2a18;
+    }
+
+    :global {
+        .benchmark-reset {
+            box-sizing: border-box;
+        }
+    }
+
+    @keyframes pulse {
+        0% { opacity: 0.4; transform: scale(0.98); }
+        100% { opacity: 1; transform: scale(1); }
+    }
+
+    @keyframes -global-marquee {
+        from { transform: translateX(0); }
+        to { transform: translateX(12px); }
+    }
+
+    .chunk-shell {
+        padding: 16px;
+        margin: 12px 0;
+        border: 1px solid #d9c7ab;
+        background: linear-gradient(180deg, #fffdf9 0%, #f4ead9 100%);
+    }
+
+    .chunk-shell :is(.badge, .card, .summary) {
+        border-radius: 10px;
+    }
+
+    .chunk-shell.state .summary {
+        animation: pulse 180ms ease-out;
+    }
+
+    .summary span {
+        display: inline-block;
+        margin-right: 8px;
+    }
+
+    .item-less {
+        color: #7a4f2a;
+    }
+
+    [data-index] {
+        color: var(--custom, #5c4634);
+    }
+</style>
+
+<svelte:head>
+    <title>{title} - Benchmark</title>
+    <meta name="description" content="Benchmark component">
+    <link rel="canonical" href="/benchmark">
+</svelte:head>
+
+<svelte:window onscroll={handleClick} />
+<svelte:document onvisibilitychange={handleClick} />
+<svelte:body onmouseenter={handleClick} use:action={state} />
+
+{#snippet badge(text, variant)}
+    <span class="badge" class:primary={variant === "primary"} class:secondary={variant === "secondary"}>
+        {text}
+    </span>
+{/snippet}
+
+{#snippet card(heading, body)}
+    <div class="card">
+        <h3>{heading}</h3>
+        <p>{body}</p>
+        {@render badge("new", "primary")}
+    </div>
+{/snippet}
+
+{#snippet metricSummary({ label, values = [counter], meta: { id = propsId } = {} })}
+    <section class="summary" data-id={id}>
+        <h4>{label}</h4>
+        {#each values as value, index}
+            <span>{index}: {value}</span>
+        {/each}
+    </section>
+{/snippet}
+
+<div class="chunk-shell benchmark-reset benchmark-host" data-kind="chunk-0">
+    Chunk 0: Lorem {state} + {state} = Ipsum;
+    <p>Props: title={title}, count={count}, doubled={doubled}, computed={computed}</p>
+    <p>Module: {moduleSummary} | Store: {storeSummary} | Label: {$labelStore}</p>
+
+    {@html "<b>raw html chunk 0</b>"}
+    {@debug counter, state}
+
+    <div
+        class:state
+        class:staticly={true}
+        class:invinsible
+        class:reactive={counter}
+        class={{ active: checked, big: counter > 10 }}
+        style:color={state}
+        style:font-size="14px"
+        style:opacity={counter / 100}
+        style:--custom="value-0"
+        onclick={handleClick}
+        onscroll={handleClick}
+        onclickcapture={handleClick}
+        onfocus={getHandler()}
+        bind:this={dynamicEl}
+    >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+
+        {#if state}
+            {@const localLen = state.length}
+            <span title="{title}: {doubled}" empty {state} {counter} count={count}>
+                Duis aute irure dolor: {localLen}. Chunk 0.
+            </span>
+        {:else}
+            <div>
+                <input {title} {state} value={count} />
+            </div>
+
+            {#if counter > 30}
+                <h1 {state}>
+                    Lorem ipsum dolor sit amet. Chunk 0.
+                </h1>
+            {:else if counter == 100}
+                Lorem ipsum dolor sit amet. Chunk 0.
+            {:else}
+                <h2>EMPTY</h2>
+            {/if}
+        {/if}
+    </div>
+
+    {#key counter}
+        <p transition:slide>Keyed content chunk 0: {counter}</p>
+    {/key}
+
+    {#each items as item, idx (item.id)}
+        {@const itemLabel = `${idx}:${item.name}`}
+        <p {...rest} data-index="chunk-0-{idx}" animate:flip>{itemLabel}</p>
+    {/each}
+
+    {#each items}
+        <span class="item-less">Repeated shell chunk 0</span>
+    {/each}
+
+    {#await promise}
+        <p>Loading chunk 0...</p>
+    {:then value}
+        <p>Resolved: {value}</p>
+    {:catch error}
+        <p>Error: {error.message}</p>
+    {/await}
+
+    {#await promise then quickValue}
+        <p>Quick resolved: {quickValue}</p>
+    {/await}
+
+    <input bind:value={state} />
+    <textarea bind:value={state} />
+    <select bind:value={selected}>
+        <option value="opt-0">Zero</option>
+        <option value="opt-1">One</option>
+    </select>
+    <input type="checkbox" bind:checked={checked} />
+    <input type="radio" bind:group={group} value="opt-0" />
+    <div bind:this={inputEl} bind:clientWidth={counter} contenteditable bind:innerHTML={state}>editable</div>
+    <video bind:volume={volume} bind:paused={checked}></video>
+
+    <div use:action={state}>action target</div>
+    <div transition:fade>transition target</div>
+    <div in:fly={{ y: 200 }} out:fade>in/out target</div>
+    <svelte:element this={state ? "div" : "span"} class="dynamic-0">
+        Dynamic element chunk 0: {title}
+    </svelte:element>
+
+    <ChildComponent bind:this={componentRef} title={title} onclick={getHandler()}>
+        <strong>Inline child chunk 0: {title}</strong>
+        <div slot="footer">Footer chunk 0: {counter}</div>
+    </ChildComponent>
+
+    {@render badge("chunk-0", "secondary")}
+    {@render card(title, "Content for chunk 0")}
+    {@render metricSummary({ label: title, values: [count, doubled, counter], meta: { id: propsId } })}
+    {@render show?.()}
+
+    <button onclick={addMetric}>Update store</button>
+    <p>Metric count: {$metrics.length}</p>
+
+    <svelte:boundary onerror={handleError}>
+        <p>Boundary chunk 0: {title}</p>
+        {#snippet failed(error)}
+            <p>Error in chunk 0: {error.message}</p>
+        {/snippet}
+    </svelte:boundary>
+</div>

--- a/tasks/compiler_tests/cases2/diagnose_runes_dev_ce_benchmark/config.json
+++ b/tasks/compiler_tests/cases2/diagnose_runes_dev_ce_benchmark/config.json
@@ -1,0 +1,5 @@
+{
+  "dev": true,
+  "runes": true,
+  "customElement": true
+}

--- a/tasks/compiler_tests/test_v3.rs
+++ b/tasks/compiler_tests/test_v3.rs
@@ -3253,3 +3253,9 @@ fn clock_svg_derived_onmount() {
 fn diagnose_component_default_and_named_slot_expr() {
     assert_compiler("diagnose_component_default_and_named_slot_expr");
 }
+
+#[rstest]
+#[ignore = "diagnose: pending fix"]
+fn diagnose_runes_dev_ce_benchmark() {
+    assert_compiler("diagnose_runes_dev_ce_benchmark");
+}


### PR DESCRIPTION
Re-apply the broad `diagnose_runes_dev_ce_benchmark` repro after rebase
and route remaining findings into their owning specs, dropping the
items master already closed via narrower repros (binding_group order,
JSDoc @type leak, css=injected divergences):

- custom-elements: compile-option `customElement: true` constructor,
  CE/legacy `get NAME()` accessors + `legacy_api`, `$$host` in rest_props
- bind-directives: dev-mode named function get/set callbacks
- snippet-block: dev `add_svelte_meta` on @render, default-init nested
  destructure dependency tracking
- component-node: dev `wrap_snippet` on default `children` slot
- unknown.md: dev `==`/`===` `strict_equals` wrapping, `$props`/
  `add_locations` source-line offsets, conditional `$state.raw` unwrap

Tick fully-covered roadmap items: `use:action` (11/11),
`transition:/in:/out:` (16/16), Experimental async (36/36).