### PR TITLE
Validate invalid export specifiers in module scope

### DIFF
--- a/crates/svelte_analyze/src/validate/mod.rs
+++ b/crates/svelte_analyze/src/validate/mod.rs
@@ -37,6 +37,15 @@ pub fn validate(
     if let Some(module_program) = &parsed.module_program {
         let offset = parsed.module_script_content_span.map_or(0, |s| s.start);
         runes::validate_module_props_runes(data, module_program, offset, runes, diags);
+        if let Some(module_scope) = data.scoping.module_scope_id() {
+            runes::validate_module_invalid_export_specifiers(
+                data,
+                module_program,
+                module_scope,
+                offset,
+                diags,
+            );
+        }
         stores::validate_module(data, module_program, offset, diags);
         validate_perf_class_warnings(module_program, offset, 0, diags);
     }
@@ -86,6 +95,13 @@ pub fn validate_standalone_module(
     diags: &mut Vec<Diagnostic>,
 ) {
     runes::validate(data, program, offset, runes, diags);
+    runes::validate_module_invalid_export_specifiers(
+        data,
+        program,
+        data.scoping.root_scope_id(),
+        offset,
+        diags,
+    );
     stores::validate_standalone_module(data, program, offset, diags);
     validate_perf_class_warnings(program, offset, 0, diags);
 }

--- a/crates/svelte_analyze/src/validate/runes.rs
+++ b/crates/svelte_analyze/src/validate/runes.rs
@@ -282,6 +282,69 @@ fn validate_invalid_export(
     }
 }
 
+pub(super) fn validate_module_invalid_export_specifiers(
+    data: &AnalysisData,
+    program: &oxc_ast::ast::Program<'_>,
+    scope_id: oxc_semantic::ScopeId,
+    offset: u32,
+    diags: &mut Vec<Diagnostic>,
+) {
+    validate_invalid_export_specifiers(
+        data,
+        program,
+        scope_id,
+        offset,
+        diags,
+        || DiagnosticKind::DerivedInvalidExport,
+        |data, sym_id| matches!(data.binding_semantics(sym_id), BindingSemantics::Derived(_)),
+    );
+    validate_invalid_export_specifiers(
+        data,
+        program,
+        scope_id,
+        offset,
+        diags,
+        || DiagnosticKind::StateInvalidExport,
+        is_reassigned_state_export,
+    );
+}
+
+fn validate_invalid_export_specifiers(
+    data: &AnalysisData,
+    program: &oxc_ast::ast::Program<'_>,
+    scope_id: oxc_semantic::ScopeId,
+    offset: u32,
+    diags: &mut Vec<Diagnostic>,
+    make_kind: impl Fn() -> DiagnosticKind + Copy,
+    predicate: impl Fn(&AnalysisData, oxc_semantic::SymbolId) -> bool + Copy,
+) {
+    for stmt in &program.body {
+        let oxc_ast::ast::Statement::ExportNamedDeclaration(export) = stmt else {
+            continue;
+        };
+        if export.declaration.is_some() {
+            continue;
+        }
+        for spec in &export.specifiers {
+            let (name, span) = match &spec.local {
+                ModuleExportName::IdentifierReference(id) => (id.name.as_str(), id.span),
+                ModuleExportName::IdentifierName(id) => (id.name.as_str(), id.span),
+                ModuleExportName::StringLiteral(_) => continue,
+            };
+            let Some(sym_id) = data.scoping.find_binding(scope_id, name) else {
+                continue;
+            };
+            if !predicate(data, sym_id) {
+                continue;
+            }
+            let span = Span::new(span.start + offset, span.end + offset);
+            if !crate::validate::span_already_taken(diags, span) {
+                diags.push(Diagnostic::error(make_kind(), span));
+            }
+        }
+    }
+}
+
 fn validate_invalid_named_export(
     data: &AnalysisData,
     export: &ExportNamedDeclaration<'_>,

--- a/specs/state-rune.md
+++ b/specs/state-rune.md
@@ -3,7 +3,7 @@
 ## Current state
 - **Working**: 43/44 use cases
 - **Tests**: 49/50 green
-- Last updated: 2026-04-30
+- Last updated: 2026-05-01
 
 ## Source
 Audit of existing implementation
@@ -124,7 +124,7 @@ Audit of existing implementation
 - [x] `validate_state_referenced_locally_no_warning_for_proxy_state`
 - [x] `validate_state_referenced_locally_for_state_raw`
 - [x] `validate_state_referenced_locally_no_warning_across_fn_boundary_state`
-- [ ] `validate_state_invalid_export_for_reassigned_state_export_specifier`
+- [x] `validate_state_invalid_export_for_reassigned_state_export_specifier`
 - [x] `validate_state_invalid_export_for_reassigned_state_default_export`
 - [x] `validate_state_invalid_export_no_error_for_default_export_without_reassignment`
 - [x] `validate_state_eager_no_args`

--- a/tasks/diagnostic_tests/cases/runes/validate_state_invalid_export_for_reassigned_state_export_specifier/case-rust.json
+++ b/tasks/diagnostic_tests/cases/runes/validate_state_invalid_export_for_reassigned_state_export_specifier/case-rust.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "severity": "error",
+    "code": "state_invalid_export",
+    "start": 59,
+    "end": 64
+  }
+]


### PR DESCRIPTION
## Summary
Add validation for invalid export specifiers in module scope, specifically detecting when derived state or reassigned state variables are exported via named export specifiers.

## Key Changes
- **New validation function**: `validate_module_invalid_export_specifiers()` checks for invalid exports of derived and reassigned state in module scope
- **Helper function**: `validate_invalid_export_specifiers()` extracts common logic for validating export specifiers against a predicate, supporting both derived state and reassigned state checks
- **Integration**: Call the new validation in both `validate()` (for Svelte components with module scripts) and `validate_standalone_module()` (for standalone modules)
- **Test case**: Updated diagnostic test to expect an error when reassigned state is exported via export specifier

## Implementation Details
- The validation iterates through `ExportNamedDeclaration` statements and checks each export specifier
- It skips export declarations with inline declarations (only validates re-exports)
- For each specifier, it looks up the binding in the module scope and applies a predicate function to determine if it's invalid
- Supports two predicates: one for derived state and one for reassigned state exports
- Uses `span_already_taken()` to avoid duplicate diagnostics

https://claude.ai/code/session_01TgEerVQtbMemgP4HnEF69V